### PR TITLE
Compile traits/operator_overloading.v

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,8 +31,8 @@ jobs:
     # - name: Compile Coq translations
     #   run: |
     #     cd coq_translation/examples-from-rust-book ;
-    #     coqc -R . CoqOfRust CoqOfRust.v ;
+    #     coqc -impredicative-set -R . CoqOfRust CoqOfRust.v ;
     #     for f in `find . -name "*.v" |sort` ; do
-    #       coqc -R . CoqOfRust $f ;
+    #       coqc -impredicative-set -R . CoqOfRust $f ;
     #     done ;
     #     cd ../..

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,9 @@ jobs:
       run: |
         cargo run --bin coq-of-rust -- translate --path examples-from-rust-book
         git -c color.ui=always diff --exit-code
-    # - name: Compile Coq translations
-    #   run: |
-    #     cd coq_translation/examples-from-rust-book ;
-    #     coqc -impredicative-set -R . CoqOfRust CoqOfRust.v ;
-    #     for f in `find . -name "*.v" |sort` ; do
-    #       coqc -impredicative-set -R . CoqOfRust $f ;
-    #     done ;
-    #     cd ../..
+    - name: Compile Coq translations
+      run: |
+        cd coq_translation/examples-from-rust-book
+        coq_makefile -f _CoqProject -o Makefile
+        make -f Makefile
+        cd ../..

--- a/coq_translation/examples-from-rust-book/.gitignore
+++ b/coq_translation/examples-from-rust-book/.gitignore
@@ -1,0 +1,3 @@
+.Makefile.d
+Makefile
+Makefile.conf

--- a/coq_translation/examples-from-rust-book/CoqOfRust.v
+++ b/coq_translation/examples-from-rust-book/CoqOfRust.v
@@ -67,9 +67,15 @@ Notation "e1 ::[ e2 ]" := (Notation.double_colon e1 e2)
 Global Instance AssociatedFunctionFromMethod
   (type : Set) (name : string) (T : Set)
   `(Notation.Dot (Kind := string) name (T := type -> T)) :
-  Notation.DoubleColon type name (T := type -> T) := {|
+  Notation.DoubleColon type name (T := type -> T) := {
   Notation.double_colon := Notation.dot name;
-|}.
+}.
+
+Definition defaultType (T : option Set) (Default : Set) : Set :=
+  match T with
+  | Some T => T
+  | None => Default
+  end.
 
 Parameter axiom : forall {A : Set}, A.
 
@@ -129,9 +135,9 @@ Module std.
         to_string : ref Self -> String;
       }.
 
-      Global Instance Method_to_string `(Trait) : Notation.Dot "to_string" := {|
+      Global Instance Method_to_string `(Trait) : Notation.Dot "to_string" := {
         Notation.dot := to_string;
-      |}.
+      }.
     End ToString.
   End string.
 
@@ -165,15 +171,15 @@ Module std.
         write_fmt : mut_ref Self -> Arguments -> Result;
       }.
 
-      Global Instance Method_write_str `(Trait) : Notation.Dot "write_str" := {|
+      Global Instance Method_write_str `(Trait) : Notation.Dot "write_str" := {
         Notation.dot := write_str;
-      |}.
-      Global Instance Method_write_char `(Trait) : Notation.Dot "write_char" := {|
+      }.
+      Global Instance Method_write_char `(Trait) : Notation.Dot "write_char" := {
         Notation.dot := write_char;
-      |}.
-      Global Instance Method_write_fmt `(Trait) : Notation.Dot "write_fmt" := {|
+      }.
+      Global Instance Method_write_fmt `(Trait) : Notation.Dot "write_fmt" := {
         Notation.dot := write_fmt;
-      |}.
+      }.
     End Write.
 
     Module Formatter.
@@ -185,9 +191,9 @@ Module std.
       Parameter new : forall {W : Set} `{Write.Trait W}, mut_ref W -> Formatter.
 
       Global Instance Formatter_new {W : Set} `{Write.Trait W} :
-        Notation.DoubleColon Formatter "new" := {|
+        Notation.DoubleColon Formatter "new" := {
         Notation.double_colon := new;
-      |}.
+      }.
     End ImplFormatter.
 
     Module Display.
@@ -261,81 +267,81 @@ Module std.
         ref T -> (ref T -> mut_ref Formatter -> Result) -> Self.
 
       Global Instance ArgumentV1_new {T : Set} :
-        Notation.DoubleColon ArgumentV1 "new" := {|
+        Notation.DoubleColon ArgumentV1 "new" := {
         Notation.double_colon := new (T := T);
-      |}.
+      }.
 
       Parameter new_display :
         forall {T : Set} `{Display.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_display {T : Set} `{Display.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_display" := {|
+        Notation.DoubleColon ArgumentV1 "new_display" := {
         Notation.double_colon := new_display (T := T);
-      |}.
+      }.
 
       Parameter new_debug :
         forall {T : Set} `{Debug.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_debug {T : Set} `{Debug.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_debug" := {|
+        Notation.DoubleColon ArgumentV1 "new_debug" := {
         Notation.double_colon := new_debug (T := T);
-      |}.
+      }.
 
       Parameter new_octal :
         forall {T : Set} `{Octal.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_octal {T : Set} `{Octal.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_octal" := {|
+        Notation.DoubleColon ArgumentV1 "new_octal" := {
         Notation.double_colon := new_octal (T := T);
-      |}.
+      }.
 
       Parameter new_lower_hex :
         forall {T : Set} `{LowerHex.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_lower_hex {T : Set} `{LowerHex.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_lower_hex" := {|
+        Notation.DoubleColon ArgumentV1 "new_lower_hex" := {
         Notation.double_colon := new_lower_hex (T := T);
-      |}.
+      }.
 
       Parameter new_upper_hex :
         forall {T : Set} `{UpperHex.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_upper_hex {T : Set} `{UpperHex.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_upper_hex" := {|
+        Notation.DoubleColon ArgumentV1 "new_upper_hex" := {
         Notation.double_colon := new_upper_hex (T := T);
-      |}.
+      }.
 
       Parameter new_pointer :
         forall {T : Set} `{Pointer.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_pointer {T : Set} `{Pointer.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_pointer" := {|
+        Notation.DoubleColon ArgumentV1 "new_pointer" := {
         Notation.double_colon := new_pointer (T := T);
-      |}.
+      }.
 
       Parameter new_binary :
         forall {T : Set} `{Binary.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_binary {T : Set} `{Binary.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_binary" := {|
+        Notation.DoubleColon ArgumentV1 "new_binary" := {
         Notation.double_colon := new_binary (T := T);
-      |}.
+      }.
 
       Parameter new_lower_exp :
         forall {T : Set} `{LowerExp.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_lower_exp {T : Set} `{LowerExp.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_lower_exp" := {|
+        Notation.DoubleColon ArgumentV1 "new_lower_exp" := {
         Notation.double_colon := new_lower_exp (T := T);
-      |}.
+      }.
 
       Parameter new_upper_exp :
         forall {T : Set} `{UpperExp.Trait T}, ref T -> Self.
 
       Global Instance ArgumentV1_new_upper_exp {T : Set} `{UpperExp.Trait T} :
-        Notation.DoubleColon ArgumentV1 "new_upper_exp" := {|
+        Notation.DoubleColon ArgumentV1 "new_upper_exp" := {
         Notation.double_colon := new_upper_exp (T := T);
-      |}.
+      }.
     End ImplArgumentV1.
 
     Module ImplArguments.
@@ -343,9 +349,9 @@ Module std.
         ref (list (ref str)) -> ref (list ArgumentV1) -> Arguments.
 
       Global Instance Arguments_new_v1 :
-        Notation.DoubleColon Arguments "new_v1" := {|
+        Notation.DoubleColon Arguments "new_v1" := {
         Notation.double_colon := new_v1;
-      |}.
+      }.
     End ImplArguments.
 
     Global Instance Write_for_Formatter : Write.Trait Formatter.
@@ -376,13 +382,17 @@ Module std.
 
   Module ops.
     Module Add.
-      Class Trait {Output : Set} (Self : Set) : Set := {
+      Global Unset Primitive Projections.
+
+      Class Trait {Output : Set} (Self : Set) (Rhs : option Set) : Set := {
         Output := Output;
-        add : Self -> Self -> Output;
-        }.
-      Global Instance Method_add `(Trait) : Notation.Dot "add" := {|
+        Rhs := defaultType Rhs Self;
+        add : Self -> Rhs -> Output;
+      }.
+
+      Global Instance Method_add `(Trait) : Notation.Dot "add" := {
         Notation.dot := add;
-      |}.
+      }.
     End Add.
 
     Module Sub.
@@ -390,9 +400,9 @@ Module std.
         Output := Output;
         sub : Self -> Self -> Output;
         }.
-      Global Instance Method_sub `(Trait) : Notation.Dot "sub" := {|
+      Global Instance Method_sub `(Trait) : Notation.Dot "sub" := {
         Notation.dot := sub;
-      |}.
+      }.
     End Sub.
 
     Module Mul.
@@ -400,9 +410,9 @@ Module std.
         Output := Output;
         mul : Self -> Self -> Output;
         }.
-      Global Instance Method_mul `(Trait) : Notation.Dot "mul" := {|
+      Global Instance Method_mul `(Trait) : Notation.Dot "mul" := {
         Notation.dot := mul;
-      |}.
+      }.
     End Mul.
 
     Module Div.
@@ -410,9 +420,9 @@ Module std.
         Output := Output;
         div : Self -> Self -> Output;
         }.
-      Global Instance Method_div `(Trait) : Notation.Dot "div" := {|
+      Global Instance Method_div `(Trait) : Notation.Dot "div" := {
         Notation.dot := div;
-      |}.
+      }.
     End Div.
 
     Module Rem.
@@ -420,9 +430,9 @@ Module std.
         Output := Output;
         rem : Self -> Self -> Output;
         }.
-      Global Instance Method_add `(Trait) : Notation.Dot "rem" := {|
+      Global Instance Method_add `(Trait) : Notation.Dot "rem" := {
         Notation.dot := rem;
-      |}.
+      }.
     End Rem.
 
     Module BitXor.
@@ -430,9 +440,9 @@ Module std.
         Output := Output;
         bitxor : Self -> Self -> Output;
         }.
-      Global Instance Method_bitxor `(Trait) : Notation.Dot "bitxor" := {|
+      Global Instance Method_bitxor `(Trait) : Notation.Dot "bitxor" := {
         Notation.dot := bitxor;
-      |}.
+      }.
     End BitXor.
 
     Module BitAnd.
@@ -440,9 +450,9 @@ Module std.
         Output := Output;
         bitand : Self -> Self -> Output;
         }.
-      Global Instance Method_bitand `(Trait) : Notation.Dot "bitand" := {|
+      Global Instance Method_bitand `(Trait) : Notation.Dot "bitand" := {
         Notation.dot := bitand;
-      |}.
+      }.
     End BitAnd.
 
     Module BitOr.
@@ -450,9 +460,9 @@ Module std.
         Output := Output;
         bitor : Self -> Self -> Output;
         }.
-      Global Instance Method_bitor `(Trait) : Notation.Dot "bitor" := {|
+      Global Instance Method_bitor `(Trait) : Notation.Dot "bitor" := {
         Notation.dot := bitor;
-      |}.
+      }.
     End BitOr.
 
     Module Shl.
@@ -460,9 +470,9 @@ Module std.
         Output := Output;
         shl : Self -> Self -> Output;
         }.
-      Global Instance Method_shl `(Trait) : Notation.Dot "shl" := {|
+      Global Instance Method_shl `(Trait) : Notation.Dot "shl" := {
         Notation.dot := shl;
-      |}.
+      }.
     End Shl.
 
     Module Shr.
@@ -470,9 +480,9 @@ Module std.
         Output := Output;
         shr : Self -> Self -> Output;
         }.
-      Global Instance Method_shr `(Trait) : Notation.Dot "shr" := {|
+      Global Instance Method_shr `(Trait) : Notation.Dot "shr" := {
         Notation.dot := shr;
-      |}.
+      }.
     End Shr.
   End ops.
 
@@ -490,12 +500,12 @@ Module std.
         ne : ref Self -> ref Self -> bool;
       }.
 
-      Global Instance Method_eq `(Trait) : Notation.Dot "eq" := {| 
+      Global Instance Method_eq `(Trait) : Notation.Dot "eq" := { 
         Notation.dot := eq;
-      |}.
-      Global Instance Method_ne `(Trait) : Notation.Dot "ne" := {| 
+      }.
+      Global Instance Method_ne `(Trait) : Notation.Dot "ne" := { 
         Notation.dot := ne;
-      |}.
+      }.
     End PartialEq.
 
     Module PartialOrd.
@@ -507,21 +517,21 @@ Module std.
         ge : ref Self -> ref Self -> bool;
       }.
 
-      Global Instance Method_partial_cmp `(Trait) : Notation.Dot "partial_cmp" := {| 
+      Global Instance Method_partial_cmp `(Trait) : Notation.Dot "partial_cmp" := { 
         Notation.dot := partial_cmp;
-      |}.
-      Global Instance Method_lt `(Trait) : Notation.Dot "lt" := {| 
+      }.
+      Global Instance Method_lt `(Trait) : Notation.Dot "lt" := { 
         Notation.dot := lt;
-      |}.
-      Global Instance Method_le `(Trait) : Notation.Dot "le" := {| 
+      }.
+      Global Instance Method_le `(Trait) : Notation.Dot "le" := { 
         Notation.dot := le;
-      |}.
-      Global Instance Method_gt `(Trait) : Notation.Dot "gt" := {| 
+      }.
+      Global Instance Method_gt `(Trait) : Notation.Dot "gt" := { 
         Notation.dot := gt;
-      |}.
-      Global Instance Method_ge `(Trait) : Notation.Dot "ge" := {| 
+      }.
+      Global Instance Method_ge `(Trait) : Notation.Dot "ge" := { 
         Notation.dot := ge;
-      |}.
+      }.
     End PartialOrd.
   End cmp.
 

--- a/coq_translation/examples-from-rust-book/_CoqProject
+++ b/coq_translation/examples-from-rust-book/_CoqProject
@@ -1,2 +1,22 @@
 -R . CoqOfRust
 -arg -impredicative-set
+
+# Files that currently compile
+attributes/dead_code.v
+cargo/concurrent_tests.v
+conversion/converting_to_string.v
+CoqOfRust.v
+expressions/statement.v
+hello_world/hello_world.v
+macro_rules/macro_example.v
+primitives/compound_types.v
+scoping_rules/scoping_rules_borrowing_aliasing.v
+scoping_rules/scoping_rules_lifetimes_elision.v
+scoping_rules/scoping_rules_lifetimes_functions.v
+scoping_rules/scoping_rules_lifetimes.v
+traits/operator_overloading.v
+traits/traits.v
+variable_bindings/freezing.v
+variable_bindings/mutability.v
+variable_bindings/scope.v
+variable_bindings/variable_shadowing.v

--- a/coq_translation/examples-from-rust-book/conversion/converting_to_string.v
+++ b/coq_translation/examples-from-rust-book/conversion/converting_to_string.v
@@ -10,9 +10,9 @@ Module Circle.
     radius : i32;
   }.
   
-  Global Instance Get_radius : Notation.Dot "radius" := {|
+  Global Instance Get_radius : Notation.Dot "radius" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Circle.
 Definition Circle : Set := Circle.t.
 
@@ -25,13 +25,13 @@ Module Impl_fmt_Display_for_Circle.
         [ "Circle of radius " ]
         [ _crate.fmt.ArgumentV1::["new_display"] self.["radius"] ]).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Display.Trait Self := {|
+  Global Instance I : fmt.Display.Trait Self := {
     fmt.Display.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Display_for_Circle.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/conversion/from.v
+++ b/coq_translation/examples-from-rust-book/conversion/from.v
@@ -10,9 +10,9 @@ Module Number.
     value : i32;
   }.
   
-  Global Instance Get_value : Notation.Dot "value" := {|
+  Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Number.
 Definition Number : Set := Number.t.
 
@@ -29,13 +29,13 @@ Module Impl__crate_fmt_Debug_for_Number.
       "value"
       self.["value"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Number.
 
 Module Impl_From_for_Number.
@@ -44,13 +44,13 @@ Module Impl_From_for_Number.
   Definition from (item : i32) : Self := {| Number.value := item; |}.
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I : From.Trait i32 Self := {|
+  Global Instance I : From.Trait Self i32 := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_Number.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/conversion/into.v
+++ b/coq_translation/examples-from-rust-book/conversion/into.v
@@ -10,9 +10,9 @@ Module Number.
     value : i32;
   }.
   
-  Global Instance Get_value : Notation.Dot "value" := {|
+  Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Number.
 Definition Number : Set := Number.t.
 
@@ -29,13 +29,13 @@ Module Impl__crate_fmt_Debug_for_Number.
       "value"
       self.["value"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Number.
 
 Module Impl_From_for_Number.
@@ -44,13 +44,13 @@ Module Impl_From_for_Number.
   Definition from (item : i32) : Self := {| Number.value := item; |}.
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I : From.Trait i32 Self := {|
+  Global Instance I : From.Trait Self i32 := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_Number.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/conversion/parsing_a_string.v
+++ b/coq_translation/examples-from-rust-book/conversion/parsing_a_string.v
@@ -6,7 +6,7 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let parsed := "5".["parse"].["unwrap"] in
   let turbo_parsed := "10".["parse"].["unwrap"] in
-  let sum := add parsed turbo_parsed in
+  let sum := parsed.["add"] turbo_parsed in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Sum: "; "\n" ]

--- a/coq_translation/examples-from-rust-book/conversion/try_from_and_try_into.v
+++ b/coq_translation/examples-from-rust-book/conversion/try_from_and_try_into.v
@@ -10,9 +10,9 @@ Module TryInto := std.convert.TryInto.
 Module EvenNumber.
   Inductive t : Set := Build (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End EvenNumber.
 Definition EvenNumber := EvenNumber.t.
 
@@ -28,13 +28,13 @@ Module Impl__crate_fmt_Debug_for_EvenNumber.
       "EvenNumber"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_EvenNumber.
 
 Module Impl__crate_marker_StructuralPartialEq_for_EvenNumber.
@@ -51,13 +51,13 @@ Module Impl__crate_cmp_PartialEq_for_EvenNumber.
     (IndexedField.get (index := 0) self).["eq"]
       (IndexedField.get (index := 0) other).
   
-  Global Instance Method_eq : Notation.Dot "eq" := {|
+  Global Instance Method_eq : Notation.Dot "eq" := {
     Notation.dot := eq;
-  |}.
+  }.
   
-  Global Instance I : _crate.cmp.PartialEq.Trait Self := {|
+  Global Instance I : _crate.cmp.PartialEq.Trait Self := {
     _crate.cmp.PartialEq.eq := eq;
-  |}.
+  }.
 End Impl__crate_cmp_PartialEq_for_EvenNumber.
 
 Module Impl_TryFrom_for_EvenNumber.
@@ -72,14 +72,13 @@ Module Impl_TryFrom_for_EvenNumber.
       Err ().
   
   Global Instance AssociatedFunction_try_from :
-    Notation.DoubleColon Self "try_from" := {|
+    Notation.DoubleColon Self "try_from" := {
     Notation.double_colon := try_from;
-  |}.
+  }.
   
-  Global Instance I : TryFrom.Trait i32 Self := {|
-    TryFrom.Error := Error;
+  Global Instance I : TryFrom.Trait Self i32 := {
     TryFrom.try_from := try_from;
-  |}.
+  }.
 End Impl_TryFrom_for_EvenNumber.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/conversion/try_from_and_try_into.v
+++ b/coq_translation/examples-from-rust-book/conversion/try_from_and_try_into.v
@@ -48,8 +48,7 @@ Module Impl__crate_cmp_PartialEq_for_EvenNumber.
   Definition Self := EvenNumber.
   
   Definition eq (self : ref Self) (other : ref EvenNumber) : bool :=
-    eqb
-      (IndexedField.get (index := 0) self)
+    (IndexedField.get (index := 0) self).["eq"]
       (IndexedField.get (index := 0) other).
   
   Global Instance Method_eq : Notation.Dot "eq" := {|
@@ -67,7 +66,7 @@ Module Impl_TryFrom_for_EvenNumber.
   Definition Error : Set := .
   
   Definition try_from (value : i32) : Result :=
-    if (eqb (rem value 2) 0 : bool) then
+    if ((value.["rem"] 2).["eq"] 0 : bool) then
       Ok (EvenNumber.Build value)
     else
       Err ().
@@ -86,7 +85,7 @@ End Impl_TryFrom_for_EvenNumber.
 Definition main (_ : unit) : unit :=
   match (EvenNumber::["try_from"] 8, Ok (EvenNumber.Build 8)) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -99,7 +98,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (EvenNumber::["try_from"] 5, Err ()) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -113,7 +112,7 @@ Definition main (_ : unit) : unit :=
   let result := 8.["try_into"] in
   match (result, Ok (EvenNumber.Build 8)) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -127,7 +126,7 @@ Definition main (_ : unit) : unit :=
   let result := 5.["try_into"] in
   match (result, Err ()) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/custom_types/constants.v
+++ b/coq_translation/examples-from-rust-book/custom_types/constants.v
@@ -7,7 +7,7 @@ Definition LANGUAGE (_ : unit) := "Rust".
 
 Definition THRESHOLD (_ : unit) := 10.
 
-Definition is_big (n : i32) : bool := gt n THRESHOLD.
+Definition is_big (n : i32) : bool := n.["gt"] THRESHOLD.
 
 Definition main (_ : unit) : unit :=
   let n := 16 in

--- a/coq_translation/examples-from-rust-book/custom_types/enums_testcase_linked_list.v
+++ b/coq_translation/examples-from-rust-book/custom_types/enums_testcase_linked_list.v
@@ -30,7 +30,7 @@ Module ImplList.
   
   Definition len (self : ref Self) : u32 :=
     match deref self with
-    | Cons (_, tail) => add 1 tail.["len"]
+    | Cons (_, tail) => 1.["add"] tail.["len"]
     | Nil => 0
     end.
   

--- a/coq_translation/examples-from-rust-book/custom_types/enums_testcase_linked_list.v
+++ b/coq_translation/examples-from-rust-book/custom_types/enums_testcase_linked_list.v
@@ -17,16 +17,16 @@ Module ImplList.
   
   Definition new (_ : unit) : List := Nil.
   
-  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {|
+  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {
     Notation.double_colon := new;
-  |}.
+  }.
   
   Definition prepend (self : Self) (elem : u32) : List :=
     Cons elem (Box::["new"] self).
   
-  Global Instance Method_prepend : Notation.Dot "prepend" := {|
+  Global Instance Method_prepend : Notation.Dot "prepend" := {
     Notation.dot := prepend;
-  |}.
+  }.
   
   Definition len (self : ref Self) : u32 :=
     match deref self with
@@ -34,9 +34,9 @@ Module ImplList.
     | Nil => 0
     end.
   
-  Global Instance Method_len : Notation.Dot "len" := {|
+  Global Instance Method_len : Notation.Dot "len" := {
     Notation.dot := len;
-  |}.
+  }.
   
   Definition stringify (self : ref Self) : String :=
     match deref self with
@@ -56,9 +56,9 @@ Module ImplList.
       res
     end.
   
-  Global Instance Method_stringify : Notation.Dot "stringify" := {|
+  Global Instance Method_stringify : Notation.Dot "stringify" := {
     Notation.dot := stringify;
-  |}.
+  }.
 End ImplList.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/custom_types/enums_type_aliases_v2.v
+++ b/coq_translation/examples-from-rust-book/custom_types/enums_type_aliases_v2.v
@@ -18,8 +18,8 @@ Module ImplVeryVerboseEnumOfThingsToDoWithNumbers.
   
   Definition run (self : ref Self) (x : i32) (y : i32) : i32 :=
     match self with
-    | ImplSelf.Add => add x y
-    | ImplSelf.Subtract => sub x y
+    | ImplSelf.Add => x.["add"] y
+    | ImplSelf.Subtract => x.["sub"] y
     end.
   
   Global Instance Method_run : Notation.Dot "run" := {|

--- a/coq_translation/examples-from-rust-book/custom_types/enums_type_aliases_v2.v
+++ b/coq_translation/examples-from-rust-book/custom_types/enums_type_aliases_v2.v
@@ -22,7 +22,7 @@ Module ImplVeryVerboseEnumOfThingsToDoWithNumbers.
     | ImplSelf.Subtract => x.["sub"] y
     end.
   
-  Global Instance Method_run : Notation.Dot "run" := {|
+  Global Instance Method_run : Notation.Dot "run" := {
     Notation.dot := run;
-  |}.
+  }.
 End ImplVeryVerboseEnumOfThingsToDoWithNumbers.

--- a/coq_translation/examples-from-rust-book/custom_types/structures.v
+++ b/coq_translation/examples-from-rust-book/custom_types/structures.v
@@ -9,12 +9,12 @@ Module Person.
     age : u8;
   }.
   
-  Global Instance Get_name : Notation.Dot "name" := {|
+  Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_age : Notation.Dot "age" := {|
+  }.
+  Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Person.
 Definition Person : Set := Person.t.
 
@@ -33,26 +33,29 @@ Module Impl__crate_fmt_Debug_for_Person.
       "age"
       self.["age"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Person.
 
-Error StructUnit.
+Module Unit.
+  Inductive t : Set := Build.
+End Unit.
+Definition Unit := Unit.t.
 
 Module Pair.
   Inductive t : Set := Build (_ : i32) (_ : f32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Pair.
 Definition Pair := Pair.t.
 
@@ -62,12 +65,12 @@ Module Point.
     y : f32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Point.
 Definition Point : Set := Point.t.
 
@@ -77,12 +80,12 @@ Module Rectangle.
     bottom_right : Point;
   }.
   
-  Global Instance Get_top_left : Notation.Dot "top_left" := {|
+  Global Instance Get_top_left : Notation.Dot "top_left" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {|
+  }.
+  Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.
 
@@ -119,7 +122,7 @@ Definition main (_ : unit) : unit :=
       Rectangle.top_left := {| Point.x := left_edge; Point.y := top_edge; |};
       Rectangle.bottom_right := bottom_right;
     |} in
-  let _unit := Unit in
+  let _unit := Unit.Build in
   let pair := Pair.Build 1 0 (* 0.1 *) in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/error_handling/aliases_for_result.v
+++ b/coq_translation/examples-from-rust-book/error_handling/aliases_for_result.v
@@ -15,7 +15,7 @@ Definition multiply
   first_number_str.["parse"].["and_then"]
     (fun first_number =>
       second_number_str.["parse"].["map"]
-        (fun second_number => mul first_number second_number)).
+        (fun second_number => first_number.["mul"] second_number)).
 
 Definition print (result : AliasedResult) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/boxing_errors.v
+++ b/coq_translation/examples-from-rust-book/error_handling/boxing_errors.v
@@ -71,7 +71,7 @@ Definition double_first (vec : Vec) : Result :=
   (vec.["first"].["ok_or_else"] (fun  => EmptyVec.["into"])).["and_then"]
     (fun s =>
       (s.["parse"].["map_err"] (fun e => e.["into"])).["map"]
-        (fun i => mul 2 i)).
+        (fun i => 2.["mul"] i)).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/boxing_errors.v
+++ b/coq_translation/examples-from-rust-book/error_handling/boxing_errors.v
@@ -9,7 +9,10 @@ Module fmt := std.fmt.
 
 Definition Result : Set := std.result.Result.
 
-Error StructUnit.
+Module EmptyVec.
+  Inductive t : Set := Build.
+End EmptyVec.
+Definition EmptyVec := EmptyVec.t.
 
 Module Impl__crate_fmt_Debug_for_EmptyVec.
   Definition Self := EmptyVec.
@@ -20,27 +23,27 @@ Module Impl__crate_fmt_Debug_for_EmptyVec.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "EmptyVec".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_EmptyVec.
 
 Module Impl__crate_clone_Clone_for_EmptyVec.
   Definition Self := EmptyVec.
   
-  Definition clone (self : ref Self) : EmptyVec := EmptyVec.
+  Definition clone (self : ref Self) : EmptyVec := EmptyVec.Build.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_EmptyVec.
 
 Module Impl_fmt_Display_for_EmptyVec.
@@ -52,13 +55,13 @@ Module Impl_fmt_Display_for_EmptyVec.
         [ "invalid first item to double" ]
         [  ]).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Display.Trait Self := {|
+  Global Instance I : fmt.Display.Trait Self := {
     fmt.Display.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Display_for_EmptyVec.
 
 Module Impl_error_Error_for_EmptyVec.
@@ -68,7 +71,7 @@ Module Impl_error_Error_for_EmptyVec.
 End Impl_error_Error_for_EmptyVec.
 
 Definition double_first (vec : Vec) : Result :=
-  (vec.["first"].["ok_or_else"] (fun  => EmptyVec.["into"])).["and_then"]
+  (vec.["first"].["ok_or_else"] (fun  => EmptyVec.Build.["into"])).["and_then"]
     (fun s =>
       (s.["parse"].["map_err"] (fun e => e.["into"])).["map"]
         (fun i => 2.["mul"] i)).

--- a/coq_translation/examples-from-rust-book/error_handling/combinators_and_then.v
+++ b/coq_translation/examples-from-rust-book/error_handling/combinators_and_then.v
@@ -24,13 +24,13 @@ Module Impl__crate_fmt_Debug_for_Food.
     | Food.Sushi => _crate.fmt.Formatter::["write_str"] f "Sushi"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Food.
 
 Module Day.
@@ -54,13 +54,13 @@ Module Impl__crate_fmt_Debug_for_Day.
     | Day.Wednesday => _crate.fmt.Formatter::["write_str"] f "Wednesday"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Day.
 
 Definition have_ingredients (food : Food) : Option :=

--- a/coq_translation/examples-from-rust-book/error_handling/combinators_map.v
+++ b/coq_translation/examples-from-rust-book/error_handling/combinators_map.v
@@ -24,21 +24,21 @@ Module Impl__crate_fmt_Debug_for_Food.
     | Food.Potato => _crate.fmt.Formatter::["write_str"] f "Potato"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Food.
 
 Module Peeled.
   Inductive t : Set := Build (_ : Food).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Peeled.
 Definition Peeled := Peeled.t.
 
@@ -54,21 +54,21 @@ Module Impl__crate_fmt_Debug_for_Peeled.
       "Peeled"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Peeled.
 
 Module Chopped.
   Inductive t : Set := Build (_ : Food).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Chopped.
 Definition Chopped := Chopped.t.
 
@@ -84,21 +84,21 @@ Module Impl__crate_fmt_Debug_for_Chopped.
       "Chopped"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Chopped.
 
 Module Cooked.
   Inductive t : Set := Build (_ : Food).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Cooked.
 Definition Cooked := Cooked.t.
 
@@ -114,13 +114,13 @@ Module Impl__crate_fmt_Debug_for_Cooked.
       "Cooked"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Cooked.
 
 Definition peel (food : Option) : Option :=

--- a/coq_translation/examples-from-rust-book/error_handling/defining_an_error_type.v
+++ b/coq_translation/examples-from-rust-book/error_handling/defining_an_error_type.v
@@ -7,7 +7,10 @@ Module fmt := std.fmt.
 
 Definition Result : Set := std.result.Result.
 
-Error StructUnit.
+Module DoubleError.
+  Inductive t : Set := Build.
+End DoubleError.
+Definition DoubleError := DoubleError.t.
 
 Module Impl__crate_fmt_Debug_for_DoubleError.
   Definition Self := DoubleError.
@@ -18,27 +21,27 @@ Module Impl__crate_fmt_Debug_for_DoubleError.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "DoubleError".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_DoubleError.
 
 Module Impl__crate_clone_Clone_for_DoubleError.
   Definition Self := DoubleError.
   
-  Definition clone (self : ref Self) : DoubleError := DoubleError.
+  Definition clone (self : ref Self) : DoubleError := DoubleError.Build.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_DoubleError.
 
 Module Impl_fmt_Display_for_DoubleError.
@@ -50,19 +53,19 @@ Module Impl_fmt_Display_for_DoubleError.
         [ "invalid first item to double" ]
         [  ]).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Display.Trait Self := {|
+  Global Instance I : fmt.Display.Trait Self := {
     fmt.Display.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Display_for_DoubleError.
 
 Definition double_first (vec : Vec) : Result :=
-  (vec.["first"].["ok_or"] DoubleError).["and_then"]
+  (vec.["first"].["ok_or"] DoubleError.Build).["and_then"]
     (fun s =>
-      (s.["parse"].["map_err"] (fun _ => DoubleError)).["map"]
+      (s.["parse"].["map_err"] (fun _ => DoubleError.Build)).["map"]
         (fun i => 2.["mul"] i)).
 
 Definition print (result : Result) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/defining_an_error_type.v
+++ b/coq_translation/examples-from-rust-book/error_handling/defining_an_error_type.v
@@ -63,7 +63,7 @@ Definition double_first (vec : Vec) : Result :=
   (vec.["first"].["ok_or"] DoubleError).["and_then"]
     (fun s =>
       (s.["parse"].["map_err"] (fun _ => DoubleError)).["map"]
-        (fun i => mul 2 i)).
+        (fun i => 2.["mul"] i)).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/early_returns.v
+++ b/coq_translation/examples-from-rust-book/error_handling/early_returns.v
@@ -20,7 +20,7 @@ Definition multiply
     | Ok (second_number) => second_number
     | Err (e) => Return (Err e)
     end in
-  Ok (mul first_number second_number).
+  Ok (first_number.["mul"] second_number).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/introducing_question_mark.v
+++ b/coq_translation/examples-from-rust-book/error_handling/introducing_question_mark.v
@@ -20,7 +20,7 @@ Definition multiply
     | Break {| Break.0 := residual; |} => Return (LangItem residual)
     | Continue {| Continue.0 := val; |} => val
     end in
-  Ok (mul first_number second_number).
+  Ok (first_number.["mul"] second_number).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
+++ b/coq_translation/examples-from-rust-book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
@@ -24,7 +24,7 @@ Definition multiply
       Return (_crate.result.Result.Err (_crate.convert.From.from err)) ;;
       tt
     end in
-  Ok (mul first_number second_number).
+  Ok (first_number.["mul"] second_number).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/map_in_result_via_combinators.v
+++ b/coq_translation/examples-from-rust-book/error_handling/map_in_result_via_combinators.v
@@ -13,7 +13,7 @@ Definition multiply
   first_number_str.["parse"].["and_then"]
     (fun first_number =>
       second_number_str.["parse"].["map"]
-        (fun second_number => mul first_number second_number)).
+        (fun second_number => first_number.["mul"] second_number)).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/map_in_result_via_match.v
+++ b/coq_translation/examples-from-rust-book/error_handling/map_in_result_via_match.v
@@ -13,7 +13,7 @@ Definition multiply
   match first_number_str.["parse"] with
   | Ok (first_number) =>
     match second_number_str.["parse"] with
-    | Ok (second_number) => Ok (mul first_number second_number)
+    | Ok (second_number) => Ok (first_number.["mul"] second_number)
     | Err (e) => Err e
     end
   | Err (e) => Err e

--- a/coq_translation/examples-from-rust-book/error_handling/multiple_error_types.v
+++ b/coq_translation/examples-from-rust-book/error_handling/multiple_error_types.v
@@ -5,7 +5,7 @@ Import Root.std.prelude.rust_2015.
 
 Definition double_first (vec : Vec) : i32 :=
   let first := vec.["first"].["unwrap"] in
-  mul 2 first.["parse"].["unwrap"].
+  2.["mul"] first.["parse"].["unwrap"].
 
 Definition main (_ : unit) : unit :=
   let numbers := Slice::["into_vec"] [ "42"; "93"; "18" ] in

--- a/coq_translation/examples-from-rust-book/error_handling/option_and_unwrap.v
+++ b/coq_translation/examples-from-rust-book/error_handling/option_and_unwrap.v
@@ -23,7 +23,7 @@ Definition give_adult (drink : Option) : unit :=
 
 Definition drink (drink : Option) : unit :=
   let inside := drink.["unwrap"] in
-  if (eqb inside "lemonade" : bool) then
+  if (inside.["eq"] "lemonade" : bool) then
     _crate.rt.begin_panic "AAAaaaaa!!!!" ;;
     tt
   else

--- a/coq_translation/examples-from-rust-book/error_handling/other_uses_of_question_mark.v
+++ b/coq_translation/examples-from-rust-book/error_handling/other_uses_of_question_mark.v
@@ -64,7 +64,7 @@ Definition double_first (vec : Vec) : Result :=
     | Break {| Break.0 := residual; |} => Return (LangItem residual)
     | Continue {| Continue.0 := val; |} => val
     end in
-  Ok (mul 2 parsed).
+  Ok (2.["mul"] parsed).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/other_uses_of_question_mark.v
+++ b/coq_translation/examples-from-rust-book/error_handling/other_uses_of_question_mark.v
@@ -9,7 +9,10 @@ Module fmt := std.fmt.
 
 Definition Result : Set := std.result.Result.
 
-Error StructUnit.
+Module EmptyVec.
+  Inductive t : Set := Build.
+End EmptyVec.
+Definition EmptyVec := EmptyVec.t.
 
 Module Impl__crate_fmt_Debug_for_EmptyVec.
   Definition Self := EmptyVec.
@@ -20,13 +23,13 @@ Module Impl__crate_fmt_Debug_for_EmptyVec.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "EmptyVec".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_EmptyVec.
 
 Module Impl_fmt_Display_for_EmptyVec.
@@ -38,13 +41,13 @@ Module Impl_fmt_Display_for_EmptyVec.
         [ "invalid first item to double" ]
         [  ]).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Display.Trait Self := {|
+  Global Instance I : fmt.Display.Trait Self := {
     fmt.Display.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Display_for_EmptyVec.
 
 Module Impl_error_Error_for_EmptyVec.
@@ -55,7 +58,7 @@ End Impl_error_Error_for_EmptyVec.
 
 Definition double_first (vec : Vec) : Result :=
   let first :=
-    match LangItem (vec.["first"].["ok_or"] EmptyVec) with
+    match LangItem (vec.["first"].["ok_or"] EmptyVec.Build) with
     | Break {| Break.0 := residual; |} => Return (LangItem residual)
     | Continue {| Continue.0 := val; |} => val
     end in

--- a/coq_translation/examples-from-rust-book/error_handling/panic.v
+++ b/coq_translation/examples-from-rust-book/error_handling/panic.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition drink (beverage : ref str) : unit :=
-  if (eqb beverage "lemonade" : bool) then
+  if (beverage.["eq"] "lemonade" : bool) then
     _crate.rt.begin_panic "AAAaaaaa!!!!" ;;
     tt
   else

--- a/coq_translation/examples-from-rust-book/error_handling/pulling_results_out_of_options.v
+++ b/coq_translation/examples-from-rust-book/error_handling/pulling_results_out_of_options.v
@@ -8,7 +8,7 @@ Definition ParseIntError := ParseIntError.t.
 
 Definition double_first (vec : Vec) : Option :=
   vec.["first"].["map"]
-    (fun first => first.["parse"].["map"] (fun n => mul 2 n)).
+    (fun first => first.["parse"].["map"] (fun n => 2.["mul"] n)).
 
 Definition main (_ : unit) : unit :=
   let numbers := Slice::["into_vec"] [ "42"; "93"; "18" ] in

--- a/coq_translation/examples-from-rust-book/error_handling/pulling_results_out_of_options_with_stop_error_processing.v
+++ b/coq_translation/examples-from-rust-book/error_handling/pulling_results_out_of_options_with_stop_error_processing.v
@@ -9,7 +9,7 @@ Definition ParseIntError := ParseIntError.t.
 Definition double_first (vec : Vec) : Result :=
   let opt :=
     vec.["first"].["map"]
-      (fun first => first.["parse"].["map"] (fun n => mul 2 n)) in
+      (fun first => first.["parse"].["map"] (fun n => 2.["mul"] n)) in
   opt.["map_or"] (Ok None) (fun r => r.["map"] Some).
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_get_or_insert.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_get_or_insert.v
@@ -28,13 +28,13 @@ Module Impl__crate_fmt_Debug_for_Fruit.
     | Fruit.Lemon => _crate.fmt.Formatter::["write_str"] f "Lemon"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Fruit.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_get_or_insert_with.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_get_or_insert_with.v
@@ -28,13 +28,13 @@ Module Impl__crate_fmt_Debug_for_Fruit.
     | Fruit.Lemon => _crate.fmt.Formatter::["write_str"] f "Lemon"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Fruit.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_or.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_or.v
@@ -28,13 +28,13 @@ Module Impl__crate_fmt_Debug_for_Fruit.
     | Fruit.Lemon => _crate.fmt.Formatter::["write_str"] f "Lemon"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Fruit.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_or_else.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_and_defaults_via_or_else.v
@@ -28,13 +28,13 @@ Module Impl__crate_fmt_Debug_for_Fruit.
     | Fruit.Lemon => _crate.fmt.Formatter::["write_str"] f "Lemon"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Fruit.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_via_question_mark.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_via_question_mark.v
@@ -124,7 +124,7 @@ Definition main (_ : unit) : unit :=
     |} in
   match (p.["work_phone_area_code"], Some 61) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/error_handling/unpacking_options_via_question_mark.v
+++ b/coq_translation/examples-from-rust-book/error_handling/unpacking_options_via_question_mark.v
@@ -8,9 +8,9 @@ Module Person.
     job : Option;
   }.
   
-  Global Instance Get_job : Notation.Dot "job" := {|
+  Global Instance Get_job : Notation.Dot "job" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Person.
 Definition Person : Set := Person.t.
 
@@ -19,9 +19,9 @@ Module Job.
     phone_number : Option;
   }.
   
-  Global Instance Get_phone_number : Notation.Dot "phone_number" := {|
+  Global Instance Get_phone_number : Notation.Dot "phone_number" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Job.
 Definition Job : Set := Job.t.
 
@@ -32,13 +32,13 @@ Module Impl__crate_clone_Clone_for_Job.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Job.
 
 Module Impl__crate_marker_Copy_for_Job.
@@ -54,12 +54,12 @@ Module PhoneNumber.
     number : u32;
   }.
   
-  Global Instance Get_area_code : Notation.Dot "area_code" := {|
+  Global Instance Get_area_code : Notation.Dot "area_code" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_number : Notation.Dot "number" := {|
+  }.
+  Global Instance Get_number : Notation.Dot "number" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End PhoneNumber.
 Definition PhoneNumber : Set := PhoneNumber.t.
 
@@ -71,13 +71,13 @@ Module Impl__crate_clone_Clone_for_PhoneNumber.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_PhoneNumber.
 
 Module Impl__crate_marker_Copy_for_PhoneNumber.
@@ -103,9 +103,9 @@ Module ImplPerson.
       end.["area_code"].
   
   Global Instance Method_work_phone_area_code :
-    Notation.Dot "work_phone_area_code" := {|
+    Notation.Dot "work_phone_area_code" := {
     Notation.dot := work_phone_area_code;
-  |}.
+  }.
 End ImplPerson.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/error_handling/wrapping_errors.v
+++ b/coq_translation/examples-from-rust-book/error_handling/wrapping_errors.v
@@ -112,7 +112,7 @@ Definition double_first (vec : Vec) : Result :=
     | Break {| Break.0 := residual; |} => Return (LangItem residual)
     | Continue {| Continue.0 := val; |} => val
     end in
-  Ok (mul 2 parsed).
+  Ok (2.["mul"] parsed).
 
 Definition print (result : Result) : unit :=
   match result with

--- a/coq_translation/examples-from-rust-book/error_handling/wrapping_errors.v
+++ b/coq_translation/examples-from-rust-book/error_handling/wrapping_errors.v
@@ -34,13 +34,13 @@ Module Impl__crate_fmt_Debug_for_DoubleError.
       _crate.fmt.Formatter::["debug_tuple_field1_finish"] f "Parse" __self_0
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_DoubleError.
 
 Module Impl_fmt_Display_for_DoubleError.
@@ -60,13 +60,13 @@ Module Impl_fmt_Display_for_DoubleError.
           [  ])
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Display.Trait Self := {|
+  Global Instance I : fmt.Display.Trait Self := {
     fmt.Display.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Display_for_DoubleError.
 
 Module Impl_error_Error_for_DoubleError.
@@ -78,12 +78,12 @@ Module Impl_error_Error_for_DoubleError.
     | DoubleError.Parse (e) => Some e
     end.
   
-  Global Instance Method_source : Notation.Dot "source" := {|
+  Global Instance Method_source : Notation.Dot "source" := {
     Notation.dot := source;
-  |}.
+  }.
   
-  Global Instance I : error.Error.Trait Self := {|
-  |}.
+  Global Instance I : error.Error.Trait Self := {
+  }.
 End Impl_error_Error_for_DoubleError.
 
 Module Impl_From_for_DoubleError.
@@ -92,13 +92,13 @@ Module Impl_From_for_DoubleError.
   Definition from (err : ParseIntError) : DoubleError := DoubleError.Parse err.
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I : From.Trait ParseIntError Self := {|
+  Global Instance I : From.Trait Self ParseIntError := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_DoubleError.
 
 Definition double_first (vec : Vec) : Result :=

--- a/coq_translation/examples-from-rust-book/expressions/blocks.v
+++ b/coq_translation/examples-from-rust-book/expressions/blocks.v
@@ -6,11 +6,11 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let x := 5 in
   let y :=
-    let x_squared := mul x x in
-    let x_cube := mul x_squared x in
-    add (add x_cube x_squared) x in
+    let x_squared := x.["mul"] x in
+    let x_cube := x_squared.["mul"] x in
+    (x_cube.["add"] x_squared).["add"] x in
   let z :=
-    mul 2 x ;;
+    2.["mul"] x ;;
     tt in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/expressions/variable_binding_and_expression.v
+++ b/coq_translation/examples-from-rust-book/expressions/variable_binding_and_expression.v
@@ -6,6 +6,6 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let x := 5 in
   x ;;
-  add x 1 ;;
+  x.["add"] 1 ;;
   15 ;;
   tt.

--- a/coq_translation/examples-from-rust-book/flow_of_control/for_and_range_completely_inclusive.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/for_and_range_completely_inclusive.v
@@ -10,19 +10,19 @@ Definition main (_ : unit) : unit :=
       match LangItem iter with
       | None => Break
       | Some {| Some.0 := n; |} =>
-        if (eqb (rem n 15) 0 : bool) then
+        if ((n.["rem"] 15).["eq"] 0 : bool) then
           _crate.io._print
             (_crate.fmt.Arguments::["new_v1"] [ "fizzbuzz\n" ] [  ]) ;;
           tt ;;
           tt
         else
-          if (eqb (rem n 3) 0 : bool) then
+          if ((n.["rem"] 3).["eq"] 0 : bool) then
             _crate.io._print
               (_crate.fmt.Arguments::["new_v1"] [ "fizz\n" ] [  ]) ;;
             tt ;;
             tt
           else
-            if (eqb (rem n 5) 0 : bool) then
+            if ((n.["rem"] 5).["eq"] 0 : bool) then
               _crate.io._print
                 (_crate.fmt.Arguments::["new_v1"] [ "buzz\n" ] [  ]) ;;
               tt ;;

--- a/coq_translation/examples-from-rust-book/flow_of_control/for_and_range_inclusive_to_exclusive.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/for_and_range_inclusive_to_exclusive.v
@@ -10,19 +10,19 @@ Definition main (_ : unit) : unit :=
       match LangItem iter with
       | None => Break
       | Some {| Some.0 := n; |} =>
-        if (eqb (rem n 15) 0 : bool) then
+        if ((n.["rem"] 15).["eq"] 0 : bool) then
           _crate.io._print
             (_crate.fmt.Arguments::["new_v1"] [ "fizzbuzz\n" ] [  ]) ;;
           tt ;;
           tt
         else
-          if (eqb (rem n 3) 0 : bool) then
+          if ((n.["rem"] 3).["eq"] 0 : bool) then
             _crate.io._print
               (_crate.fmt.Arguments::["new_v1"] [ "fizz\n" ] [  ]) ;;
             tt ;;
             tt
           else
-            if (eqb (rem n 5) 0 : bool) then
+            if ((n.["rem"] 5).["eq"] 0 : bool) then
               _crate.io._print
                 (_crate.fmt.Arguments::["new_v1"] [ "buzz\n" ] [  ]) ;;
               tt ;;

--- a/coq_translation/examples-from-rust-book/flow_of_control/if_else.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/if_else.v
@@ -5,7 +5,7 @@ Import Root.std.prelude.rust_2015.
 
 Definition main (_ : unit) : unit :=
   let n := 5 in
-  if (lt n 0 : bool) then
+  if (n.["lt"] 0 : bool) then
     _crate.io._print
       (_crate.fmt.Arguments::["new_v1"]
         [ ""; " is negative" ]
@@ -13,7 +13,7 @@ Definition main (_ : unit) : unit :=
     tt ;;
     tt
   else
-    if (gt n 0 : bool) then
+    if (n.["gt"] 0 : bool) then
       _crate.io._print
         (_crate.fmt.Arguments::["new_v1"]
           [ ""; " is positive" ]
@@ -28,20 +28,20 @@ Definition main (_ : unit) : unit :=
       tt ;;
       tt ;;
   let big_n :=
-    if (andb (lt n 10) (gt n (neg 10)) : bool) then
+    if ((n.["lt"] 10).["andb"] (n.["gt"] (neg 10)) : bool) then
       _crate.io._print
         (_crate.fmt.Arguments::["new_v1"]
           [ ", and is a small number, increase ten-fold\n" ]
           [  ]) ;;
       tt ;;
-      mul 10 n
+      10.["mul"] n
     else
       _crate.io._print
         (_crate.fmt.Arguments::["new_v1"]
           [ ", and is a big number, halve the number\n" ]
           [  ]) ;;
       tt ;;
-      div n 2 in
+      n.["div"] 2 in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " -> "; "\n" ]

--- a/coq_translation/examples-from-rust-book/flow_of_control/infinite_loop.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/infinite_loop.v
@@ -12,7 +12,7 @@ Definition main (_ : unit) : unit :=
   tt ;;
   loop
     assign count (add count 1) ;;
-    if (eqb count 3 : bool) then
+    if (count.["eq"] 3 : bool) then
       _crate.io._print (_crate.fmt.Arguments::["new_v1"] [ "three\n" ] [  ]) ;;
       tt ;;
       Continue ;;
@@ -24,7 +24,7 @@ Definition main (_ : unit) : unit :=
         [ ""; "\n" ]
         [ _crate.fmt.ArgumentV1::["new_display"] count ]) ;;
     tt ;;
-    if (eqb count 5 : bool) then
+    if (count.["eq"] 5 : bool) then
       _crate.io._print
         (_crate.fmt.Arguments::["new_v1"] [ "OK, that's enough\n" ] [  ]) ;;
       tt ;;

--- a/coq_translation/examples-from-rust-book/flow_of_control/loop_returning_from_loops.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/loop_returning_from_loops.v
@@ -8,7 +8,7 @@ Definition main (_ : unit) : unit :=
   let result :=
     loop
       assign counter (add counter 1) ;;
-      if (eqb counter 10 : bool) then
+      if (counter.["eq"] 10 : bool) then
         Break ;;
         tt
       else
@@ -17,7 +17,7 @@ Definition main (_ : unit) : unit :=
       loop in
   match (result, 20) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/flow_of_control/match_destructuring_structs.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/match_destructuring_structs.v
@@ -11,11 +11,11 @@ Module Foo.
     y : u32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Foo.
 Definition Foo : Set := Foo.t.

--- a/coq_translation/examples-from-rust-book/flow_of_control/while.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/while.v
@@ -6,20 +6,20 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let n := 1 in
   loop
-    (if (lt n 101 : bool) then
-      if (eqb (rem n 15) 0 : bool) then
+    (if (n.["lt"] 101 : bool) then
+      if ((n.["rem"] 15).["eq"] 0 : bool) then
         _crate.io._print
           (_crate.fmt.Arguments::["new_v1"] [ "fizzbuzz\n" ] [  ]) ;;
         tt ;;
         tt
       else
-        if (eqb (rem n 3) 0 : bool) then
+        if ((n.["rem"] 3).["eq"] 0 : bool) then
           _crate.io._print
             (_crate.fmt.Arguments::["new_v1"] [ "fizz\n" ] [  ]) ;;
           tt ;;
           tt
         else
-          if (eqb (rem n 5) 0 : bool) then
+          if ((n.["rem"] 5).["eq"] 0 : bool) then
             _crate.io._print
               (_crate.fmt.Arguments::["new_v1"] [ "buzz\n" ] [  ]) ;;
             tt ;;

--- a/coq_translation/examples-from-rust-book/flow_of_control/while_let.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/while_let.v
@@ -7,7 +7,7 @@ Definition main (_ : unit) : unit :=
   let optional := Some 0 in
   loop
     (if (let_if Some (i) := optional : bool) then
-      if (gt i 9 : bool) then
+      if (i.["gt"] 9 : bool) then
         _crate.io._print
           (_crate.fmt.Arguments::["new_v1"]
             [ "Greater than 9, quit!\n" ]
@@ -21,7 +21,7 @@ Definition main (_ : unit) : unit :=
             [ "`i` is `"; "`. Try again.\n" ]
             [ _crate.fmt.ArgumentV1::["new_debug"] i ]) ;;
         tt ;;
-        assign optional (Some (add i 1)) ;;
+        assign optional (Some (i.["add"] 1)) ;;
         tt
     else
       Break ;;

--- a/coq_translation/examples-from-rust-book/flow_of_control/while_let_match_is_weird.v
+++ b/coq_translation/examples-from-rust-book/flow_of_control/while_let_match_is_weird.v
@@ -8,7 +8,7 @@ Definition main (_ : unit) : unit :=
   loop
     match optional with
     | Some (i) =>
-      if (gt i 9 : bool) then
+      if (i.["gt"] 9 : bool) then
         _crate.io._print
           (_crate.fmt.Arguments::["new_v1"]
             [ "Greater than 9, quit!\n" ]
@@ -22,7 +22,7 @@ Definition main (_ : unit) : unit :=
             [ "`i` is `"; "`. Try again.\n" ]
             [ _crate.fmt.ArgumentV1::["new_debug"] i ]) ;;
         tt ;;
-        assign optional (Some (add i 1)) ;;
+        assign optional (Some (i.["add"] 1)) ;;
         tt
     | _ =>
       Break ;;

--- a/coq_translation/examples-from-rust-book/functions/associated_functions_and_methods.v
+++ b/coq_translation/examples-from-rust-book/functions/associated_functions_and_methods.v
@@ -64,7 +64,7 @@ Module ImplRectangle.
   Definition area (self : ref Self) : f64 :=
     let Point {| Point.x := x1; Point.y := y1; |} := self.["p1"] in
     let Point {| Point.x := x2; Point.y := y2; |} := self.["p2"] in
-    (mul (sub x1 x2) (sub y1 y2)).["abs"].
+    ((x1.["sub"] x2).["mul"] (y1.["sub"] y2)).["abs"].
   
   Global Instance Method_area : Notation.Dot "area" := {|
     Notation.dot := area;
@@ -73,7 +73,8 @@ Module ImplRectangle.
   Definition perimeter (self : ref Self) : f64 :=
     let Point {| Point.x := x1; Point.y := y1; |} := self.["p1"] in
     let Point {| Point.x := x2; Point.y := y2; |} := self.["p2"] in
-    mul 2 (* 2.0 *) (add (sub x1 x2).["abs"] (sub y1 y2).["abs"]).
+    2 (* 2.0 *).["mul"]
+      ((x1.["sub"] x2).["abs"].["add"] (y1.["sub"] y2).["abs"]).
   
   Global Instance Method_perimeter : Notation.Dot "perimeter" := {|
     Notation.dot := perimeter;

--- a/coq_translation/examples-from-rust-book/functions/associated_functions_and_methods.v
+++ b/coq_translation/examples-from-rust-book/functions/associated_functions_and_methods.v
@@ -9,12 +9,12 @@ Module Point.
     y : f64;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Point.
 Definition Point : Set := Point.t.
 
@@ -25,16 +25,16 @@ Module ImplPoint.
     {| Point.y := 0 (* 0.0 *); Point.x := 1 (* 1.0 *); |}.
   
   Global Instance AssociatedFunction_origin :
-    Notation.DoubleColon Self "origin" := {|
+    Notation.DoubleColon Self "origin" := {
     Notation.double_colon := origin;
-  |}.
+  }.
   
   Definition new (x : f64) (y : f64) : Point :=
     {| Point.x := x; Point.y := y; |}.
   
-  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {|
+  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {
     Notation.double_colon := new;
-  |}.
+  }.
 End ImplPoint.
 
 Module Rectangle.
@@ -43,12 +43,12 @@ Module Rectangle.
     p2 : Point;
   }.
   
-  Global Instance Get_p1 : Notation.Dot "p1" := {|
+  Global Instance Get_p1 : Notation.Dot "p1" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_p2 : Notation.Dot "p2" := {|
+  }.
+  Global Instance Get_p2 : Notation.Dot "p2" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.
 
@@ -57,18 +57,18 @@ Module ImplRectangle.
   
   Definition get_p1 (self : ref Self) : Point := self.["p1"].
   
-  Global Instance Method_get_p1 : Notation.Dot "get_p1" := {|
+  Global Instance Method_get_p1 : Notation.Dot "get_p1" := {
     Notation.dot := get_p1;
-  |}.
+  }.
   
   Definition area (self : ref Self) : f64 :=
     let Point {| Point.x := x1; Point.y := y1; |} := self.["p1"] in
     let Point {| Point.x := x2; Point.y := y2; |} := self.["p2"] in
     ((x1.["sub"] x2).["mul"] (y1.["sub"] y2)).["abs"].
   
-  Global Instance Method_area : Notation.Dot "area" := {|
+  Global Instance Method_area : Notation.Dot "area" := {
     Notation.dot := area;
-  |}.
+  }.
   
   Definition perimeter (self : ref Self) : f64 :=
     let Point {| Point.x := x1; Point.y := y1; |} := self.["p1"] in
@@ -76,9 +76,9 @@ Module ImplRectangle.
     2 (* 2.0 *).["mul"]
       ((x1.["sub"] x2).["abs"].["add"] (y1.["sub"] y2).["abs"]).
   
-  Global Instance Method_perimeter : Notation.Dot "perimeter" := {|
+  Global Instance Method_perimeter : Notation.Dot "perimeter" := {
     Notation.dot := perimeter;
-  |}.
+  }.
   
   Definition translate (self : mut_ref Self) (x : f64) (y : f64) :=
     assign self.["p1"].["x"] (add self.["p1"].["x"] x) ;;
@@ -87,20 +87,20 @@ Module ImplRectangle.
     assign self.["p2"].["y"] (add self.["p2"].["y"] y) ;;
     tt.
   
-  Global Instance Method_translate : Notation.Dot "translate" := {|
+  Global Instance Method_translate : Notation.Dot "translate" := {
     Notation.dot := translate;
-  |}.
+  }.
 End ImplRectangle.
 
 Module Pair.
   Inductive t : Set := Build (_ : Box) (_ : Box).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Pair.
 Definition Pair := Pair.t.
 
@@ -119,9 +119,9 @@ Module ImplPair.
     tt ;;
     tt.
   
-  Global Instance Method_destroy : Notation.Dot "destroy" := {|
+  Global Instance Method_destroy : Notation.Dot "destroy" := {
     Notation.dot := destroy;
-  |}.
+  }.
 End ImplPair.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/functions/diverging_functions_example_sum_odd_numbers.v
+++ b/coq_translation/examples-from-rust-book/functions/diverging_functions_example_sum_odd_numbers.v
@@ -14,7 +14,7 @@ Definition sum_odd_numbers (up_to : u32) : u32 :=
       | None => Break
       | Some {| Some.0 := i; |} =>
         let addition :=
-          match eqb (rem i 2) 1 with
+          match (i.["rem"] 2).["eq"] 1 with
           | Bool(true) => i
           | Bool(false) => Continue
           end in

--- a/coq_translation/examples-from-rust-book/functions/functions.v
+++ b/coq_translation/examples-from-rust-book/functions/functions.v
@@ -8,12 +8,12 @@ Definition main (_ : unit) : unit :=
   tt.
 
 Definition is_divisible_by (lhs : u32) (rhs : u32) : bool :=
-  if (eqb rhs 0 : bool) then
+  if (rhs.["eq"] 0 : bool) then
     Return false ;;
     tt
   else
     tt ;;
-  eqb (rem lhs rhs) 0.
+  (lhs.["rem"] rhs).["eq"] 0.
 
 Definition fizzbuzz (n : u32) :  :=
   if (is_divisible_by n 15 : bool) then

--- a/coq_translation/examples-from-rust-book/functions/functions_closures.v
+++ b/coq_translation/examples-from-rust-book/functions/functions_closures.v
@@ -5,8 +5,8 @@ Import Root.std.prelude.rust_2015.
 
 Definition main (_ : unit) : unit :=
   let outer_var := 42 in
-  let closure_annotated := fun i => add i outer_var in
-  let closure_inferred := fun i => add i outer_var in
+  let closure_annotated := fun i => i.["add"] outer_var in
+  let closure_inferred := fun i => i.["add"] outer_var in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "closure_annotated: "; "\n" ]

--- a/coq_translation/examples-from-rust-book/functions/functions_closures_example_Iterator_any.v
+++ b/coq_translation/examples-from-rust-book/functions/functions_closures_example_Iterator_any.v
@@ -11,7 +11,7 @@ Definition main (_ : unit) : unit :=
       [ "2 in vec1: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (vec1.["iter"].["any"] (fun x => eqb x 2))
+          (vec1.["iter"].["any"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   _crate.io._print
@@ -19,7 +19,7 @@ Definition main (_ : unit) : unit :=
       [ "2 in vec2: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (vec2.["into_iter"].["any"] (fun x => eqb x 2))
+          (vec2.["into_iter"].["any"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   _crate.io._print
@@ -39,7 +39,7 @@ Definition main (_ : unit) : unit :=
       [ "2 in array1: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (array1.["iter"].["any"] (fun x => eqb x 2))
+          (array1.["iter"].["any"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   _crate.io._print
@@ -47,7 +47,7 @@ Definition main (_ : unit) : unit :=
       [ "2 in array2: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (array2.["into_iter"].["any"] (fun x => eqb x 2))
+          (array2.["into_iter"].["any"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/functions/functions_closures_example_searching_through_iterators_Iterator_find.v
+++ b/coq_translation/examples-from-rust-book/functions/functions_closures_example_searching_through_iterators_Iterator_find.v
@@ -11,7 +11,9 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Find 2 in vec1: "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_debug"] (iter.["find"] (fun x => eqb x 2))
+      [
+        _crate.fmt.ArgumentV1::["new_debug"]
+          (iter.["find"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   _crate.io._print
@@ -19,7 +21,7 @@ Definition main (_ : unit) : unit :=
       [ "Find 2 in vec2: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_debug"]
-          (into_iter.["find"] (fun x => eqb x 2))
+          (into_iter.["find"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   let array1 := [ 1; 2; 3 ] in
@@ -29,7 +31,7 @@ Definition main (_ : unit) : unit :=
       [ "Find 2 in array1: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_debug"]
-          (array1.["iter"].["find"] (fun x => eqb x 2))
+          (array1.["iter"].["find"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   _crate.io._print
@@ -37,7 +39,7 @@ Definition main (_ : unit) : unit :=
       [ "Find 2 in array2: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_debug"]
-          (array2.["into_iter"].["find"] (fun x => eqb x 2))
+          (array2.["into_iter"].["find"] (fun x => x.["eq"] 2))
       ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
+++ b/coq_translation/examples-from-rust-book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
@@ -6,10 +6,10 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let vec := Slice::["into_vec"] [ 1; 9; 3; 3; 13; 2 ] in
   let index_of_first_even_number :=
-    vec.["iter"].["position"] (fun x => eqb (rem x 2) 0) in
+    vec.["iter"].["position"] (fun x => (x.["rem"] 2).["eq"] 0) in
   match (index_of_first_even_number, Some 5) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -21,10 +21,10 @@ Definition main (_ : unit) : unit :=
       tt
   end ;;
   let index_of_first_negative_number :=
-    vec.["into_iter"].["position"] (fun x => lt x 0) in
+    vec.["into_iter"].["position"] (fun x => x.["lt"] 0) in
   match (index_of_first_negative_number, None) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/functions/higher_order_functions.v
+++ b/coq_translation/examples-from-rust-book/functions/higher_order_functions.v
@@ -3,7 +3,7 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Definition is_odd (n : u32) : bool := eqb (rem n 2) 1.
+Definition is_odd (n : u32) : bool := (n.["rem"] 2).["eq"] 1.
 
 Definition main (_ : unit) : unit :=
   _crate.io._print
@@ -19,8 +19,8 @@ Definition main (_ : unit) : unit :=
       match LangItem iter with
       | None => Break
       | Some {| Some.0 := n; |} =>
-        let n_squared := mul n n in
-        if (ge n_squared upper : bool) then
+        let n_squared := n.["mul"] n in
+        if (n_squared.["ge"] upper : bool) then
           Break ;;
           tt
         else
@@ -40,8 +40,9 @@ Definition main (_ : unit) : unit :=
       [ _crate.fmt.ArgumentV1::["new_display"] acc ]) ;;
   tt ;;
   let sum_of_squared_odd_numbers :=
-    ((({| RangeFrom.start := 0; |}.["map"] (fun n => mul n n)).["take_while"]
-          (fun n_squared => lt n_squared upper)).["filter"]
+    ((({| RangeFrom.start := 0; |}.["map"]
+            (fun n => n.["mul"] n)).["take_while"]
+          (fun n_squared => n_squared.["lt"] upper)).["filter"]
         (fun n_squared => is_odd n_squared)).["sum"] in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/generics/generics.v
+++ b/coq_translation/examples-from-rust-book/generics/generics.v
@@ -3,30 +3,33 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module A.
+  Inductive t : Set := Build.
+End A.
+Definition A := A.t.
 
 Module Single.
   Inductive t : Set := Build (_ : A).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Single.
 Definition Single := Single.t.
 
 Module SingleGen.
   Inductive t : Set := Build (_ : T).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End SingleGen.
 Definition SingleGen := SingleGen.t.
 
 Definition main (_ : unit) : unit :=
-  let _s := Single.Build A in
+  let _s := Single.Build A.Build in
   let _char := SingleGen.Build a in
-  let _t := SingleGen.Build A in
+  let _t := SingleGen.Build A.Build in
   let _i32 := SingleGen.Build 6 in
   let _char := SingleGen.Build a in
   tt.

--- a/coq_translation/examples-from-rust-book/generics/generics_associated_types_problem.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_associated_types_problem.v
@@ -41,9 +41,8 @@ Module Impl_Contains_for_Container.
       (number_1 : ref i32)
       (number_2 : ref i32)
       : bool :=
-    andb
-      (eqb (IndexedField.get (index := 0) self) number_1)
-      (eqb (IndexedField.get (index := 1) self) number_2).
+    ((IndexedField.get (index := 0) self).["eq"] number_1).["andb"]
+      ((IndexedField.get (index := 1) self).["eq"] number_2).
   
   Global Instance Method_contains : Notation.Dot "contains" := {|
     Notation.dot := contains;
@@ -74,7 +73,7 @@ Definition difference
     `{Contains.Trait A B C}
     (container : ref C)
     : i32 :=
-  sub container.["last"] container.["first"].
+  container.["last"].["sub"] container.["first"].
 
 Definition main (_ : unit) : unit :=
   let number_1 := 3 in

--- a/coq_translation/examples-from-rust-book/generics/generics_associated_types_problem.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_associated_types_problem.v
@@ -6,12 +6,12 @@ Import Root.std.prelude.rust_2015.
 Module Container.
   Inductive t : Set := Build (_ : i32) (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Container.
 Definition Container := Container.t.
 
@@ -22,15 +22,15 @@ Module Contains.
     last : (ref Self) -> i32;
   }.
   
-  Global Instance Method_contains `(Trait) : Notation.Dot "contains" := {|
+  Global Instance Method_contains `(Trait) : Notation.Dot "contains" := {
     Notation.dot := contains;
-  |}.
-  Global Instance Method_first `(Trait) : Notation.Dot "first" := {|
+  }.
+  Global Instance Method_first `(Trait) : Notation.Dot "first" := {
     Notation.dot := first;
-  |}.
-  Global Instance Method_last `(Trait) : Notation.Dot "last" := {|
+  }.
+  Global Instance Method_last `(Trait) : Notation.Dot "last" := {
     Notation.dot := last;
-  |}.
+  }.
 End Contains.
 
 Module Impl_Contains_for_Container.
@@ -44,28 +44,28 @@ Module Impl_Contains_for_Container.
     ((IndexedField.get (index := 0) self).["eq"] number_1).["andb"]
       ((IndexedField.get (index := 1) self).["eq"] number_2).
   
-  Global Instance Method_contains : Notation.Dot "contains" := {|
+  Global Instance Method_contains : Notation.Dot "contains" := {
     Notation.dot := contains;
-  |}.
+  }.
   
   Definition first (self : ref Self) : i32 :=
     IndexedField.get (index := 0) self.
   
-  Global Instance Method_first : Notation.Dot "first" := {|
+  Global Instance Method_first : Notation.Dot "first" := {
     Notation.dot := first;
-  |}.
+  }.
   
   Definition last (self : ref Self) : i32 := IndexedField.get (index := 1) self.
   
-  Global Instance Method_last : Notation.Dot "last" := {|
+  Global Instance Method_last : Notation.Dot "last" := {
     Notation.dot := last;
-  |}.
+  }.
   
-  Global Instance I : Contains.Trait i32 i32 Self := {|
+  Global Instance I : Contains.Trait Self i32 i32 := {
     Contains.contains := contains;
     Contains.first := first;
     Contains.last := last;
-  |}.
+  }.
 End Impl_Contains_for_Container.
 
 Definition difference

--- a/coq_translation/examples-from-rust-book/generics/generics_associated_types_solution.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_associated_types_solution.v
@@ -53,9 +53,8 @@ Module Impl_Contains_for_Container.
       (number_1 : ref i32)
       (number_2 : ref i32)
       : bool :=
-    andb
-      (eqb (IndexedField.get (index := 0) self) number_1)
-      (eqb (IndexedField.get (index := 1) self) number_2).
+    ((IndexedField.get (index := 0) self).["eq"] number_1).["andb"]
+      ((IndexedField.get (index := 1) self).["eq"] number_2).
   
   Global Instance Method_contains : Notation.Dot "contains" := {|
     Notation.dot := contains;
@@ -84,7 +83,7 @@ Module Impl_Contains_for_Container.
 End Impl_Contains_for_Container.
 
 Definition difference {C : Set} `{Contains.Trait C} (container : ref C) : i32 :=
-  sub container.["last"] container.["first"].
+  container.["last"].["sub"] container.["first"].
 
 Definition main (_ : unit) : unit :=
   let number_1 := 3 in

--- a/coq_translation/examples-from-rust-book/generics/generics_associated_types_solution.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_associated_types_solution.v
@@ -6,12 +6,12 @@ Import Root.std.prelude.rust_2015.
 Module Container.
   Inductive t : Set := Build (_ : i32) (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Container.
 Definition Container := Container.t.
 
@@ -24,21 +24,21 @@ Module Contains.
     last : (ref Self) -> i32;
   }.
   
-  Global Instance Method_A `(Trait) : Notation.Dot "A" := {|
+  Global Instance Method_A `(Trait) : Notation.Dot "A" := {
     Notation.dot := A;
-  |}.
-  Global Instance Method_B `(Trait) : Notation.Dot "B" := {|
+  }.
+  Global Instance Method_B `(Trait) : Notation.Dot "B" := {
     Notation.dot := B;
-  |}.
-  Global Instance Method_contains `(Trait) : Notation.Dot "contains" := {|
+  }.
+  Global Instance Method_contains `(Trait) : Notation.Dot "contains" := {
     Notation.dot := contains;
-  |}.
-  Global Instance Method_first `(Trait) : Notation.Dot "first" := {|
+  }.
+  Global Instance Method_first `(Trait) : Notation.Dot "first" := {
     Notation.dot := first;
-  |}.
-  Global Instance Method_last `(Trait) : Notation.Dot "last" := {|
+  }.
+  Global Instance Method_last `(Trait) : Notation.Dot "last" := {
     Notation.dot := last;
-  |}.
+  }.
 End Contains.
 
 Module Impl_Contains_for_Container.
@@ -56,30 +56,28 @@ Module Impl_Contains_for_Container.
     ((IndexedField.get (index := 0) self).["eq"] number_1).["andb"]
       ((IndexedField.get (index := 1) self).["eq"] number_2).
   
-  Global Instance Method_contains : Notation.Dot "contains" := {|
+  Global Instance Method_contains : Notation.Dot "contains" := {
     Notation.dot := contains;
-  |}.
+  }.
   
   Definition first (self : ref Self) : i32 :=
     IndexedField.get (index := 0) self.
   
-  Global Instance Method_first : Notation.Dot "first" := {|
+  Global Instance Method_first : Notation.Dot "first" := {
     Notation.dot := first;
-  |}.
+  }.
   
   Definition last (self : ref Self) : i32 := IndexedField.get (index := 1) self.
   
-  Global Instance Method_last : Notation.Dot "last" := {|
+  Global Instance Method_last : Notation.Dot "last" := {
     Notation.dot := last;
-  |}.
+  }.
   
-  Global Instance I : Contains.Trait Self := {|
-    Contains.A := A;
-    Contains.B := B;
+  Global Instance I : Contains.Trait Self := {
     Contains.contains := contains;
     Contains.first := first;
     Contains.last := last;
-  |}.
+  }.
 End Impl_Contains_for_Container.
 
 Definition difference {C : Set} `{Contains.Trait C} (container : ref C) : i32 :=

--- a/coq_translation/examples-from-rust-book/generics/generics_bounds.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_bounds.v
@@ -19,7 +19,7 @@ Module Impl_HasArea_for_Rectangle.
   Definition Self := Rectangle.
   
   Definition area (self : ref Self) : f64 :=
-    mul self.["length"] self.["height"].
+    self.["length"].["mul"] self.["height"].
   
   Global Instance Method_area : Notation.Dot "area" := {|
     Notation.dot := area;

--- a/coq_translation/examples-from-rust-book/generics/generics_bounds.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_bounds.v
@@ -10,9 +10,9 @@ Module HasArea.
     area : (ref Self) -> f64;
   }.
   
-  Global Instance Method_area `(Trait) : Notation.Dot "area" := {|
+  Global Instance Method_area `(Trait) : Notation.Dot "area" := {
     Notation.dot := area;
-  |}.
+  }.
 End HasArea.
 
 Module Impl_HasArea_for_Rectangle.
@@ -21,13 +21,13 @@ Module Impl_HasArea_for_Rectangle.
   Definition area (self : ref Self) : f64 :=
     self.["length"].["mul"] self.["height"].
   
-  Global Instance Method_area : Notation.Dot "area" := {|
+  Global Instance Method_area : Notation.Dot "area" := {
     Notation.dot := area;
-  |}.
+  }.
   
-  Global Instance I : HasArea.Trait Self := {|
+  Global Instance I : HasArea.Trait Self := {
     HasArea.area := area;
-  |}.
+  }.
 End Impl_HasArea_for_Rectangle.
 
 Module Rectangle.
@@ -36,12 +36,12 @@ Module Rectangle.
     height : f64;
   }.
   
-  Global Instance Get_length : Notation.Dot "length" := {|
+  Global Instance Get_length : Notation.Dot "length" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_height : Notation.Dot "height" := {|
+  }.
+  Global Instance Get_height : Notation.Dot "height" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.
 
@@ -60,13 +60,13 @@ Module Impl__crate_fmt_Debug_for_Rectangle.
       "height"
       self.["height"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Rectangle.
 
 Module Triangle.
@@ -75,12 +75,12 @@ Module Triangle.
     height : f64;
   }.
   
-  Global Instance Get_length : Notation.Dot "length" := {|
+  Global Instance Get_length : Notation.Dot "length" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_height : Notation.Dot "height" := {|
+  }.
+  Global Instance Get_height : Notation.Dot "height" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Triangle.
 Definition Triangle : Set := Triangle.t.
 

--- a/coq_translation/examples-from-rust-book/generics/generics_bounds_test_case_empty_bounds.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_bounds_test_case_empty_bounds.v
@@ -3,11 +3,20 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module Cardinal.
+  Inductive t : Set := Build.
+End Cardinal.
+Definition Cardinal := Cardinal.t.
 
-Error StructUnit.
+Module BlueJay.
+  Inductive t : Set := Build.
+End BlueJay.
+Definition BlueJay := BlueJay.t.
 
-Error StructUnit.
+Module Turkey.
+  Inductive t : Set := Build.
+End Turkey.
+Definition Turkey := Turkey.t.
 
 Module Red.
   Unset Primitive Projections.
@@ -40,9 +49,9 @@ Definition red {T : Set} `{Red.Trait T} (arg : ref T) : ref str := "red".
 Definition blue {T : Set} `{Blue.Trait T} (arg : ref T) : ref str := "blue".
 
 Definition main (_ : unit) : unit :=
-  let cardinal := Cardinal in
-  let blue_jay := BlueJay in
-  let _turkey := Turkey in
+  let cardinal := Cardinal.Build in
+  let blue_jay := BlueJay.Build in
+  let _turkey := Turkey.Build in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "A cardinal is "; "\n" ]

--- a/coq_translation/examples-from-rust-book/generics/generics_functions.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_functions.v
@@ -3,23 +3,26 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module A.
+  Inductive t : Set := Build.
+End A.
+Definition A := A.t.
 
 Module S.
   Inductive t : Set := Build (_ : A).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End S.
 Definition S := S.t.
 
 Module SGen.
   Inductive t : Set := Build (_ : T).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End SGen.
 Definition SGen := SGen.t.
 
@@ -32,8 +35,8 @@ Definition gen_spec_i32 (_s : SGen) : unit := tt.
 Definition generic {T : Set} (_s : SGen) : unit := tt.
 
 Definition main (_ : unit) : unit :=
-  reg_fn (S.Build A) ;;
-  gen_spec_t (SGen.Build A) ;;
+  reg_fn (S.Build A.Build) ;;
+  gen_spec_t (SGen.Build A.Build) ;;
   gen_spec_i32 (SGen.Build 6) ;;
   generic (SGen.Build a) ;;
   generic (SGen.Build c) ;;

--- a/coq_translation/examples-from-rust-book/generics/generics_implementation.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_implementation.v
@@ -8,9 +8,9 @@ Module Val.
     val : f64;
   }.
   
-  Global Instance Get_val : Notation.Dot "val" := {|
+  Global Instance Get_val : Notation.Dot "val" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Val.
 Definition Val : Set := Val.t.
 
@@ -19,9 +19,9 @@ Module GenVal.
     gen_val : T;
   }.
   
-  Global Instance Get_gen_val : Notation.Dot "gen_val" := {|
+  Global Instance Get_gen_val : Notation.Dot "gen_val" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End GenVal.
 Definition GenVal : Set := GenVal.t.
 
@@ -30,9 +30,9 @@ Module ImplVal.
   
   Definition value (self : ref Self) : ref f64 := self.["val"].
   
-  Global Instance Method_value : Notation.Dot "value" := {|
+  Global Instance Method_value : Notation.Dot "value" := {
     Notation.dot := value;
-  |}.
+  }.
 End ImplVal.
 
 Module ImplGenVal.
@@ -40,9 +40,9 @@ Module ImplGenVal.
   
   Definition value (self : ref Self) : ref T := self.["gen_val"].
   
-  Global Instance Method_value : Notation.Dot "value" := {|
+  Global Instance Method_value : Notation.Dot "value" := {
     Notation.dot := value;
-  |}.
+  }.
 End ImplGenVal.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom.v
@@ -6,18 +6,18 @@ Import Root.std.prelude.rust_2015.
 Module Years.
   Inductive t : Set := Build (_ : i64).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Years.
 Definition Years := Years.t.
 
 Module Days.
   Inductive t : Set := Build (_ : i64).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Days.
 Definition Days := Days.t.
 
@@ -27,9 +27,9 @@ Module ImplYears.
   Definition to_days (self : ref Self) : Days :=
     Days.Build ((IndexedField.get (index := 0) self).["mul"] 365).
   
-  Global Instance Method_to_days : Notation.Dot "to_days" := {|
+  Global Instance Method_to_days : Notation.Dot "to_days" := {
     Notation.dot := to_days;
-  |}.
+  }.
 End ImplYears.
 
 Module ImplDays.
@@ -38,9 +38,9 @@ Module ImplDays.
   Definition to_years (self : ref Self) : Years :=
     Years.Build ((IndexedField.get (index := 0) self).["div"] 365).
   
-  Global Instance Method_to_years : Notation.Dot "to_years" := {|
+  Global Instance Method_to_years : Notation.Dot "to_years" := {
     Notation.dot := to_years;
-  |}.
+  }.
 End ImplDays.
 
 Definition old_enough (age : ref Years) : bool :=

--- a/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom.v
@@ -25,7 +25,7 @@ Module ImplYears.
   Definition Self := Years.
   
   Definition to_days (self : ref Self) : Days :=
-    Days.Build (mul (IndexedField.get (index := 0) self) 365).
+    Days.Build ((IndexedField.get (index := 0) self).["mul"] 365).
   
   Global Instance Method_to_days : Notation.Dot "to_days" := {|
     Notation.dot := to_days;
@@ -36,7 +36,7 @@ Module ImplDays.
   Definition Self := Days.
   
   Definition to_years (self : ref Self) : Years :=
-    Years.Build (div (IndexedField.get (index := 0) self) 365).
+    Years.Build ((IndexedField.get (index := 0) self).["div"] 365).
   
   Global Instance Method_to_years : Notation.Dot "to_years" := {|
     Notation.dot := to_years;
@@ -44,7 +44,7 @@ Module ImplDays.
 End ImplDays.
 
 Definition old_enough (age : ref Years) : bool :=
-  ge (IndexedField.get (index := 0) age) 18.
+  (IndexedField.get (index := 0) age).["ge"] 18.
 
 Definition main (_ : unit) : unit :=
   let age := Years.Build 5 in

--- a/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom_as_base_type.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_new_type_idiom_as_base_type.v
@@ -6,9 +6,9 @@ Import Root.std.prelude.rust_2015.
 Module Years.
   Inductive t : Set := Build (_ : i64).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Years.
 Definition Years := Years.t.
 

--- a/coq_translation/examples-from-rust-book/generics/generics_phantom_type.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_phantom_type.v
@@ -29,12 +29,9 @@ Module Impl__crate_cmp_PartialEq_for_PhantomTuple.
   Definition Self := PhantomTuple.
   
   Definition eq (self : ref Self) (other : ref PhantomTuple) : bool :=
-    andb
-      (eqb
-        (IndexedField.get (index := 0) self)
-        (IndexedField.get (index := 0) other))
-      (eqb
-        (IndexedField.get (index := 1) self)
+    ((IndexedField.get (index := 0) self).["eq"]
+        (IndexedField.get (index := 0) other)).["andb"]
+      ((IndexedField.get (index := 1) self).["eq"]
         (IndexedField.get (index := 1) other)).
   
   Global Instance Method_eq : Notation.Dot "eq" := {|
@@ -72,9 +69,8 @@ Module Impl__crate_cmp_PartialEq_for_PhantomStruct.
   Definition Self := PhantomStruct.
   
   Definition eq (self : ref Self) (other : ref PhantomStruct) : bool :=
-    andb
-      (eqb self.["first"] other.["first"])
-      (eqb self.["phantom"] other.["phantom"]).
+    (self.["first"].["eq"] other.["first"]).["andb"]
+      (self.["phantom"].["eq"] other.["phantom"]).
   
   Global Instance Method_eq : Notation.Dot "eq" := {|
     Notation.dot := eq;

--- a/coq_translation/examples-from-rust-book/generics/generics_phantom_type.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_phantom_type.v
@@ -9,12 +9,12 @@ Definition PhantomData := PhantomData.t.
 Module PhantomTuple.
   Inductive t : Set := Build (_ : A) (_ : PhantomData).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End PhantomTuple.
 Definition PhantomTuple := PhantomTuple.t.
 
@@ -34,13 +34,13 @@ Module Impl__crate_cmp_PartialEq_for_PhantomTuple.
       ((IndexedField.get (index := 1) self).["eq"]
         (IndexedField.get (index := 1) other)).
   
-  Global Instance Method_eq : Notation.Dot "eq" := {|
+  Global Instance Method_eq : Notation.Dot "eq" := {
     Notation.dot := eq;
-  |}.
+  }.
   
-  Global Instance I A B : _crate.cmp.PartialEq.Trait Self := {|
+  Global Instance I A B : _crate.cmp.PartialEq.Trait Self := {
     _crate.cmp.PartialEq.eq := eq;
-  |}.
+  }.
 End Impl__crate_cmp_PartialEq_for_PhantomTuple.
 
 Module PhantomStruct.
@@ -49,12 +49,12 @@ Module PhantomStruct.
     phantom : PhantomData;
   }.
   
-  Global Instance Get_first : Notation.Dot "first" := {|
+  Global Instance Get_first : Notation.Dot "first" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_phantom : Notation.Dot "phantom" := {|
+  }.
+  Global Instance Get_phantom : Notation.Dot "phantom" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End PhantomStruct.
 Definition PhantomStruct : Set := PhantomStruct.t.
 
@@ -72,20 +72,22 @@ Module Impl__crate_cmp_PartialEq_for_PhantomStruct.
     (self.["first"].["eq"] other.["first"]).["andb"]
       (self.["phantom"].["eq"] other.["phantom"]).
   
-  Global Instance Method_eq : Notation.Dot "eq" := {|
+  Global Instance Method_eq : Notation.Dot "eq" := {
     Notation.dot := eq;
-  |}.
+  }.
   
-  Global Instance I A B : _crate.cmp.PartialEq.Trait Self := {|
+  Global Instance I A B : _crate.cmp.PartialEq.Trait Self := {
     _crate.cmp.PartialEq.eq := eq;
-  |}.
+  }.
 End Impl__crate_cmp_PartialEq_for_PhantomStruct.
 
 Definition main (_ : unit) : unit :=
-  let _tuple1 := PhantomTuple.Build Q PhantomData in
-  let _tuple2 := PhantomTuple.Build Q PhantomData in
+  let _tuple1 := PhantomTuple.Build Q PhantomData.Build in
+  let _tuple2 := PhantomTuple.Build Q PhantomData.Build in
   let _struct1 :=
-    {| PhantomStruct.first := Q; PhantomStruct.phantom := PhantomData; |} in
+    {| PhantomStruct.first := Q; PhantomStruct.phantom := PhantomData.Build;
+    |} in
   let _struct2 :=
-    {| PhantomStruct.first := Q; PhantomStruct.phantom := PhantomData; |} in
+    {| PhantomStruct.first := Q; PhantomStruct.phantom := PhantomData.Build;
+    |} in
   tt.

--- a/coq_translation/examples-from-rust-book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -23,13 +23,13 @@ Module Impl__crate_fmt_Debug_for_Inch.
       : _crate.fmt.Result :=
     _crate.intrinsics.unreachable tt.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Inch.
 
 Module Impl__crate_clone_Clone_for_Inch.
@@ -37,13 +37,13 @@ Module Impl__crate_clone_Clone_for_Inch.
   
   Definition clone (self : ref Self) : Inch := deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Inch.
 
 Module Impl__crate_marker_Copy_for_Inch.
@@ -68,13 +68,13 @@ Module Impl__crate_fmt_Debug_for_Mm.
       : _crate.fmt.Result :=
     _crate.intrinsics.unreachable tt.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Mm.
 
 Module Impl__crate_clone_Clone_for_Mm.
@@ -82,13 +82,13 @@ Module Impl__crate_clone_Clone_for_Mm.
   
   Definition clone (self : ref Self) : Mm := deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Mm.
 
 Module Impl__crate_marker_Copy_for_Mm.
@@ -101,12 +101,12 @@ End Impl__crate_marker_Copy_for_Mm.
 Module Length.
   Inductive t : Set := Build (_ : f64) (_ : PhantomData).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Length.
 Definition Length := Length.t.
 
@@ -123,13 +123,13 @@ Module Impl__crate_fmt_Debug_for_Length.
       (IndexedField.get (index := 0) self)
       (IndexedField.get (index := 1) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I Unit : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I Unit : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Length.
 
 Module Impl__crate_clone_Clone_for_Length.
@@ -140,13 +140,13 @@ Module Impl__crate_clone_Clone_for_Length.
       (_crate.clone.Clone.clone (IndexedField.get (index := 0) self))
       (_crate.clone.Clone.clone (IndexedField.get (index := 1) self)).
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I Unit : _crate.clone.Clone.Trait Self := {|
+  Global Instance I Unit : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Length.
 
 Module Impl__crate_marker_Copy_for_Length.
@@ -165,21 +165,20 @@ Module Impl_Add_for_Length.
     Length.Build
       ((IndexedField.get (index := 0) self).["add"]
         (IndexedField.get (index := 0) rhs))
-      PhantomData.
+      PhantomData.Build.
   
-  Global Instance Method_add : Notation.Dot "add" := {|
+  Global Instance Method_add : Notation.Dot "add" := {
     Notation.dot := add;
-  |}.
+  }.
   
-  Global Instance I Unit : Add.Trait Self := {|
-    Add.Output := Output;
+  Global Instance I Unit : Add.Trait Self := {
     Add.add := add;
-  |}.
+  }.
 End Impl_Add_for_Length.
 
 Definition main (_ : unit) : unit :=
-  let one_foot := Length.Build 12 (* 12.0 *) PhantomData in
-  let one_meter := Length.Build 1000 (* 1000.0 *) PhantomData in
+  let one_foot := Length.Build 12 (* 12.0 *) PhantomData.Build in
+  let one_meter := Length.Build 1000 (* 1000.0 *) PhantomData.Build in
   let two_feet := one_foot.["add"] one_foot in
   let two_meters := one_meter.["add"] one_meter in
   _crate.io._print

--- a/coq_translation/examples-from-rust-book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -163,8 +163,7 @@ Module Impl_Add_for_Length.
   
   Definition add (self : Self) (rhs : Length) : Length :=
     Length.Build
-      (add
-        (IndexedField.get (index := 0) self)
+      ((IndexedField.get (index := 0) self).["add"]
         (IndexedField.get (index := 0) rhs))
       PhantomData.
   
@@ -181,8 +180,8 @@ End Impl_Add_for_Length.
 Definition main (_ : unit) : unit :=
   let one_foot := Length.Build 12 (* 12.0 *) PhantomData in
   let one_meter := Length.Build 1000 (* 1000.0 *) PhantomData in
-  let two_feet := add one_foot one_foot in
-  let two_meters := add one_meter one_meter in
+  let two_feet := one_foot.["add"] one_foot in
+  let two_meters := one_meter.["add"] one_meter in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "one foot + one_foot = "; " in\n" ]

--- a/coq_translation/examples-from-rust-book/generics/generics_traits.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_traits.v
@@ -3,18 +3,24 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module Empty.
+  Inductive t : Set := Build.
+End Empty.
+Definition Empty := Empty.t.
 
-Error StructUnit.
+Module Null.
+  Inductive t : Set := Build.
+End Null.
+Definition Null := Null.t.
 
 Module DoubleDrop.
   Class Trait (T Self : Set) : Set := {
     double_drop : Self -> (T -> _);
   }.
   
-  Global Instance Method_double_drop `(Trait) : Notation.Dot "double_drop" := {|
+  Global Instance Method_double_drop `(Trait) : Notation.Dot "double_drop" := {
     Notation.dot := double_drop;
-  |}.
+  }.
 End DoubleDrop.
 
 Module Impl_DoubleDrop_for_U.
@@ -22,17 +28,17 @@ Module Impl_DoubleDrop_for_U.
   
   Definition double_drop (self : Self) (Pattern : T) := tt.
   
-  Global Instance Method_double_drop : Notation.Dot "double_drop" := {|
+  Global Instance Method_double_drop : Notation.Dot "double_drop" := {
     Notation.dot := double_drop;
-  |}.
+  }.
   
-  Global Instance I T U : DoubleDrop.Trait T Self := {|
+  Global Instance I T U : DoubleDrop.Trait Self T := {
     DoubleDrop.double_drop := double_drop;
-  |}.
+  }.
 End Impl_DoubleDrop_for_U.
 
 Definition main (_ : unit) : unit :=
-  let empty := Empty in
-  let null := Null in
+  let empty := Empty.Build in
+  let null := Null.Build in
   empty.["double_drop"] null ;;
   tt.

--- a/coq_translation/examples-from-rust-book/generics/generics_where_clauses.v
+++ b/coq_translation/examples-from-rust-book/generics/generics_where_clauses.v
@@ -11,9 +11,9 @@ Module PrintInOption.
   }.
   
   Global Instance Method_print_in_option `(Trait)
-    : Notation.Dot "print_in_option" := {|
+    : Notation.Dot "print_in_option" := {
     Notation.dot := print_in_option;
-  |}.
+  }.
 End PrintInOption.
 
 Module Impl_PrintInOption_for_T.
@@ -27,13 +27,13 @@ Module Impl_PrintInOption_for_T.
     tt ;;
     tt.
   
-  Global Instance Method_print_in_option : Notation.Dot "print_in_option" := {|
+  Global Instance Method_print_in_option : Notation.Dot "print_in_option" := {
     Notation.dot := print_in_option;
-  |}.
+  }.
   
-  Global Instance I T : PrintInOption.Trait Self := {|
+  Global Instance I T : PrintInOption.Trait Self := {
     PrintInOption.print_in_option := print_in_option;
-  |}.
+  }.
 End Impl_PrintInOption_for_T.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/hello_world/formatted_print.v
+++ b/coq_translation/examples-from-rust-book/hello_world/formatted_print.v
@@ -241,8 +241,8 @@ Definition main (_ : unit) : unit :=
 Module Structure.
   Inductive t : Set := Build (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Structure.
 Definition Structure := Structure.t.

--- a/coq_translation/examples-from-rust-book/macro_rules/macro_rules_designators.v
+++ b/coq_translation/examples-from-rust-book/macro_rules/macro_rules_designators.v
@@ -27,7 +27,7 @@ Definition main (_ : unit) : unit :=
       [ ""; " = "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_debug"] "1u32 + 1";
-        _crate.fmt.ArgumentV1::["new_debug"] (add 1 1)
+        _crate.fmt.ArgumentV1::["new_debug"] (1.["add"] 1)
       ]) ;;
   tt ;;
   _crate.io._print
@@ -38,7 +38,7 @@ Definition main (_ : unit) : unit :=
           "{ let x = 1u32; x * x + 2 * x - 1 }";
         _crate.fmt.ArgumentV1::["new_debug"]
           let x := 1 in
-          sub (add (mul x x) (mul 2 x)) 1
+          ((x.["mul"] x).["add"] (2.["mul"] x)).["sub"] 1
       ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/macro_rules/macro_rules_dsl.v
+++ b/coq_translation/examples-from-rust-book/macro_rules/macro_rules_dsl.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition main (_ : unit) : unit :=
-  let val := add 1 2 in
+  let val := 1.["add"] 2 in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " = "; "\n" ]
@@ -14,7 +14,7 @@ Definition main (_ : unit) : unit :=
       ]) ;;
   tt ;;
   tt ;;
-  let val := mul (add 1 2) (div 3 4) in
+  let val := (1.["add"] 2).["mul"] (3.["div"] 4) in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " = "; "\n" ]

--- a/coq_translation/examples-from-rust-book/macro_rules/macro_rules_overload.v
+++ b/coq_translation/examples-from-rust-book/macro_rules/macro_rules_overload.v
@@ -10,7 +10,7 @@ Definition main (_ : unit) : unit :=
       match
         ("1i32 + 1 == 2i32",
           "2i32 * 2 == 4i32",
-          andb (eqb (add 1 1) 2) (eqb (mul 2 2) 4))
+          ((1.["add"] 1).["eq"] 2).["andb"] ((2.["mul"] 2).["eq"] 4))
       with
       | args =>
         [
@@ -26,7 +26,7 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " or "; " is "; "\n" ]
-      match ("true", "false", or true false) with
+      match ("true", "false", true.["or"] false) with
       | args =>
         [
           _crate.fmt.ArgumentV1::["new_debug"]

--- a/coq_translation/examples-from-rust-book/macro_rules/macro_rules_repeat.v
+++ b/coq_translation/examples-from-rust-book/macro_rules/macro_rules_repeat.v
@@ -12,14 +12,15 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (std.cmp.min (add 1 2) 2) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (std.cmp.min (1.["add"] 2) 2)
+      ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (std.cmp.min 5 (std.cmp.min (mul 2 3) 4))
+          (std.cmp.min 5 (std.cmp.min (2.["mul"] 3) 4))
       ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/macro_rules/macro_rules_variadic_interfaces.v
+++ b/coq_translation/examples-from-rust-book/macro_rules/macro_rules_variadic_interfaces.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition main (_ : unit) : unit :=
-  let val := add 1 2 in
+  let val := 1.["add"] 2 in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " = "; "\n" ]
@@ -14,7 +14,7 @@ Definition main (_ : unit) : unit :=
       ]) ;;
   tt ;;
   tt ;;
-  let val := add 3 4 in
+  let val := 3.["add"] 4 in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " = "; "\n" ]
@@ -24,7 +24,7 @@ Definition main (_ : unit) : unit :=
       ]) ;;
   tt ;;
   tt ;;
-  let val := add (mul 2 3) 1 in
+  let val := (2.["mul"] 3).["add"] 1 in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; " = "; "\n" ]

--- a/coq_translation/examples-from-rust-book/modules/struct_visibility.v
+++ b/coq_translation/examples-from-rust-book/modules/struct_visibility.v
@@ -9,9 +9,9 @@ Module my.
       contents : T;
     }.
     
-    Global Instance Get_contents : Notation.Dot "contents" := {|
+    Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
-    |}.
+    }.
   End OpenBox.
   Definition OpenBox : Set := OpenBox.t.
   
@@ -20,9 +20,9 @@ Module my.
       contents : T;
     }.
     
-    Global Instance Get_contents : Notation.Dot "contents" := {|
+    Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
-    |}.
+    }.
   End ClosedBox.
   Definition ClosedBox : Set := ClosedBox.t.
   
@@ -33,9 +33,9 @@ Module my.
       {| ClosedBox.contents := contents; |}.
     
     Global Instance AssociatedFunction_new :
-      Notation.DoubleColon Self "new" := {|
+      Notation.DoubleColon Self "new" := {
       Notation.double_colon := new;
-    |}.
+    }.
   End ImplClosedBox.
 End my.
 
@@ -44,9 +44,9 @@ Module OpenBox.
     contents : T;
   }.
   
-  Global Instance Get_contents : Notation.Dot "contents" := {|
+  Global Instance Get_contents : Notation.Dot "contents" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End OpenBox.
 Definition OpenBox : Set := OpenBox.t.
 
@@ -55,9 +55,9 @@ Module ClosedBox.
     contents : T;
   }.
   
-  Global Instance Get_contents : Notation.Dot "contents" := {|
+  Global Instance Get_contents : Notation.Dot "contents" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End ClosedBox.
 Definition ClosedBox : Set := ClosedBox.t.
 
@@ -67,9 +67,9 @@ Module ImplClosedBox_2.
   Definition new (contents : T) : ClosedBox :=
     {| ClosedBox.contents := contents; |}.
   
-  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {|
+  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {
     Notation.double_colon := new;
-  |}.
+  }.
 End ImplClosedBox_2.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/primitives/arrays_and_slices.v
+++ b/coq_translation/examples-from-rust-book/primitives/arrays_and_slices.v
@@ -56,7 +56,7 @@ Definition main (_ : unit) : unit :=
   let empty_array := [  ] in
   match (empty_array, [  ]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -69,7 +69,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (empty_array, [  ][{|  |}]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -80,7 +80,7 @@ Definition main (_ : unit) : unit :=
     else
       tt
   end ;;
-  match LangItem {| Range.start := 0; Range.end := add xs.["len"] 1; |} with
+  match LangItem {| Range.start := 0; Range.end := xs.["len"].["add"] 1; |} with
   | iter =>
     loop
       match LangItem iter with

--- a/coq_translation/examples-from-rust-book/primitives/literals_operators.v
+++ b/coq_translation/examples-from-rust-book/primitives/literals_operators.v
@@ -7,22 +7,22 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "1 + 2 = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (add 1 2) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (1.["add"] 2) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "1 - 2 = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (sub 1 2) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (1.["sub"] 2) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "true AND false is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (andb true false) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (true.["andb"] false) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "true OR false is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (or true false) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (true.["or"] false) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
@@ -32,7 +32,7 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1_formatted"]
       [ "0011 AND 0101 is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_binary"] (bit_and 3 5) ]
+      [ _crate.fmt.ArgumentV1::["new_binary"] (3.["bitand"] 5) ]
       [
         {|
           _crate.fmt.rt.v1.Argument.position := 0;
@@ -53,7 +53,7 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1_formatted"]
       [ "0011 OR 0101 is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_binary"] (bit_or 3 5) ]
+      [ _crate.fmt.ArgumentV1::["new_binary"] (3.["bitor"] 5) ]
       [
         {|
           _crate.fmt.rt.v1.Argument.position := 0;
@@ -74,7 +74,7 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1_formatted"]
       [ "0011 XOR 0101 is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_binary"] (bit_xor 3 5) ]
+      [ _crate.fmt.ArgumentV1::["new_binary"] (3.["bitxor"] 5) ]
       [
         {|
           _crate.fmt.rt.v1.Argument.position := 0;
@@ -95,12 +95,12 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "1 << 5 is "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (shl 1 5) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (1.["shl"] 5) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "0x80 >> 2 is 0x"; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_lower_hex"] (shr 128 2) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_lower_hex"] (128.["shr"] 2) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/primitives/tuples.v
+++ b/coq_translation/examples-from-rust-book/primitives/tuples.v
@@ -10,18 +10,18 @@ Definition reverse (pair : i32 * bool) : bool * i32 :=
 Module Matrix.
   Inductive t : Set := Build (_ : f32) (_ : f32) (_ : f32) (_ : f32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _ _ _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1 _ _) := x1;
-  |}.
-  Global Instance Get_2 : IndexedField.Class t 2 _ := {|
+  }.
+  Global Instance Get_2 : IndexedField.Class t 2 _ := {
     IndexedField.get '(Build _ _ x2 _) := x2;
-  |}.
-  Global Instance Get_3 : IndexedField.Class t 3 _ := {|
+  }.
+  Global Instance Get_3 : IndexedField.Class t 3 _ := {
     IndexedField.get '(Build _ _ _ x3) := x3;
-  |}.
+  }.
 End Matrix.
 Definition Matrix := Matrix.t.
 
@@ -40,13 +40,13 @@ Module Impl__crate_fmt_Debug_for_Matrix.
       (IndexedField.get (index := 2) self)
       (IndexedField.get (index := 3) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Matrix.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_aliasing.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_aliasing.v
@@ -10,15 +10,15 @@ Module Point.
     z : i32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _ _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1 _) := x1;
-  |}.
-  Global Instance Get_z : Notation.Dot "z" := {|
+  }.
+  Global Instance Get_z : Notation.Dot "z" := {
     Notation.dot '(Build_t _ _ x2) := x2;
-  |}.
+  }.
 End Point.
 Definition Point : Set := Point.t.
 

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_mutablity.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_mutablity.v
@@ -10,15 +10,15 @@ Module Book.
     year : u32;
   }.
   
-  Global Instance Get_author : Notation.Dot "author" := {|
+  Global Instance Get_author : Notation.Dot "author" := {
     Notation.dot '(Build_t x0 _ _) := x0;
-  |}.
-  Global Instance Get_title : Notation.Dot "title" := {|
+  }.
+  Global Instance Get_title : Notation.Dot "title" := {
     Notation.dot '(Build_t _ x1 _) := x1;
-  |}.
-  Global Instance Get_year : Notation.Dot "year" := {|
+  }.
+  Global Instance Get_year : Notation.Dot "year" := {
     Notation.dot '(Build_t _ _ x2) := x2;
-  |}.
+  }.
 End Book.
 Definition Book : Set := Book.t.
 
@@ -31,13 +31,13 @@ Module Impl__crate_clone_Clone_for_Book.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Book.
 
 Module Impl__crate_marker_Copy_for_Book.

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
@@ -9,12 +9,12 @@ Module Point.
     y : i32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Point.
 Definition Point : Set := Point.t.
 
@@ -25,13 +25,13 @@ Module Impl__crate_clone_Clone_for_Point.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Point.
 
 Module Impl__crate_marker_Copy_for_Point.

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
@@ -50,7 +50,7 @@ Definition main (_ : unit) : unit :=
       [ "ref_c1 equals ref_c2: "; "\n" ]
       [
         _crate.fmt.ArgumentV1::["new_display"]
-          (eqb (deref ref_c1) (deref ref_c2))
+          ((deref ref_c1).["eq"] (deref ref_c2))
       ]) ;;
   tt ;;
   let point := {| Point.x := 0; Point.y := 0; |} in

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -8,9 +8,9 @@ Module Debug := std.fmt.Debug.
 Module Ref.
   Inductive t : Set := Build (_ : ref T).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Ref.
 Definition Ref := Ref.t.
 
@@ -26,13 +26,13 @@ Module Impl__crate_fmt_Debug_for_Ref.
       "Ref"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I 'a T : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I T : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Ref.
 
 Definition print {T : Set} `{Debug.Trait T} (t : T) : unit :=

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_coercion.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_coercion.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition multiply (first : ref i32) (second : ref i32) : i32 :=
-  mul first second.
+  first.["mul"] second.
 
 Definition choose_first (first : ref i32) (arg : ref i32) : ref i32 := first.
 

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_methods.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_methods.v
@@ -6,9 +6,9 @@ Import Root.std.prelude.rust_2015.
 Module Owner.
   Inductive t : Set := Build (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Owner.
 Definition Owner := Owner.t.
 
@@ -21,9 +21,9 @@ Module ImplOwner.
       (add (IndexedField.get (index := 0) self) 1) ;;
     tt.
   
-  Global Instance Method_add_one : Notation.Dot "add_one" := {|
+  Global Instance Method_add_one : Notation.Dot "add_one" := {
     Notation.dot := add_one;
-  |}.
+  }.
   
   Definition print (self : ref Self) :=
     _crate.io._print
@@ -36,9 +36,9 @@ Module ImplOwner.
     tt ;;
     tt.
   
-  Global Instance Method_print : Notation.Dot "print" := {|
+  Global Instance Method_print : Notation.Dot "print" := {
     Notation.dot := print;
-  |}.
+  }.
 End ImplOwner.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_structs.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_structs.v
@@ -6,9 +6,9 @@ Import Root.std.prelude.rust_2015.
 Module Borrowed.
   Inductive t : Set := Build (_ : ref i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Borrowed.
 Definition Borrowed := Borrowed.t.
 
@@ -24,13 +24,13 @@ Module Impl__crate_fmt_Debug_for_Borrowed.
       "Borrowed"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Borrowed.
 
 Module NamedBorrowed.
@@ -39,12 +39,12 @@ Module NamedBorrowed.
     y : ref i32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End NamedBorrowed.
 Definition NamedBorrowed : Set := NamedBorrowed.t.
 
@@ -63,13 +63,13 @@ Module Impl__crate_fmt_Debug_for_NamedBorrowed.
       "y"
       self.["y"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_NamedBorrowed.
 
 Module Either.
@@ -93,13 +93,13 @@ Module Impl__crate_fmt_Debug_for_Either.
       _crate.fmt.Formatter::["debug_tuple_field1_finish"] f "Ref" __self_0
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Either.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_traits.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_lifetimes_traits.v
@@ -8,9 +8,9 @@ Module Borrowed.
     x : ref i32;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Borrowed.
 Definition Borrowed : Set := Borrowed.t.
 
@@ -27,13 +27,13 @@ Module Impl__crate_fmt_Debug_for_Borrowed.
       "x"
       self.["x"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Borrowed.
 
 Module Impl_Default_for_Borrowed.
@@ -42,13 +42,13 @@ Module Impl_Default_for_Borrowed.
   Definition default (_ : unit) : Self := {| Self.x := 10; |}.
   
   Global Instance AssociatedFunction_default :
-    Notation.DoubleColon Self "default" := {|
+    Notation.DoubleColon Self "default" := {
     Notation.double_colon := default;
-  |}.
+  }.
   
-  Global Instance I 'a : Default.Trait Self := {|
+  Global Instance I : Default.Trait Self := {
     Default.default := default;
-  |}.
+  }.
 End Impl_Default_for_Borrowed.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
@@ -11,12 +11,12 @@ Module Person.
     age : Box;
   }.
   
-  Global Instance Get_name : Notation.Dot "name" := {|
+  Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_age : Notation.Dot "age" := {|
+  }.
+  Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Person.
 Definition Person : Set := Person.t.
 
@@ -35,11 +35,11 @@ Module Impl__crate_fmt_Debug_for_Person.
       "age"
       self.["age"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Person.

--- a/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_raii_desctructor.v
+++ b/coq_translation/examples-from-rust-book/scoping_rules/scoping_rules_raii_desctructor.v
@@ -3,7 +3,10 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module ToDrop.
+  Inductive t : Set := Build.
+End ToDrop.
+Definition ToDrop := ToDrop.t.
 
 Module Impl_Drop_for_ToDrop.
   Definition Self := ToDrop.
@@ -14,17 +17,17 @@ Module Impl_Drop_for_ToDrop.
     tt ;;
     tt.
   
-  Global Instance Method_drop : Notation.Dot "drop" := {|
+  Global Instance Method_drop : Notation.Dot "drop" := {
     Notation.dot := drop;
-  |}.
+  }.
   
-  Global Instance I : Drop.Trait Self := {|
+  Global Instance I : Drop.Trait Self := {
     Drop.drop := drop;
-  |}.
+  }.
 End Impl_Drop_for_ToDrop.
 
 Definition main (_ : unit) : unit :=
-  let x := ToDrop in
+  let x := ToDrop.Build in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"] [ "Made a ToDrop!\n" ] [  ]) ;;
   tt ;;

--- a/coq_translation/examples-from-rust-book/std_library_types/box_stack_heap.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/box_stack_heap.v
@@ -11,12 +11,12 @@ Module Point.
     y : f64;
   }.
   
-  Global Instance Get_x : Notation.Dot "x" := {|
+  Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_y : Notation.Dot "y" := {|
+  }.
+  Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Point.
 Definition Point : Set := Point.t.
 
@@ -35,13 +35,13 @@ Module Impl__crate_fmt_Debug_for_Point.
       "y"
       self.["y"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Point.
 
 Module Impl__crate_clone_Clone_for_Point.
@@ -51,13 +51,13 @@ Module Impl__crate_clone_Clone_for_Point.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Point.
 
 Module Impl__crate_marker_Copy_for_Point.
@@ -73,12 +73,12 @@ Module Rectangle.
     bottom_right : Point;
   }.
   
-  Global Instance Get_top_left : Notation.Dot "top_left" := {|
+  Global Instance Get_top_left : Notation.Dot "top_left" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {|
+  }.
+  Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.
 

--- a/coq_translation/examples-from-rust-book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -32,9 +32,8 @@ Module Impl__crate_cmp_PartialEq_for_Account.
   Definition Self := Account.
   
   Definition eq (self : ref Self) (other : ref Account) : bool :=
-    andb
-      (eqb self.["username"] other.["username"])
-      (eqb self.["password"] other.["password"]).
+    (self.["username"].["eq"] other.["username"]).["andb"]
+      (self.["password"].["eq"] other.["password"]).
   
   Global Instance Method_eq : Notation.Dot "eq" := {|
     Notation.dot := eq;

--- a/coq_translation/examples-from-rust-book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -12,19 +12,19 @@ Module Account.
     password : ref str;
   }.
   
-  Global Instance Get_username : Notation.Dot "username" := {|
+  Global Instance Get_username : Notation.Dot "username" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_password : Notation.Dot "password" := {|
+  }.
+  Global Instance Get_password : Notation.Dot "password" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Account.
 Definition Account : Set := Account.t.
 
 Module Impl__crate_marker_StructuralPartialEq_for_Account.
   Definition Self := Account.
   
-  Global Instance I 'a : _crate.marker.StructuralPartialEq.Trait Self :=
+  Global Instance I : _crate.marker.StructuralPartialEq.Trait Self :=
     _crate.marker.StructuralPartialEq.Build_Class _.
 End Impl__crate_marker_StructuralPartialEq_for_Account.
 
@@ -35,19 +35,19 @@ Module Impl__crate_cmp_PartialEq_for_Account.
     (self.["username"].["eq"] other.["username"]).["andb"]
       (self.["password"].["eq"] other.["password"]).
   
-  Global Instance Method_eq : Notation.Dot "eq" := {|
+  Global Instance Method_eq : Notation.Dot "eq" := {
     Notation.dot := eq;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.cmp.PartialEq.Trait Self := {|
+  Global Instance I : _crate.cmp.PartialEq.Trait Self := {
     _crate.cmp.PartialEq.eq := eq;
-  |}.
+  }.
 End Impl__crate_cmp_PartialEq_for_Account.
 
 Module Impl__crate_marker_StructuralEq_for_Account.
   Definition Self := Account.
   
-  Global Instance I 'a : _crate.marker.StructuralEq.Trait Self :=
+  Global Instance I : _crate.marker.StructuralEq.Trait Self :=
     _crate.marker.StructuralEq.Build_Class _.
 End Impl__crate_marker_StructuralEq_for_Account.
 
@@ -60,12 +60,12 @@ Module Impl__crate_cmp_Eq_for_Account.
     tt.
   
   Global Instance Method_assert_receiver_is_total_eq :
-    Notation.Dot "assert_receiver_is_total_eq" := {|
+    Notation.Dot "assert_receiver_is_total_eq" := {
     Notation.dot := assert_receiver_is_total_eq;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.cmp.Eq.Trait Self := {|
-  |}.
+  Global Instance I : _crate.cmp.Eq.Trait Self := {
+  }.
 End Impl__crate_cmp_Eq_for_Account.
 
 Module Impl__crate_hash_Hash_for_Account.
@@ -75,13 +75,13 @@ Module Impl__crate_hash_Hash_for_Account.
     _crate.hash.Hash.hash self.["username"] state ;;
     _crate.hash.Hash.hash self.["password"] state.
   
-  Global Instance Method_hash : Notation.Dot "hash" := {|
+  Global Instance Method_hash : Notation.Dot "hash" := {
     Notation.dot := hash;
-  |}.
+  }.
   
-  Global Instance I 'a : _crate.hash.Hash.Trait Self := {|
+  Global Instance I : _crate.hash.Hash.Trait Self := {
     _crate.hash.Hash.hash := hash;
-  |}.
+  }.
 End Impl__crate_hash_Hash_for_Account.
 
 Module AccountInfo.
@@ -90,12 +90,12 @@ Module AccountInfo.
     email : ref str;
   }.
   
-  Global Instance Get_name : Notation.Dot "name" := {|
+  Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_email : Notation.Dot "email" := {|
+  }.
+  Global Instance Get_email : Notation.Dot "email" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End AccountInfo.
 Definition AccountInfo : Set := AccountInfo.t.
 

--- a/coq_translation/examples-from-rust-book/std_library_types/option.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/option.v
@@ -4,10 +4,10 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition checked_division (dividend : i32) (divisor : i32) : Option :=
-  if (eqb divisor 0 : bool) then
+  if (divisor.["eq"] 0 : bool) then
     None
   else
-    Some (div dividend divisor).
+    Some (dividend.["div"] divisor).
 
 Definition try_division (dividend : i32) (divisor : i32) : unit :=
   match checked_division dividend divisor with

--- a/coq_translation/examples-from-rust-book/std_library_types/panic.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/panic.v
@@ -4,11 +4,11 @@ Require Import CoqOfRust.CoqOfRust.
 Import Root.std.prelude.rust_2015.
 
 Definition division (dividend : i32) (divisor : i32) : i32 :=
-  if (eqb divisor 0 : bool) then
+  if (divisor.["eq"] 0 : bool) then
     _crate.rt.begin_panic "division by zero" ;;
     tt
   else
-    div dividend divisor.
+    dividend.["div"] divisor.
 
 Definition main (_ : unit) : unit :=
   let _x := Box::["new"] 0 in

--- a/coq_translation/examples-from-rust-book/std_library_types/result.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/result.v
@@ -40,19 +40,19 @@ Module checked.
   Definition MathResult : Set := Result.
   
   Definition div (x : f64) (y : f64) : MathResult :=
-    if (eqb y 0 (* 0.0 *) : bool) then
+    if (y.["eq"] 0 (* 0.0 *) : bool) then
       Err MathError.DivisionByZero
     else
-      Ok (div x y).
+      Ok (x.["div"] y).
   
   Definition sqrt (x : f64) : MathResult :=
-    if (lt x 0 (* 0.0 *) : bool) then
+    if (x.["lt"] 0 (* 0.0 *) : bool) then
       Err MathError.NegativeSquareRoot
     else
       Ok x.["sqrt"].
   
   Definition ln (x : f64) : MathResult :=
-    if (le x 0 (* 0.0 *) : bool) then
+    if (x.["le"] 0 (* 0.0 *) : bool) then
       Err MathError.NonPositiveLogarithm
     else
       Ok x.["ln"].
@@ -94,19 +94,19 @@ End Impl__crate_fmt_Debug_for_MathError.
 Definition MathResult : Set := Result.
 
 Definition div (x : f64) (y : f64) : MathResult :=
-  if (eqb y 0 (* 0.0 *) : bool) then
+  if (y.["eq"] 0 (* 0.0 *) : bool) then
     Err MathError.DivisionByZero
   else
-    Ok (div x y).
+    Ok (x.["div"] y).
 
 Definition sqrt (x : f64) : MathResult :=
-  if (lt x 0 (* 0.0 *) : bool) then
+  if (x.["lt"] 0 (* 0.0 *) : bool) then
     Err MathError.NegativeSquareRoot
   else
     Ok x.["sqrt"].
 
 Definition ln (x : f64) : MathResult :=
-  if (le x 0 (* 0.0 *) : bool) then
+  if (x.["le"] 0 (* 0.0 *) : bool) then
     Err MathError.NonPositiveLogarithm
   else
     Ok x.["ln"].

--- a/coq_translation/examples-from-rust-book/std_library_types/result.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/result.v
@@ -28,13 +28,13 @@ Module checked.
         _crate.fmt.Formatter::["write_str"] f "NegativeSquareRoot"
       end.
     
-    Global Instance Method_fmt : Notation.Dot "fmt" := {|
+    Global Instance Method_fmt : Notation.Dot "fmt" := {
       Notation.dot := fmt;
-    |}.
+    }.
     
-    Global Instance I : _crate.fmt.Debug.Trait Self := {|
+    Global Instance I : _crate.fmt.Debug.Trait Self := {
       _crate.fmt.Debug.fmt := fmt;
-    |}.
+    }.
   End Impl__crate_fmt_Debug_for_MathError.
   
   Definition MathResult : Set := Result.
@@ -82,13 +82,13 @@ Module Impl__crate_fmt_Debug_for_MathError.
       _crate.fmt.Formatter::["write_str"] f "NegativeSquareRoot"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_MathError.
 
 Definition MathResult : Set := Result.

--- a/coq_translation/examples-from-rust-book/std_library_types/result_chaining_with_question_mark.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/result_chaining_with_question_mark.v
@@ -40,19 +40,19 @@ Module checked.
   Definition MathResult : Set := Result.
   
   Definition div (x : f64) (y : f64) : MathResult :=
-    if (eqb y 0 (* 0.0 *) : bool) then
+    if (y.["eq"] 0 (* 0.0 *) : bool) then
       Err MathError.DivisionByZero
     else
-      Ok (div x y).
+      Ok (x.["div"] y).
   
   Definition sqrt (x : f64) : MathResult :=
-    if (lt x 0 (* 0.0 *) : bool) then
+    if (x.["lt"] 0 (* 0.0 *) : bool) then
       Err MathError.NegativeSquareRoot
     else
       Ok x.["sqrt"].
   
   Definition ln (x : f64) : MathResult :=
-    if (le x 0 (* 0.0 *) : bool) then
+    if (x.["le"] 0 (* 0.0 *) : bool) then
       Err MathError.NonPositiveLogarithm
     else
       Ok x.["ln"].
@@ -124,19 +124,19 @@ End Impl__crate_fmt_Debug_for_MathError.
 Definition MathResult : Set := Result.
 
 Definition div (x : f64) (y : f64) : MathResult :=
-  if (eqb y 0 (* 0.0 *) : bool) then
+  if (y.["eq"] 0 (* 0.0 *) : bool) then
     Err MathError.DivisionByZero
   else
-    Ok (div x y).
+    Ok (x.["div"] y).
 
 Definition sqrt (x : f64) : MathResult :=
-  if (lt x 0 (* 0.0 *) : bool) then
+  if (x.["lt"] 0 (* 0.0 *) : bool) then
     Err MathError.NegativeSquareRoot
   else
     Ok x.["sqrt"].
 
 Definition ln (x : f64) : MathResult :=
-  if (le x 0 (* 0.0 *) : bool) then
+  if (x.["le"] 0 (* 0.0 *) : bool) then
     Err MathError.NonPositiveLogarithm
   else
     Ok x.["ln"].

--- a/coq_translation/examples-from-rust-book/std_library_types/result_chaining_with_question_mark.v
+++ b/coq_translation/examples-from-rust-book/std_library_types/result_chaining_with_question_mark.v
@@ -28,13 +28,13 @@ Module checked.
         _crate.fmt.Formatter::["write_str"] f "NegativeSquareRoot"
       end.
     
-    Global Instance Method_fmt : Notation.Dot "fmt" := {|
+    Global Instance Method_fmt : Notation.Dot "fmt" := {
       Notation.dot := fmt;
-    |}.
+    }.
     
-    Global Instance I : _crate.fmt.Debug.Trait Self := {|
+    Global Instance I : _crate.fmt.Debug.Trait Self := {
       _crate.fmt.Debug.fmt := fmt;
-    |}.
+    }.
   End Impl__crate_fmt_Debug_for_MathError.
   
   Definition MathResult : Set := Result.
@@ -112,13 +112,13 @@ Module Impl__crate_fmt_Debug_for_MathError.
       _crate.fmt.Formatter::["write_str"] f "NegativeSquareRoot"
     end.
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_MathError.
 
 Definition MathResult : Set := Result.

--- a/coq_translation/examples-from-rust-book/std_misc/foreign_function_interface.v
+++ b/coq_translation/examples-from-rust-book/std_misc/foreign_function_interface.v
@@ -36,12 +36,12 @@ Module Complex.
     im : f32;
   }.
   
-  Global Instance Get_re : Notation.Dot "re" := {|
+  Global Instance Get_re : Notation.Dot "re" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_im : Notation.Dot "im" := {|
+  }.
+  Global Instance Get_im : Notation.Dot "im" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Complex.
 Definition Complex : Set := Complex.t.
 
@@ -52,13 +52,13 @@ Module Impl__crate_clone_Clone_for_Complex.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Complex.
 
 Module Impl__crate_marker_Copy_for_Complex.
@@ -89,11 +89,11 @@ Module Impl_fmt_Debug_for_Complex.
             _crate.fmt.ArgumentV1::["new_display"] self.["im"]
           ]).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : fmt.Debug.Trait Self := {|
+  Global Instance I : fmt.Debug.Trait Self := {
     fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl_fmt_Debug_for_Complex.

--- a/coq_translation/examples-from-rust-book/std_misc/foreign_function_interface.v
+++ b/coq_translation/examples-from-rust-book/std_misc/foreign_function_interface.v
@@ -72,7 +72,7 @@ Module Impl_fmt_Debug_for_Complex.
   Definition Self := Complex.
   
   Definition fmt (self : ref Self) (f : mut_ref fmt.Formatter) : fmt.Result :=
-    if (lt self.["im"] 0 (* 0. *) : bool) then
+    if (self.["im"].["lt"] 0 (* 0. *) : bool) then
       f.["write_fmt"]
         (_crate.fmt.Arguments::["new_v1"]
           [ ""; "-"; "i" ]

--- a/coq_translation/examples-from-rust-book/std_misc/program_arguments.v
+++ b/coq_translation/examples-from-rust-book/std_misc/program_arguments.v
@@ -16,7 +16,7 @@ Definition main (_ : unit) : unit :=
     (_crate.fmt.Arguments::["new_v1"]
       [ "I got "; " arguments: "; ".\n" ]
       [
-        _crate.fmt.ArgumentV1::["new_debug"] (sub args.["len"] 1);
+        _crate.fmt.ArgumentV1::["new_debug"] (args.["len"].["sub"] 1);
         _crate.fmt.ArgumentV1::["new_debug"] args[{| RangeFrom.start := 1; |}]
       ]) ;;
   tt ;;

--- a/coq_translation/examples-from-rust-book/std_misc/program_arguments_parsing.v
+++ b/coq_translation/examples-from-rust-book/std_misc/program_arguments_parsing.v
@@ -9,7 +9,7 @@ Definition increase (number : i32) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (add number 1) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (number.["add"] 1) ]) ;;
   tt ;;
   tt.
 
@@ -17,7 +17,7 @@ Definition decrease (number : i32) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ ""; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (sub number 1) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (number.["sub"] 1) ]) ;;
   tt ;;
   tt.
 

--- a/coq_translation/examples-from-rust-book/subtle.v
+++ b/coq_translation/examples-from-rust-book/subtle.v
@@ -25,9 +25,9 @@ Definition Option := Option.t.
 Module Choice.
   Inductive t : Set := Build (_ : u8).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Choice.
 Definition Choice := Choice.t.
 
@@ -45,13 +45,13 @@ Module Impl__crate_clone_Clone_for_Choice.
     let _ := tt in
     deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Choice.
 
 Module Impl__crate_fmt_Debug_for_Choice.
@@ -66,13 +66,13 @@ Module Impl__crate_fmt_Debug_for_Choice.
       "Choice"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Choice.
 
 Module ImplChoice.
@@ -81,9 +81,9 @@ Module ImplChoice.
   Definition unwrap_u8 (self : ref Self) : u8 :=
     IndexedField.get (index := 0) self.
   
-  Global Instance Method_unwrap_u8 : Notation.Dot "unwrap_u8" := {|
+  Global Instance Method_unwrap_u8 : Notation.Dot "unwrap_u8" := {
     Notation.dot := unwrap_u8;
-  |}.
+  }.
 End ImplChoice.
 
 Module Impl_From_for_bool.
@@ -107,13 +107,13 @@ Module Impl_From_for_bool.
     (IndexedField.get (index := 0) source).["ne"] 0.
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I : From.Trait Choice Self := {|
+  Global Instance I : From.Trait Self Choice := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_bool.
 
 Module Impl_BitAnd_for_Choice.
@@ -125,14 +125,13 @@ Module Impl_BitAnd_for_Choice.
     ((IndexedField.get (index := 0) self).["bitand"]
         (IndexedField.get (index := 0) rhs)).["into"].
   
-  Global Instance Method_bitand : Notation.Dot "bitand" := {|
+  Global Instance Method_bitand : Notation.Dot "bitand" := {
     Notation.dot := bitand;
-  |}.
+  }.
   
-  Global Instance I : BitAnd.Trait Self := {|
-    BitAnd.Output := Output;
+  Global Instance I : BitAnd.Trait Self := {
     BitAnd.bitand := bitand;
-  |}.
+  }.
 End Impl_BitAnd_for_Choice.
 
 Module Impl_BitAndAssign_for_Choice.
@@ -142,13 +141,13 @@ Module Impl_BitAndAssign_for_Choice.
     assign (deref self) ((deref self).["bitand"] rhs) ;;
     tt.
   
-  Global Instance Method_bitand_assign : Notation.Dot "bitand_assign" := {|
+  Global Instance Method_bitand_assign : Notation.Dot "bitand_assign" := {
     Notation.dot := bitand_assign;
-  |}.
+  }.
   
-  Global Instance I : BitAndAssign.Trait Self := {|
+  Global Instance I : BitAndAssign.Trait Self := {
     BitAndAssign.bitand_assign := bitand_assign;
-  |}.
+  }.
 End Impl_BitAndAssign_for_Choice.
 
 Module Impl_BitOr_for_Choice.
@@ -160,14 +159,13 @@ Module Impl_BitOr_for_Choice.
     ((IndexedField.get (index := 0) self).["bitor"]
         (IndexedField.get (index := 0) rhs)).["into"].
   
-  Global Instance Method_bitor : Notation.Dot "bitor" := {|
+  Global Instance Method_bitor : Notation.Dot "bitor" := {
     Notation.dot := bitor;
-  |}.
+  }.
   
-  Global Instance I : BitOr.Trait Self := {|
-    BitOr.Output := Output;
+  Global Instance I : BitOr.Trait Self := {
     BitOr.bitor := bitor;
-  |}.
+  }.
 End Impl_BitOr_for_Choice.
 
 Module Impl_BitOrAssign_for_Choice.
@@ -177,13 +175,13 @@ Module Impl_BitOrAssign_for_Choice.
     assign (deref self) ((deref self).["bitor"] rhs) ;;
     tt.
   
-  Global Instance Method_bitor_assign : Notation.Dot "bitor_assign" := {|
+  Global Instance Method_bitor_assign : Notation.Dot "bitor_assign" := {
     Notation.dot := bitor_assign;
-  |}.
+  }.
   
-  Global Instance I : BitOrAssign.Trait Self := {|
+  Global Instance I : BitOrAssign.Trait Self := {
     BitOrAssign.bitor_assign := bitor_assign;
-  |}.
+  }.
 End Impl_BitOrAssign_for_Choice.
 
 Module Impl_BitXor_for_Choice.
@@ -195,14 +193,13 @@ Module Impl_BitXor_for_Choice.
     ((IndexedField.get (index := 0) self).["bitxor"]
         (IndexedField.get (index := 0) rhs)).["into"].
   
-  Global Instance Method_bitxor : Notation.Dot "bitxor" := {|
+  Global Instance Method_bitxor : Notation.Dot "bitxor" := {
     Notation.dot := bitxor;
-  |}.
+  }.
   
-  Global Instance I : BitXor.Trait Self := {|
-    BitXor.Output := Output;
+  Global Instance I : BitXor.Trait Self := {
     BitXor.bitxor := bitxor;
-  |}.
+  }.
 End Impl_BitXor_for_Choice.
 
 Module Impl_BitXorAssign_for_Choice.
@@ -212,13 +209,13 @@ Module Impl_BitXorAssign_for_Choice.
     assign (deref self) ((deref self).["bitxor"] rhs) ;;
     tt.
   
-  Global Instance Method_bitxor_assign : Notation.Dot "bitxor_assign" := {|
+  Global Instance Method_bitxor_assign : Notation.Dot "bitxor_assign" := {
     Notation.dot := bitxor_assign;
-  |}.
+  }.
   
-  Global Instance I : BitXorAssign.Trait Self := {|
+  Global Instance I : BitXorAssign.Trait Self := {
     BitXorAssign.bitxor_assign := bitxor_assign;
-  |}.
+  }.
 End Impl_BitXorAssign_for_Choice.
 
 Module Impl_Not_for_Choice.
@@ -229,14 +226,13 @@ Module Impl_Not_for_Choice.
   Definition not (self : Self) : Choice :=
     (1.["bitand"] (not (IndexedField.get (index := 0) self))).["into"].
   
-  Global Instance Method_not : Notation.Dot "not" := {|
+  Global Instance Method_not : Notation.Dot "not" := {
     Notation.dot := not;
-  |}.
+  }.
   
-  Global Instance I : Not.Trait Self := {|
-    Not.Output := Output;
+  Global Instance I : Not.Trait Self := {
     Not.not := not;
-  |}.
+  }.
 End Impl_Not_for_Choice.
 
 Definition black_box (input : u8) : u8 :=
@@ -256,13 +252,13 @@ Module Impl_From_for_Choice.
   Definition from (input : u8) : Choice := Choice.Build (black_box input).
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I : From.Trait u8 Self := {|
+  Global Instance I : From.Trait Self u8 := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_Choice.
 
 Module ConstantTimeEq.
@@ -270,14 +266,14 @@ Module ConstantTimeEq.
     ct_eq : (ref Self) -> ((ref Self) -> Choice);
   }.
   
-  Global Instance Method_ct_eq `(Trait) : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq `(Trait) : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
-  Global Instance Method_ct_ne `(Trait) : Notation.Dot "ct_ne" := {|
+  }.
+  Global Instance Method_ct_ne `(Trait) : Notation.Dot "ct_ne" := {
     Notation.dot (self : ref Self) (other : ref Self) :=
       (not (self.["ct_eq"] other)
       : Choice);
-  |}.
+  }.
 End ConstantTimeEq.
 
 Module Impl_ConstantTimeEq_for_Slice.
@@ -306,13 +302,13 @@ Module Impl_ConstantTimeEq_for_Slice.
     end ;;
     x.["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I T : ConstantTimeEq.Trait Self := {|
+  Global Instance I T : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_Slice.
 
 Module Impl_ConstantTimeEq_for_Choice.
@@ -321,13 +317,13 @@ Module Impl_ConstantTimeEq_for_Choice.
   Definition ct_eq (self : ref Self) (rhs : ref Choice) : Choice :=
     not ((deref self).["bitxor"] (deref rhs)).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_Choice.
 
 Module Impl_ConstantTimeEq_for_u8.
@@ -338,13 +334,13 @@ Module Impl_ConstantTimeEq_for_u8.
     let y := (x.["bitor"] x.["wrapping_neg"]).["shr"] (8.["sub"] 1) in
     (cast (y.["bitxor"] (cast 1 u8)) u8).["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_u8.
 
 Module Impl_ConstantTimeEq_for_i8.
@@ -353,13 +349,13 @@ Module Impl_ConstantTimeEq_for_i8.
   Definition ct_eq (self : ref Self) (other : ref i8) : Choice :=
     (cast (deref self) u8).["ct_eq"] (cast (deref other) u8).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_i8.
 
 Module Impl_ConstantTimeEq_for_u16.
@@ -370,13 +366,13 @@ Module Impl_ConstantTimeEq_for_u16.
     let y := (x.["bitor"] x.["wrapping_neg"]).["shr"] (16.["sub"] 1) in
     (cast (y.["bitxor"] (cast 1 u16)) u8).["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_u16.
 
 Module Impl_ConstantTimeEq_for_i16.
@@ -385,13 +381,13 @@ Module Impl_ConstantTimeEq_for_i16.
   Definition ct_eq (self : ref Self) (other : ref i16) : Choice :=
     (cast (deref self) u16).["ct_eq"] (cast (deref other) u16).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_i16.
 
 Module Impl_ConstantTimeEq_for_u32.
@@ -402,13 +398,13 @@ Module Impl_ConstantTimeEq_for_u32.
     let y := (x.["bitor"] x.["wrapping_neg"]).["shr"] (32.["sub"] 1) in
     (cast (y.["bitxor"] (cast 1 u32)) u8).["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_u32.
 
 Module Impl_ConstantTimeEq_for_i32.
@@ -417,13 +413,13 @@ Module Impl_ConstantTimeEq_for_i32.
   Definition ct_eq (self : ref Self) (other : ref i32) : Choice :=
     (cast (deref self) u32).["ct_eq"] (cast (deref other) u32).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_i32.
 
 Module Impl_ConstantTimeEq_for_u64.
@@ -434,13 +430,13 @@ Module Impl_ConstantTimeEq_for_u64.
     let y := (x.["bitor"] x.["wrapping_neg"]).["shr"] (64.["sub"] 1) in
     (cast (y.["bitxor"] (cast 1 u64)) u8).["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_u64.
 
 Module Impl_ConstantTimeEq_for_i64.
@@ -449,13 +445,13 @@ Module Impl_ConstantTimeEq_for_i64.
   Definition ct_eq (self : ref Self) (other : ref i64) : Choice :=
     (cast (deref self) u64).["ct_eq"] (cast (deref other) u64).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_i64.
 
 Module Impl_ConstantTimeEq_for_usize.
@@ -468,13 +464,13 @@ Module Impl_ConstantTimeEq_for_usize.
         (((Root.core.mem.size_of tt).["mul"] 8).["sub"] 1) in
     (cast (y.["bitxor"] (cast 1 usize)) u8).["into"].
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_usize.
 
 Module Impl_ConstantTimeEq_for_isize.
@@ -483,13 +479,13 @@ Module Impl_ConstantTimeEq_for_isize.
   Definition ct_eq (self : ref Self) (other : ref isize) : Choice :=
     (cast (deref self) usize).["ct_eq"] (cast (deref other) usize).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeEq.Trait Self := {|
+  Global Instance I : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_isize.
 
 Module ConditionallySelectable.
@@ -498,25 +494,25 @@ Module ConditionallySelectable.
   }.
   
   Global Instance Method_conditional_select `(Trait)
-    : Notation.Dot "conditional_select" := {|
+    : Notation.Dot "conditional_select" := {
     Notation.dot := conditional_select;
-  |}.
+  }.
   Global Instance Method_conditional_assign `(Trait)
-    : Notation.Dot "conditional_assign" := {|
+    : Notation.Dot "conditional_assign" := {
     Notation.dot (self : mut_ref Self) (other : ref Self) (choice : Choice) :=
       (assign (deref self) (Self::["conditional_select"] self other choice) ;;
       tt
       : unit);
-  |}.
+  }.
   Global Instance Method_conditional_swap `(Trait)
-    : Notation.Dot "conditional_swap" := {|
+    : Notation.Dot "conditional_swap" := {
     Notation.dot (a : mut_ref Self) (b : mut_ref Self) (choice : Choice) :=
       (let t := deref a in
       a.["conditional_assign"] b choice ;;
       b.["conditional_assign"] t choice ;;
       tt
       : unit);
-  |}.
+  }.
 End ConditionallySelectable.
 
 Module Impl_ConditionallySelectable_for_u8.
@@ -531,9 +527,9 @@ Module Impl_ConditionallySelectable_for_u8.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -548,9 +544,9 @@ Module Impl_ConditionallySelectable_for_u8.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -563,13 +559,13 @@ Module Impl_ConditionallySelectable_for_u8.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_u8.
 
 Module Impl_ConditionallySelectable_for_i8.
@@ -584,9 +580,9 @@ Module Impl_ConditionallySelectable_for_i8.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -601,9 +597,9 @@ Module Impl_ConditionallySelectable_for_i8.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -616,13 +612,13 @@ Module Impl_ConditionallySelectable_for_i8.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_i8.
 
 Module Impl_ConditionallySelectable_for_u16.
@@ -637,9 +633,9 @@ Module Impl_ConditionallySelectable_for_u16.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -654,9 +650,9 @@ Module Impl_ConditionallySelectable_for_u16.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -669,13 +665,13 @@ Module Impl_ConditionallySelectable_for_u16.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_u16.
 
 Module Impl_ConditionallySelectable_for_i16.
@@ -690,9 +686,9 @@ Module Impl_ConditionallySelectable_for_i16.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -707,9 +703,9 @@ Module Impl_ConditionallySelectable_for_i16.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -722,13 +718,13 @@ Module Impl_ConditionallySelectable_for_i16.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_i16.
 
 Module Impl_ConditionallySelectable_for_u32.
@@ -743,9 +739,9 @@ Module Impl_ConditionallySelectable_for_u32.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -760,9 +756,9 @@ Module Impl_ConditionallySelectable_for_u32.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -775,13 +771,13 @@ Module Impl_ConditionallySelectable_for_u32.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_u32.
 
 Module Impl_ConditionallySelectable_for_i32.
@@ -796,9 +792,9 @@ Module Impl_ConditionallySelectable_for_i32.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -813,9 +809,9 @@ Module Impl_ConditionallySelectable_for_i32.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -828,13 +824,13 @@ Module Impl_ConditionallySelectable_for_i32.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_i32.
 
 Module Impl_ConditionallySelectable_for_u64.
@@ -849,9 +845,9 @@ Module Impl_ConditionallySelectable_for_u64.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -866,9 +862,9 @@ Module Impl_ConditionallySelectable_for_u64.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -881,13 +877,13 @@ Module Impl_ConditionallySelectable_for_u64.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_u64.
 
 Module Impl_ConditionallySelectable_for_i64.
@@ -902,9 +898,9 @@ Module Impl_ConditionallySelectable_for_i64.
     a.["bitxor"] (mask.["bitand"] (a.["bitxor"] b)).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
   Definition conditional_assign
       (self : mut_ref Self)
@@ -919,9 +915,9 @@ Module Impl_ConditionallySelectable_for_i64.
     tt.
   
   Global Instance Method_conditional_assign :
-    Notation.Dot "conditional_assign" := {|
+    Notation.Dot "conditional_assign" := {
     Notation.dot := conditional_assign;
-  |}.
+  }.
   
   Definition conditional_swap
       (a : mut_ref Self)
@@ -934,13 +930,13 @@ Module Impl_ConditionallySelectable_for_i64.
     tt.
   
   Global Instance AssociatedFunction_conditional_swap :
-    Notation.DoubleColon Self "conditional_swap" := {|
+    Notation.DoubleColon Self "conditional_swap" := {
     Notation.double_colon := conditional_swap;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_i64.
 
 Module Impl_ConditionallySelectable_for_Choice.
@@ -958,13 +954,13 @@ Module Impl_ConditionallySelectable_for_Choice.
         choice).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
-  Global Instance I : ConditionallySelectable.Trait Self := {|
+  Global Instance I : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_Choice.
 
 Module ConditionallyNegatable.
@@ -973,9 +969,9 @@ Module ConditionallyNegatable.
   }.
   
   Global Instance Method_conditional_negate `(Trait)
-    : Notation.Dot "conditional_negate" := {|
+    : Notation.Dot "conditional_negate" := {
     Notation.dot := conditional_negate;
-  |}.
+  }.
 End ConditionallyNegatable.
 
 Module Impl_ConditionallyNegatable_for_T.
@@ -987,13 +983,13 @@ Module Impl_ConditionallyNegatable_for_T.
     tt.
   
   Global Instance Method_conditional_negate :
-    Notation.Dot "conditional_negate" := {|
+    Notation.Dot "conditional_negate" := {
     Notation.dot := conditional_negate;
-  |}.
+  }.
   
-  Global Instance I T : ConditionallyNegatable.Trait Self := {|
+  Global Instance I T : ConditionallyNegatable.Trait Self := {
     ConditionallyNegatable.conditional_negate := conditional_negate;
-  |}.
+  }.
 End Impl_ConditionallyNegatable_for_T.
 
 Module CtOption.
@@ -1002,12 +998,12 @@ Module CtOption.
     is_some : Choice;
   }.
   
-  Global Instance Get_value : Notation.Dot "value" := {|
+  Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_is_some : Notation.Dot "is_some" := {|
+  }.
+  Global Instance Get_is_some : Notation.Dot "is_some" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End CtOption.
 Definition CtOption : Set := CtOption.t.
 
@@ -1020,13 +1016,13 @@ Module Impl__crate_clone_Clone_for_CtOption.
       CtOption.is_some := _crate.clone.Clone.clone self.["is_some"];
     |}.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I T : _crate.clone.Clone.Trait Self := {|
+  Global Instance I T : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_CtOption.
 
 Module Impl__crate_marker_Copy_for_CtOption.
@@ -1051,13 +1047,13 @@ Module Impl__crate_fmt_Debug_for_CtOption.
       "is_some"
       self.["is_some"].
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I T : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I T : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_CtOption.
 
 Module Impl_From_for_Option.
@@ -1070,13 +1066,13 @@ Module Impl_From_for_Option.
       None.
   
   Global Instance AssociatedFunction_from :
-    Notation.DoubleColon Self "from" := {|
+    Notation.DoubleColon Self "from" := {
     Notation.double_colon := from;
-  |}.
+  }.
   
-  Global Instance I T : From.Trait CtOption Self := {|
+  Global Instance I T : From.Trait Self CtOption := {
     From.from := from;
-  |}.
+  }.
 End Impl_From_for_Option.
 
 Module ImplCtOption.
@@ -1085,9 +1081,9 @@ Module ImplCtOption.
   Definition new (value : T) (is_some : Choice) : CtOption :=
     {| CtOption.value := value; CtOption.is_some := is_some; |}.
   
-  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {|
+  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {
     Notation.double_colon := new;
-  |}.
+  }.
   
   Definition expect (self : Self) (msg : ref str) : T :=
     match (self.["is_some"].["unwrap_u8"], 1) with
@@ -1108,9 +1104,9 @@ Module ImplCtOption.
     end ;;
     self.["value"].
   
-  Global Instance Method_expect : Notation.Dot "expect" := {|
+  Global Instance Method_expect : Notation.Dot "expect" := {
     Notation.dot := expect;
-  |}.
+  }.
   
   Definition unwrap (self : Self) : T :=
     match (self.["is_some"].["unwrap_u8"], 1) with
@@ -1128,35 +1124,35 @@ Module ImplCtOption.
     end ;;
     self.["value"].
   
-  Global Instance Method_unwrap : Notation.Dot "unwrap" := {|
+  Global Instance Method_unwrap : Notation.Dot "unwrap" := {
     Notation.dot := unwrap;
-  |}.
+  }.
   
   Definition unwrap_or (self : Self) (def : T) : T :=
     T::["conditional_select"] def self.["value"] self.["is_some"].
   
-  Global Instance Method_unwrap_or : Notation.Dot "unwrap_or" := {|
+  Global Instance Method_unwrap_or : Notation.Dot "unwrap_or" := {
     Notation.dot := unwrap_or;
-  |}.
+  }.
   
   Definition unwrap_or_else (self : Self) (f : F) : T :=
     T::["conditional_select"] (f tt) self.["value"] self.["is_some"].
   
-  Global Instance Method_unwrap_or_else : Notation.Dot "unwrap_or_else" := {|
+  Global Instance Method_unwrap_or_else : Notation.Dot "unwrap_or_else" := {
     Notation.dot := unwrap_or_else;
-  |}.
+  }.
   
   Definition is_some (self : ref Self) : Choice := self.["is_some"].
   
-  Global Instance Method_is_some : Notation.Dot "is_some" := {|
+  Global Instance Method_is_some : Notation.Dot "is_some" := {
     Notation.dot := is_some;
-  |}.
+  }.
   
   Definition is_none (self : ref Self) : Choice := not self.["is_some"].
   
-  Global Instance Method_is_none : Notation.Dot "is_none" := {|
+  Global Instance Method_is_none : Notation.Dot "is_none" := {
     Notation.dot := is_none;
-  |}.
+  }.
   
   Definition map (self : Self) (f : F) : CtOption :=
     CtOption::["new"]
@@ -1167,9 +1163,9 @@ Module ImplCtOption.
           self.["is_some"]))
       self.["is_some"].
   
-  Global Instance Method_map : Notation.Dot "map" := {|
+  Global Instance Method_map : Notation.Dot "map" := {
     Notation.dot := map;
-  |}.
+  }.
   
   Definition and_then (self : Self) (f : F) : CtOption :=
     let tmp :=
@@ -1181,18 +1177,18 @@ Module ImplCtOption.
     assign tmp.["is_some"] (bitand tmp.["is_some"] self.["is_some"]) ;;
     tmp.
   
-  Global Instance Method_and_then : Notation.Dot "and_then" := {|
+  Global Instance Method_and_then : Notation.Dot "and_then" := {
     Notation.dot := and_then;
-  |}.
+  }.
   
   Definition or_else (self : Self) (f : F) : CtOption :=
     let is_none := self.["is_none"] in
     let f := f tt in
     Self::["conditional_select"] self f is_none.
   
-  Global Instance Method_or_else : Notation.Dot "or_else" := {|
+  Global Instance Method_or_else : Notation.Dot "or_else" := {
     Notation.dot := or_else;
-  |}.
+  }.
 End ImplCtOption.
 
 Module Impl_ConditionallySelectable_for_CtOption.
@@ -1208,13 +1204,13 @@ Module Impl_ConditionallySelectable_for_CtOption.
       (Choice::["conditional_select"] a.["is_some"] b.["is_some"] choice).
   
   Global Instance AssociatedFunction_conditional_select :
-    Notation.DoubleColon Self "conditional_select" := {|
+    Notation.DoubleColon Self "conditional_select" := {
     Notation.double_colon := conditional_select;
-  |}.
+  }.
   
-  Global Instance I T : ConditionallySelectable.Trait Self := {|
+  Global Instance I T : ConditionallySelectable.Trait Self := {
     ConditionallySelectable.conditional_select := conditional_select;
-  |}.
+  }.
 End Impl_ConditionallySelectable_for_CtOption.
 
 Module Impl_ConstantTimeEq_for_CtOption.
@@ -1227,13 +1223,13 @@ Module Impl_ConstantTimeEq_for_CtOption.
         (self.["value"].["ct_eq"] rhs.["value"])).["bitor"]
       ((not a).["bitand"] (not b)).
   
-  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {|
+  Global Instance Method_ct_eq : Notation.Dot "ct_eq" := {
     Notation.dot := ct_eq;
-  |}.
+  }.
   
-  Global Instance I T : ConstantTimeEq.Trait Self := {|
+  Global Instance I T : ConstantTimeEq.Trait Self := {
     ConstantTimeEq.ct_eq := ct_eq;
-  |}.
+  }.
 End Impl_ConstantTimeEq_for_CtOption.
 
 Module ConstantTimeGreater.
@@ -1241,9 +1237,9 @@ Module ConstantTimeGreater.
     ct_gt : (ref Self) -> ((ref Self) -> Choice);
   }.
   
-  Global Instance Method_ct_gt `(Trait) : Notation.Dot "ct_gt" := {|
+  Global Instance Method_ct_gt `(Trait) : Notation.Dot "ct_gt" := {
     Notation.dot := ct_gt;
-  |}.
+  }.
 End ConstantTimeGreater.
 
 Module Impl_ConstantTimeGreater_for_u8.
@@ -1277,13 +1273,13 @@ Module Impl_ConstantTimeGreater_for_u8.
       while ;;
     Choice::["from"] (cast (bit.["bitand"] 1) u8).
   
-  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {|
+  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {
     Notation.dot := ct_gt;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeGreater.Trait Self := {|
+  Global Instance I : ConstantTimeGreater.Trait Self := {
     ConstantTimeGreater.ct_gt := ct_gt;
-  |}.
+  }.
 End Impl_ConstantTimeGreater_for_u8.
 
 Module Impl_ConstantTimeGreater_for_u16.
@@ -1317,13 +1313,13 @@ Module Impl_ConstantTimeGreater_for_u16.
       while ;;
     Choice::["from"] (cast (bit.["bitand"] 1) u8).
   
-  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {|
+  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {
     Notation.dot := ct_gt;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeGreater.Trait Self := {|
+  Global Instance I : ConstantTimeGreater.Trait Self := {
     ConstantTimeGreater.ct_gt := ct_gt;
-  |}.
+  }.
 End Impl_ConstantTimeGreater_for_u16.
 
 Module Impl_ConstantTimeGreater_for_u32.
@@ -1357,13 +1353,13 @@ Module Impl_ConstantTimeGreater_for_u32.
       while ;;
     Choice::["from"] (cast (bit.["bitand"] 1) u8).
   
-  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {|
+  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {
     Notation.dot := ct_gt;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeGreater.Trait Self := {|
+  Global Instance I : ConstantTimeGreater.Trait Self := {
     ConstantTimeGreater.ct_gt := ct_gt;
-  |}.
+  }.
 End Impl_ConstantTimeGreater_for_u32.
 
 Module Impl_ConstantTimeGreater_for_u64.
@@ -1397,24 +1393,24 @@ Module Impl_ConstantTimeGreater_for_u64.
       while ;;
     Choice::["from"] (cast (bit.["bitand"] 1) u8).
   
-  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {|
+  Global Instance Method_ct_gt : Notation.Dot "ct_gt" := {
     Notation.dot := ct_gt;
-  |}.
+  }.
   
-  Global Instance I : ConstantTimeGreater.Trait Self := {|
+  Global Instance I : ConstantTimeGreater.Trait Self := {
     ConstantTimeGreater.ct_gt := ct_gt;
-  |}.
+  }.
 End Impl_ConstantTimeGreater_for_u64.
 
 Module ConstantTimeLess.
   Class Trait (Self : Set) : Set := {
   }.
   
-  Global Instance Method_ct_lt `(Trait) : Notation.Dot "ct_lt" := {|
+  Global Instance Method_ct_lt `(Trait) : Notation.Dot "ct_lt" := {
     Notation.dot (self : ref Self) (other : ref Self) :=
       ((not (self.["ct_gt"] other)).["bitand"] (not (self.["ct_eq"] other))
       : Choice);
-  |}.
+  }.
 End ConstantTimeLess.
 
 Module Impl_ConstantTimeLess_for_u8.

--- a/coq_translation/examples-from-rust-book/testing/documentation_testing.v
+++ b/coq_translation/examples-from-rust-book/testing/documentation_testing.v
@@ -3,12 +3,12 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Definition add (a : i32) (b : i32) : i32 := add a b.
+Definition add (a : i32) (b : i32) : i32 := a.["add"] b.
 
 Definition div (a : i32) (b : i32) : i32 :=
-  if (eqb b 0 : bool) then
+  if (b.["eq"] 0 : bool) then
     _crate.rt.begin_panic "Divide-by-zero error" ;;
     tt
   else
     tt ;;
-  div a b.
+  a.["div"] b.

--- a/coq_translation/examples-from-rust-book/testing/unit_testing.v
+++ b/coq_translation/examples-from-rust-book/testing/unit_testing.v
@@ -3,6 +3,6 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Definition add (a : i32) (b : i32) : i32 := add a b.
+Definition add (a : i32) (b : i32) : i32 := a.["add"] b.
 
-Definition bad_add (a : i32) (b : i32) : i32 := sub a b.
+Definition bad_add (a : i32) (b : i32) : i32 := a.["sub"] b.

--- a/coq_translation/examples-from-rust-book/traits/clone.v
+++ b/coq_translation/examples-from-rust-book/traits/clone.v
@@ -3,7 +3,10 @@ Require Import CoqOfRust.CoqOfRust.
 
 Import Root.std.prelude.rust_2015.
 
-Error StructUnit.
+Module Unit.
+  Inductive t : Set := Build.
+End Unit.
+Definition Unit := Unit.t.
 
 Module Impl__crate_fmt_Debug_for_Unit.
   Definition Self := Unit.
@@ -14,13 +17,13 @@ Module Impl__crate_fmt_Debug_for_Unit.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "Unit".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Unit.
 
 Module Impl__crate_clone_Clone_for_Unit.
@@ -28,13 +31,13 @@ Module Impl__crate_clone_Clone_for_Unit.
   
   Definition clone (self : ref Self) : Unit := deref self.
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Unit.
 
 Module Impl__crate_marker_Copy_for_Unit.
@@ -47,12 +50,12 @@ End Impl__crate_marker_Copy_for_Unit.
 Module Pair.
   Inductive t : Set := Build (_ : Box) (_ : Box).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0 _) := x0;
-  |}.
-  Global Instance Get_1 : IndexedField.Class t 1 _ := {|
+  }.
+  Global Instance Get_1 : IndexedField.Class t 1 _ := {
     IndexedField.get '(Build _ x1) := x1;
-  |}.
+  }.
 End Pair.
 Definition Pair := Pair.t.
 
@@ -64,13 +67,13 @@ Module Impl__crate_clone_Clone_for_Pair.
       (_crate.clone.Clone.clone (IndexedField.get (index := 0) self))
       (_crate.clone.Clone.clone (IndexedField.get (index := 1) self)).
   
-  Global Instance Method_clone : Notation.Dot "clone" := {|
+  Global Instance Method_clone : Notation.Dot "clone" := {
     Notation.dot := clone;
-  |}.
+  }.
   
-  Global Instance I : _crate.clone.Clone.Trait Self := {|
+  Global Instance I : _crate.clone.Clone.Trait Self := {
     _crate.clone.Clone.clone := clone;
-  |}.
+  }.
 End Impl__crate_clone_Clone_for_Pair.
 
 Module Impl__crate_fmt_Debug_for_Pair.
@@ -86,17 +89,17 @@ Module Impl__crate_fmt_Debug_for_Pair.
       (IndexedField.get (index := 0) self)
       (IndexedField.get (index := 1) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Pair.
 
 Definition main (_ : unit) : unit :=
-  let unit := Unit in
+  let unit := Unit.Build in
   let copied_unit := unit in
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/traits/derive.v
+++ b/coq_translation/examples-from-rust-book/traits/derive.v
@@ -23,8 +23,7 @@ Module Impl__crate_cmp_PartialEq_for_Centimeters.
   Definition Self := Centimeters.
   
   Definition eq (self : ref Self) (other : ref Centimeters) : bool :=
-    eqb
-      (IndexedField.get (index := 0) self)
+    (IndexedField.get (index := 0) self).["eq"]
       (IndexedField.get (index := 0) other).
   
   Global Instance Method_eq : Notation.Dot "eq" := {|
@@ -91,7 +90,7 @@ Module ImplInches.
   
   Definition to_centimeters (self : ref Self) : Centimeters :=
     let Inches (inches) := self in
-    Centimeters.Build (mul (cast inches f64) 3 (* 2.54 *)).
+    Centimeters.Build ((cast inches f64).["mul"] 3 (* 2.54 *)).
   
   Global Instance Method_to_centimeters : Notation.Dot "to_centimeters" := {|
     Notation.dot := to_centimeters;
@@ -117,7 +116,7 @@ Definition main (_ : unit) : unit :=
   tt ;;
   let meter := Centimeters.Build 100 (* 100.0 *) in
   let cmp :=
-    if (lt foot.["to_centimeters"] meter : bool) then
+    if (foot.["to_centimeters"].["lt"] meter : bool) then
       "smaller"
     else
       "bigger" in

--- a/coq_translation/examples-from-rust-book/traits/derive.v
+++ b/coq_translation/examples-from-rust-book/traits/derive.v
@@ -6,9 +6,9 @@ Import Root.std.prelude.rust_2015.
 Module Centimeters.
   Inductive t : Set := Build (_ : f64).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Centimeters.
 Definition Centimeters := Centimeters.t.
 
@@ -26,13 +26,13 @@ Module Impl__crate_cmp_PartialEq_for_Centimeters.
     (IndexedField.get (index := 0) self).["eq"]
       (IndexedField.get (index := 0) other).
   
-  Global Instance Method_eq : Notation.Dot "eq" := {|
+  Global Instance Method_eq : Notation.Dot "eq" := {
     Notation.dot := eq;
-  |}.
+  }.
   
-  Global Instance I : _crate.cmp.PartialEq.Trait Self := {|
+  Global Instance I : _crate.cmp.PartialEq.Trait Self := {
     _crate.cmp.PartialEq.eq := eq;
-  |}.
+  }.
 End Impl__crate_cmp_PartialEq_for_Centimeters.
 
 Module Impl__crate_cmp_PartialOrd_for_Centimeters.
@@ -46,21 +46,21 @@ Module Impl__crate_cmp_PartialOrd_for_Centimeters.
       (IndexedField.get (index := 0) self)
       (IndexedField.get (index := 0) other).
   
-  Global Instance Method_partial_cmp : Notation.Dot "partial_cmp" := {|
+  Global Instance Method_partial_cmp : Notation.Dot "partial_cmp" := {
     Notation.dot := partial_cmp;
-  |}.
+  }.
   
-  Global Instance I : _crate.cmp.PartialOrd.Trait Self := {|
+  Global Instance I : _crate.cmp.PartialOrd.Trait Self := {
     _crate.cmp.PartialOrd.partial_cmp := partial_cmp;
-  |}.
+  }.
 End Impl__crate_cmp_PartialOrd_for_Centimeters.
 
 Module Inches.
   Inductive t : Set := Build (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Inches.
 Definition Inches := Inches.t.
 
@@ -76,13 +76,13 @@ Module Impl__crate_fmt_Debug_for_Inches.
       "Inches"
       (IndexedField.get (index := 0) self).
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_Inches.
 
 Module ImplInches.
@@ -92,17 +92,17 @@ Module ImplInches.
     let Inches (inches) := self in
     Centimeters.Build ((cast inches f64).["mul"] 3 (* 2.54 *)).
   
-  Global Instance Method_to_centimeters : Notation.Dot "to_centimeters" := {|
+  Global Instance Method_to_centimeters : Notation.Dot "to_centimeters" := {
     Notation.dot := to_centimeters;
-  |}.
+  }.
 End ImplInches.
 
 Module Seconds.
   Inductive t : Set := Build (_ : i32).
   
-  Global Instance Get_0 : IndexedField.Class t 0 _ := {|
+  Global Instance Get_0 : IndexedField.Class t 0 _ := {
     IndexedField.get '(Build x0) := x0;
-  |}.
+  }.
 End Seconds.
 Definition Seconds := Seconds.t.
 

--- a/coq_translation/examples-from-rust-book/traits/disambiguating_overlapping_traits.v
+++ b/coq_translation/examples-from-rust-book/traits/disambiguating_overlapping_traits.v
@@ -72,7 +72,7 @@ Definition main (_ : unit) : unit :=
   let username := UsernameWidget.get form in
   match ("rustacean".["to_owned"], username) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -86,7 +86,7 @@ Definition main (_ : unit) : unit :=
   let age := AgeWidget.get form in
   match (28, age) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/traits/disambiguating_overlapping_traits.v
+++ b/coq_translation/examples-from-rust-book/traits/disambiguating_overlapping_traits.v
@@ -8,9 +8,9 @@ Module UsernameWidget.
     get : (ref Self) -> String;
   }.
   
-  Global Instance Method_get `(Trait) : Notation.Dot "get" := {|
+  Global Instance Method_get `(Trait) : Notation.Dot "get" := {
     Notation.dot := get;
-  |}.
+  }.
 End UsernameWidget.
 
 Module AgeWidget.
@@ -18,9 +18,9 @@ Module AgeWidget.
     get : (ref Self) -> u8;
   }.
   
-  Global Instance Method_get `(Trait) : Notation.Dot "get" := {|
+  Global Instance Method_get `(Trait) : Notation.Dot "get" := {
     Notation.dot := get;
-  |}.
+  }.
 End AgeWidget.
 
 Module Form.
@@ -29,12 +29,12 @@ Module Form.
     age : u8;
   }.
   
-  Global Instance Get_username : Notation.Dot "username" := {|
+  Global Instance Get_username : Notation.Dot "username" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_age : Notation.Dot "age" := {|
+  }.
+  Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Form.
 Definition Form : Set := Form.t.
 
@@ -43,13 +43,13 @@ Module Impl_UsernameWidget_for_Form.
   
   Definition get (self : ref Self) : String := self.["username"].["clone"].
   
-  Global Instance Method_get : Notation.Dot "get" := {|
+  Global Instance Method_get : Notation.Dot "get" := {
     Notation.dot := get;
-  |}.
+  }.
   
-  Global Instance I : UsernameWidget.Trait Self := {|
+  Global Instance I : UsernameWidget.Trait Self := {
     UsernameWidget.get := get;
-  |}.
+  }.
 End Impl_UsernameWidget_for_Form.
 
 Module Impl_AgeWidget_for_Form.
@@ -57,13 +57,13 @@ Module Impl_AgeWidget_for_Form.
   
   Definition get (self : ref Self) : u8 := self.["age"].
   
-  Global Instance Method_get : Notation.Dot "get" := {|
+  Global Instance Method_get : Notation.Dot "get" := {
     Notation.dot := get;
-  |}.
+  }.
   
-  Global Instance I : AgeWidget.Trait Self := {|
+  Global Instance I : AgeWidget.Trait Self := {
     AgeWidget.get := get;
-  |}.
+  }.
 End Impl_AgeWidget_for_Form.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/traits/drop.v
+++ b/coq_translation/examples-from-rust-book/traits/drop.v
@@ -8,9 +8,9 @@ Module Droppable.
     name : ref str;
   }.
   
-  Global Instance Get_name : Notation.Dot "name" := {|
+  Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0) := x0;
-  |}.
+  }.
 End Droppable.
 Definition Droppable : Set := Droppable.t.
 
@@ -25,13 +25,13 @@ Module Impl_Drop_for_Droppable.
     tt ;;
     tt.
   
-  Global Instance Method_drop : Notation.Dot "drop" := {|
+  Global Instance Method_drop : Notation.Dot "drop" := {
     Notation.dot := drop;
-  |}.
+  }.
   
-  Global Instance I : Drop.Trait Self := {|
+  Global Instance I : Drop.Trait Self := {
     Drop.drop := drop;
-  |}.
+  }.
 End Impl_Drop_for_Droppable.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/traits/impl_trait_as_return_type.v
+++ b/coq_translation/examples-from-rust-book/traits/impl_trait_as_return_type.v
@@ -22,7 +22,7 @@ Definition main (_ : unit) : unit :=
   let v3 := combine_vecs v1 v2 in
   match (Some 1, v3.["next"]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -35,7 +35,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (Some 2, v3.["next"]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -48,7 +48,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (Some 3, v3.["next"]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -61,7 +61,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (Some 4, v3.["next"]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind
@@ -74,7 +74,7 @@ Definition main (_ : unit) : unit :=
   end ;;
   match (Some 5, v3.["next"]) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/traits/iterators.v
+++ b/coq_translation/examples-from-rust-book/traits/iterators.v
@@ -9,12 +9,12 @@ Module Fibonacci.
     next : u32;
   }.
   
-  Global Instance Get_curr : Notation.Dot "curr" := {|
+  Global Instance Get_curr : Notation.Dot "curr" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_next : Notation.Dot "next" := {|
+  }.
+  Global Instance Get_next : Notation.Dot "next" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Fibonacci.
 Definition Fibonacci : Set := Fibonacci.t.
 
@@ -29,14 +29,13 @@ Module Impl_Iterator_for_Fibonacci.
     assign self.["next"] (current.["add"] self.["next"]) ;;
     Some current.
   
-  Global Instance Method_next : Notation.Dot "next" := {|
+  Global Instance Method_next : Notation.Dot "next" := {
     Notation.dot := next;
-  |}.
+  }.
   
-  Global Instance I : Iterator.Trait Self := {|
-    Iterator.Item := Item;
+  Global Instance I : Iterator.Trait Self := {
     Iterator.next := next;
-  |}.
+  }.
 End Impl_Iterator_for_Fibonacci.
 
 Definition fibonacci (_ : unit) : Fibonacci :=

--- a/coq_translation/examples-from-rust-book/traits/iterators.v
+++ b/coq_translation/examples-from-rust-book/traits/iterators.v
@@ -26,7 +26,7 @@ Module Impl_Iterator_for_Fibonacci.
   Definition next (self : mut_ref Self) : Option :=
     let current := self.["curr"] in
     assign self.["curr"] self.["next"] ;;
-    assign self.["next"] (add current self.["next"]) ;;
+    assign self.["next"] (current.["add"] self.["next"]) ;;
     Some current.
   
   Global Instance Method_next : Notation.Dot "next" := {|

--- a/coq_translation/examples-from-rust-book/traits/operator_overloading.v
+++ b/coq_translation/examples-from-rust-book/traits/operator_overloading.v
@@ -5,11 +5,20 @@ Import Root.std.prelude.rust_2015.
 
 Module ops := std.ops.
 
-Error StructUnit.
+Module Foo.
+  Inductive t : Set := Build.
+End Foo.
+Definition Foo := Foo.t.
 
-Error StructUnit.
+Module Bar.
+  Inductive t : Set := Build.
+End Bar.
+Definition Bar := Bar.t.
 
-Error StructUnit.
+Module FooBar.
+  Inductive t : Set := Build.
+End FooBar.
+Definition FooBar := FooBar.t.
 
 Module Impl__crate_fmt_Debug_for_FooBar.
   Definition Self := FooBar.
@@ -20,16 +29,19 @@ Module Impl__crate_fmt_Debug_for_FooBar.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "FooBar".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_FooBar.
 
-Error StructUnit.
+Module BarFoo.
+  Inductive t : Set := Build.
+End BarFoo.
+Definition BarFoo := BarFoo.t.
 
 Module Impl__crate_fmt_Debug_for_BarFoo.
   Definition Self := BarFoo.
@@ -40,13 +52,13 @@ Module Impl__crate_fmt_Debug_for_BarFoo.
       : _crate.fmt.Result :=
     _crate.fmt.Formatter::["write_str"] f "BarFoo".
   
-  Global Instance Method_fmt : Notation.Dot "fmt" := {|
+  Global Instance Method_fmt : Notation.Dot "fmt" := {
     Notation.dot := fmt;
-  |}.
+  }.
   
-  Global Instance I : _crate.fmt.Debug.Trait Self := {|
+  Global Instance I : _crate.fmt.Debug.Trait Self := {
     _crate.fmt.Debug.fmt := fmt;
-  |}.
+  }.
 End Impl__crate_fmt_Debug_for_BarFoo.
 
 Module Impl_ops_Add_for_Foo.
@@ -60,16 +72,15 @@ Module Impl_ops_Add_for_Foo.
         [ "> Foo.add(Bar) was called\n" ]
         [  ]) ;;
     tt ;;
-    FooBar.
+    FooBar.Build.
   
-  Global Instance Method_add : Notation.Dot "add" := {|
+  Global Instance Method_add : Notation.Dot "add" := {
     Notation.dot := add;
-  |}.
+  }.
   
-  Global Instance I : ops.Add.Trait Bar Self := {|
-    ops.Add.Output := Output;
+  Global Instance I : ops.Add.Trait Self (Some Bar) := {
     ops.Add.add := add;
-  |}.
+  }.
 End Impl_ops_Add_for_Foo.
 
 Module Impl_ops_Add_for_Bar.
@@ -83,27 +94,26 @@ Module Impl_ops_Add_for_Bar.
         [ "> Bar.add(Foo) was called\n" ]
         [  ]) ;;
     tt ;;
-    BarFoo.
+    BarFoo.Build.
   
-  Global Instance Method_add : Notation.Dot "add" := {|
+  Global Instance Method_add : Notation.Dot "add" := {
     Notation.dot := add;
-  |}.
+  }.
   
-  Global Instance I : ops.Add.Trait Foo Self := {|
-    ops.Add.Output := Output;
+  Global Instance I : ops.Add.Trait Self (Some Foo) := {
     ops.Add.add := add;
-  |}.
+  }.
 End Impl_ops_Add_for_Bar.
 
 Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Foo + Bar = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_debug"] (Foo.["add"] Bar) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_debug"] (Foo.Build.["add"] Bar.Build) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Bar + Foo = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_debug"] (Bar.["add"] Foo) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_debug"] (Bar.Build.["add"] Foo.Build) ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/traits/operator_overloading.v
+++ b/coq_translation/examples-from-rust-book/traits/operator_overloading.v
@@ -99,11 +99,11 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Foo + Bar = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_debug"] (add Foo Bar) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_debug"] (Foo.["add"] Bar) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "Bar + Foo = "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_debug"] (add Bar Foo) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_debug"] (Bar.["add"] Foo) ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/traits/returning_traits_with_dyn.v
+++ b/coq_translation/examples-from-rust-book/traits/returning_traits_with_dyn.v
@@ -20,9 +20,9 @@ Module Animal.
     noise : (ref Self) -> (ref str);
   }.
   
-  Global Instance Method_noise `(Trait) : Notation.Dot "noise" := {|
+  Global Instance Method_noise `(Trait) : Notation.Dot "noise" := {
     Notation.dot := noise;
-  |}.
+  }.
 End Animal.
 
 Module Impl_Animal_for_Sheep.
@@ -30,13 +30,13 @@ Module Impl_Animal_for_Sheep.
   
   Definition noise (self : ref Self) : ref str := "baaaaah!".
   
-  Global Instance Method_noise : Notation.Dot "noise" := {|
+  Global Instance Method_noise : Notation.Dot "noise" := {
     Notation.dot := noise;
-  |}.
+  }.
   
-  Global Instance I : Animal.Trait Self := {|
+  Global Instance I : Animal.Trait Self := {
     Animal.noise := noise;
-  |}.
+  }.
 End Impl_Animal_for_Sheep.
 
 Module Impl_Animal_for_Cow.
@@ -44,13 +44,13 @@ Module Impl_Animal_for_Cow.
   
   Definition noise (self : ref Self) : ref str := "moooooo!".
   
-  Global Instance Method_noise : Notation.Dot "noise" := {|
+  Global Instance Method_noise : Notation.Dot "noise" := {
     Notation.dot := noise;
-  |}.
+  }.
   
-  Global Instance I : Animal.Trait Self := {|
+  Global Instance I : Animal.Trait Self := {
     Animal.noise := noise;
-  |}.
+  }.
 End Impl_Animal_for_Cow.
 
 Definition random_animal (random_number : f64) : Box :=

--- a/coq_translation/examples-from-rust-book/traits/returning_traits_with_dyn.v
+++ b/coq_translation/examples-from-rust-book/traits/returning_traits_with_dyn.v
@@ -54,7 +54,7 @@ Module Impl_Animal_for_Cow.
 End Impl_Animal_for_Cow.
 
 Definition random_animal (random_number : f64) : Box :=
-  if (lt random_number 1 (* 0.5 *) : bool) then
+  if (random_number.["lt"] 1 (* 0.5 *) : bool) then
     Box::["new"] {|  |}
   else
     Box::["new"] {|  |}.

--- a/coq_translation/examples-from-rust-book/traits/supertraits.v
+++ b/coq_translation/examples-from-rust-book/traits/supertraits.v
@@ -8,9 +8,9 @@ Module Person.
     name : (ref Self) -> String;
   }.
   
-  Global Instance Method_name `(Trait) : Notation.Dot "name" := {|
+  Global Instance Method_name `(Trait) : Notation.Dot "name" := {
     Notation.dot := name;
-  |}.
+  }.
 End Person.
 
 Module Student.
@@ -18,9 +18,9 @@ Module Student.
     university : (ref Self) -> String;
   }.
   
-  Global Instance Method_university `(Trait) : Notation.Dot "university" := {|
+  Global Instance Method_university `(Trait) : Notation.Dot "university" := {
     Notation.dot := university;
-  |}.
+  }.
 End Student.
 
 Module Programmer.
@@ -29,9 +29,9 @@ Module Programmer.
   }.
   
   Global Instance Method_fav_language `(Trait)
-    : Notation.Dot "fav_language" := {|
+    : Notation.Dot "fav_language" := {
     Notation.dot := fav_language;
-  |}.
+  }.
 End Programmer.
 
 Module CompSciStudent.
@@ -40,9 +40,9 @@ Module CompSciStudent.
   }.
   
   Global Instance Method_git_username `(Trait)
-    : Notation.Dot "git_username" := {|
+    : Notation.Dot "git_username" := {
     Notation.dot := git_username;
-  |}.
+  }.
 End CompSciStudent.
 
 Definition comp_sci_student_greeting (student : ref TraitObject) : String :=

--- a/coq_translation/examples-from-rust-book/traits/traits.v
+++ b/coq_translation/examples-from-rust-book/traits/traits.v
@@ -9,12 +9,12 @@ Module Sheep.
     name : ref str;
   }.
   
-  Global Instance Get_naked : Notation.Dot "naked" := {|
+  Global Instance Get_naked : Notation.Dot "naked" := {
     Notation.dot '(Build_t x0 _) := x0;
-  |}.
-  Global Instance Get_name : Notation.Dot "name" := {|
+  }.
+  Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t _ x1) := x1;
-  |}.
+  }.
 End Sheep.
 Definition Sheep : Set := Sheep.t.
 
@@ -25,16 +25,16 @@ Module Animal.
     noise : (ref Self) -> (ref str);
   }.
   
-  Global Instance Method_new `(Trait) : Notation.Dot "new" := {|
+  Global Instance Method_new `(Trait) : Notation.Dot "new" := {
     Notation.dot := new;
-  |}.
-  Global Instance Method_name `(Trait) : Notation.Dot "name" := {|
+  }.
+  Global Instance Method_name `(Trait) : Notation.Dot "name" := {
     Notation.dot := name;
-  |}.
-  Global Instance Method_noise `(Trait) : Notation.Dot "noise" := {|
+  }.
+  Global Instance Method_noise `(Trait) : Notation.Dot "noise" := {
     Notation.dot := noise;
-  |}.
-  Global Instance Method_talk `(Trait) : Notation.Dot "talk" := {|
+  }.
+  Global Instance Method_talk `(Trait) : Notation.Dot "talk" := {
     Notation.dot (self : ref Self) :=
       (_crate.io._print
         (_crate.fmt.Arguments::["new_v1"]
@@ -46,7 +46,7 @@ Module Animal.
       tt ;;
       tt
       : unit);
-  |}.
+  }.
 End Animal.
 
 Module ImplSheep.
@@ -54,9 +54,9 @@ Module ImplSheep.
   
   Definition is_naked (self : ref Self) : bool := self.["naked"].
   
-  Global Instance Method_is_naked : Notation.Dot "is_naked" := {|
+  Global Instance Method_is_naked : Notation.Dot "is_naked" := {
     Notation.dot := is_naked;
-  |}.
+  }.
 End ImplSheep.
 
 Module Impl_Animal_for_Sheep.
@@ -65,15 +65,15 @@ Module Impl_Animal_for_Sheep.
   Definition new (name : ref str) : Sheep :=
     {| Sheep.name := name; Sheep.naked := false; |}.
   
-  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {|
+  Global Instance AssociatedFunction_new : Notation.DoubleColon Self "new" := {
     Notation.double_colon := new;
-  |}.
+  }.
   
   Definition name (self : ref Self) : ref str := self.["name"].
   
-  Global Instance Method_name : Notation.Dot "name" := {|
+  Global Instance Method_name : Notation.Dot "name" := {
     Notation.dot := name;
-  |}.
+  }.
   
   Definition noise (self : ref Self) : ref str :=
     if (self.["is_naked"] : bool) then
@@ -81,9 +81,9 @@ Module Impl_Animal_for_Sheep.
     else
       "baaaaah!".
   
-  Global Instance Method_noise : Notation.Dot "noise" := {|
+  Global Instance Method_noise : Notation.Dot "noise" := {
     Notation.dot := noise;
-  |}.
+  }.
   
   Definition talk (self : ref Self) :=
     _crate.io._print
@@ -96,15 +96,15 @@ Module Impl_Animal_for_Sheep.
     tt ;;
     tt.
   
-  Global Instance Method_talk : Notation.Dot "talk" := {|
+  Global Instance Method_talk : Notation.Dot "talk" := {
     Notation.dot := talk;
-  |}.
+  }.
   
-  Global Instance I : Animal.Trait Self := {|
+  Global Instance I : Animal.Trait Self := {
     Animal.new := new;
     Animal.name := name;
     Animal.noise := noise;
-  |}.
+  }.
 End Impl_Animal_for_Sheep.
 
 Module ImplSheep_2.
@@ -127,9 +127,9 @@ Module ImplSheep_2.
       assign self.["naked"] true ;;
       tt.
   
-  Global Instance Method_shear : Notation.Dot "shear" := {|
+  Global Instance Method_shear : Notation.Dot "shear" := {
     Notation.dot := shear;
-  |}.
+  }.
 End ImplSheep_2.
 
 Definition main (_ : unit) : unit :=

--- a/coq_translation/examples-from-rust-book/types/aliasing.v
+++ b/coq_translation/examples-from-rust-book/types/aliasing.v
@@ -18,7 +18,7 @@ Definition main (_ : unit) : unit :=
       [
         _crate.fmt.ArgumentV1::["new_display"] nanoseconds;
         _crate.fmt.ArgumentV1::["new_display"] inches;
-        _crate.fmt.ArgumentV1::["new_display"] (add nanoseconds inches)
+        _crate.fmt.ArgumentV1::["new_display"] (nanoseconds.["add"] inches)
       ]) ;;
   tt ;;
   tt.

--- a/coq_translation/examples-from-rust-book/types/casting.v
+++ b/coq_translation/examples-from-rust-book/types/casting.v
@@ -36,7 +36,7 @@ Definition main (_ : unit) : unit :=
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]
       [ "1000 mod 256 is : "; "\n" ]
-      [ _crate.fmt.ArgumentV1::["new_display"] (rem 1000 256) ]) ;;
+      [ _crate.fmt.ArgumentV1::["new_display"] (1000.["rem"] 256) ]) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/coq_translation/examples-from-rust-book/unsafe_operations/calling_unsafe_functions.v
+++ b/coq_translation/examples-from-rust-book/unsafe_operations/calling_unsafe_functions.v
@@ -12,7 +12,7 @@ Definition main (_ : unit) : unit :=
   let my_slice := slice.from_raw_parts pointer length in
   match (some_vector.["as_slice"], my_slice) with
   | (left_val, right_val) =>
-    if (not (eqb (deref left_val) (deref right_val)) : bool) then
+    if (not ((deref left_val).["eq"] (deref right_val)) : bool) then
       let kind := _crate.panicking.AssertKind.Eq in
       _crate.panicking.assert_failed
         kind

--- a/coq_translation/examples-from-rust-book/unsafe_operations/inline_assembly_inlateout_mul.v
+++ b/coq_translation/examples-from-rust-book/unsafe_operations/inline_assembly_inlateout_mul.v
@@ -12,4 +12,4 @@ Definition mul (a : u64) (b : u64) : u128 :=
   let hi := tt in
   InlineAsm ;;
   tt ;;
-  add (shl (cast hi u128) 64) (cast lo u128).
+  ((cast hi u128).["shl"] 64).["add"] (cast lo u128).

--- a/coq_translation/examples-from-rust-book/unsafe_operations/inline_assembly_symbol_operands_and_abi_clobbers.v
+++ b/coq_translation/examples-from-rust-book/unsafe_operations/inline_assembly_symbol_operands_and_abi_clobbers.v
@@ -13,7 +13,7 @@ Definition foo (arg : i32) : i32 :=
       [ "arg = "; "\n" ]
       [ _crate.fmt.ArgumentV1::["new_display"] arg ]) ;;
   tt ;;
-  mul arg 2.
+  arg.["mul"] 2.
 
 Definition call_foo (arg : i32) : i32 :=
   let result := tt in

--- a/coq_translation/examples-from-rust-book/unsafe_operations/raw_pointers.v
+++ b/coq_translation/examples-from-rust-book/unsafe_operations/raw_pointers.v
@@ -5,7 +5,7 @@ Import Root.std.prelude.rust_2015.
 
 Definition main (_ : unit) : unit :=
   let raw_p := 10 in
-  if (not (eqb (deref raw_p) 10) : bool) then
+  if (not ((deref raw_p).["eq"] 10) : bool) then
     _crate.panicking.panic "assertion failed: *raw_p == 10"
   else
     tt ;;

--- a/coq_translation/examples-from-rust-book/variable_bindings/declare_first.v
+++ b/coq_translation/examples-from-rust-book/variable_bindings/declare_first.v
@@ -6,7 +6,7 @@ Import Root.std.prelude.rust_2015.
 Definition main (_ : unit) : unit :=
   let a_binding := tt in
   let x := 2 in
-  assign a_binding (mul x x) ;;
+  assign a_binding (x.["mul"] x) ;;
   tt ;;
   _crate.io._print
     (_crate.fmt.Arguments::["new_v1"]

--- a/lib/src/expression.rs
+++ b/lib/src/expression.rs
@@ -120,12 +120,12 @@ fn compile_bin_op(bin_op: &BinOp) -> String {
         BinOpKind::Rem => "rem".to_string(),
         BinOpKind::And => "andb".to_string(),
         BinOpKind::Or => "or".to_string(),
-        BinOpKind::BitXor => "bit_xor".to_string(),
-        BinOpKind::BitAnd => "bit_and".to_string(),
-        BinOpKind::BitOr => "bit_or".to_string(),
+        BinOpKind::BitXor => "bitxor".to_string(),
+        BinOpKind::BitAnd => "bitand".to_string(),
+        BinOpKind::BitOr => "bitor".to_string(),
         BinOpKind::Shl => "shl".to_string(),
         BinOpKind::Shr => "shr".to_string(),
-        BinOpKind::Eq => "eqb".to_string(),
+        BinOpKind::Eq => "eq".to_string(),
         BinOpKind::Lt => "lt".to_string(),
         BinOpKind::Le => "le".to_string(),
         BinOpKind::Ne => "ne".to_string(),
@@ -225,10 +225,11 @@ pub fn compile_expr(tcx: TyCtxt, expr: &rustc_hir::Expr) -> Expr {
         rustc_hir::ExprKind::Binary(bin_op, expr_left, expr_right) => {
             let expr_left = compile_expr(tcx, expr_left);
             let expr_right = compile_expr(tcx, expr_right);
-            let func = Box::new(Expr::LocalVar(compile_bin_op(bin_op)));
-            Expr::Call {
+            let func = compile_bin_op(bin_op);
+            Expr::MethodCall {
+                object: Box::new(expr_left),
                 func,
-                args: vec![expr_left, expr_right],
+                args: vec![expr_right],
             }
         }
         rustc_hir::ExprKind::Unary(un_op, expr) => {


### PR DESCRIPTION
In this PR, we:

* generate method calls for the binary operators;
* handle the unit struct definitions;
* handle trait implementations for traits that have type parameters with a default type

The end result is to achieve the translation of https://github.com/formal-land/coq-of-rust/blob/main/examples-from-rust-book/traits/operator_overloading.rs