### PR TITLE
Add Imp to represent imperative source languages

### DIFF
--- a/coq_translation/Imp.v
+++ b/coq_translation/Imp.v
@@ -27,8 +27,12 @@ Inductive Ctl_ty : Set :=
 | Panic (** unrecovarable errors *)
 | Exception. (** recovarable errors/user errors *)
 
-(** [Mem i] is the memory indexed by the type i, it returns an existential type *)
-Parameter Mem : Set -> (forall a : Set, a).
+(** The type of a memory value which depends on an index *)
+Definition Mem_val_type {a : Set} (i : a) : Set. Admitted.
+(** A memory area indexed by the type [a] *)
+Definition Mem_area (a : Set) : forall (i : a), Mem_val_type i. Admitted.
+Check Mem_area nat. (* A memory area indexed by naturals *)
+Check Mem_val_type 0.
 
 (** [Imp] defines a free monad for a imperative language *)
 Inductive Imp : Set -> Set
@@ -40,9 +44,29 @@ Inductive Imp : Set -> Set
 | Loop {a b : Set} : Imp unit -> Imp unit 
 (** It keeps evaluating its parameter until the answer is [Break]. *)
 | Control {a : Set} : Ctl_ty -> a -> Imp a (** return, break, exceptons ... *)
-| ReadMem {a b : Set} : Mem a b -> a -> Imp b (** read from memory *)
-| WriteMem {a b : Set} : Mem a b -> a -> b -> Imp unit (** write to memory *)
 | Sequence {a b : Set} : Imp a -> (a -> Imp b) -> Imp b
   (** to represent a sequence of computations that may depend on
+
       previous computations *)
 .
+
+
+
+(** Free is the free monad definiton it has to be merged into Imp and 
+    it is here only for reference 
+
+    Free a f =
+      Pure a
+    | Free (f (Free a f))
+
+*)
+Module Free.
+  (* Inductive t (a : Set) (fnctr : Set -> Set) : Set := *)
+  (* | Pure : a -> t a fnctr *)
+  (* | Free : ??? *)
+  (* . *)
+End Free.
+
+
+                         
+                   

--- a/coq_translation/Imp.v
+++ b/coq_translation/Imp.v
@@ -6,6 +6,12 @@ Import ListNotations.
 Open Scope Z_scope.
 Open Scope string_scope.
 
+(** Fail monad placeholder
+
+   Is going to be replaces by the real result monad
+*)
+Parameter result : Set -> Set -> Set.
+
 (** Imp is a imperative language to be used as target language
     for translation from other imperative source languages to Coq, for
     example Rust and Solidity.
@@ -21,24 +27,18 @@ Inductive Ctl_ty : Set :=
 | Panic (** unrecovarable errors *)
 | Exception. (** recovarable errors/user errors *)
 
-
-(** [Mem i a] is the memory indexed by the type i, containing the type a 
-    
-    I think this is not enough to represent memory, each "memory cell"
-    will have its own type, maybe a list of dependent pairs?
-
-*)
-Parameter Mem : Set -> Set -> Set.
+(** [Mem i] is the memory indexed by the type i, it returns an existential type *)
+Parameter Mem : Set -> (forall a : Set, a).
 
 (** [Imp] defines a free monad for a imperative language *)
 Inductive Imp : Set -> Set
   (** Set -> Set is a guess here to be to make it a mappable *)
   := 
 | Pure {a : Set} : a -> Imp a (** pure expressions *)
-| Impure {a : Set} : a -> Imp a
-  (** impure expressions, like function calls that may fail,
-      not sure if I need this *)
-| Loop {a b : Set} : list a -> Imp a (** may loop return values? *)
+| Impure {a e : Set} : a -> Imp (result a e)
+  (** impure expressions, like function calls that may fail *)
+| Loop {a b : Set} : Imp unit -> Imp unit 
+(** It keeps evaluating its parameter until the answer is [Break]. *)
 | Control {a : Set} : Ctl_ty -> a -> Imp a (** return, break, exceptons ... *)
 | ReadMem {a b : Set} : Mem a b -> a -> Imp b (** read from memory *)
 | WriteMem {a b : Set} : Mem a b -> a -> b -> Imp unit (** write to memory *)

--- a/coq_translation/Imp.v
+++ b/coq_translation/Imp.v
@@ -1,0 +1,48 @@
+Require Import Coq.ZArith.ZArith.
+Require Import Coq.Lists.List.
+Require Import Coq.Strings.String.
+
+Import ListNotations.
+Open Scope Z_scope.
+Open Scope string_scope.
+
+(** Imp is a imperative language to be used as target language
+    for translation from other imperative source languages to Coq, for
+    example Rust and Solidity.
+
+    The main idea is to have a free monad to represent the imperative constructs
+    that are not directly mappable to gallina. See the [Imp] type below
+*)
+
+Inductive Ctl_ty : Set :=
+| Return (** return from function *)
+| Break (** break loops *)
+| Continue (** restart loops *)
+| Panic (** unrecovarable errors *)
+| Exception. (** recovarable errors/user errors *)
+
+
+(** [Mem i a] is the memory indexed by the type i, containing the type a 
+    
+    I think this is not enough to represent memory, each "memory cell"
+    will have its own type, maybe a list of dependent pairs?
+
+*)
+Parameter Mem : Set -> Set -> Set.
+
+(** [Imp] defines a free monad for a imperative language *)
+Inductive Imp : Set -> Set
+  (** Set -> Set is a guess here to be to make it a mappable *)
+  := 
+| Pure {a : Set} : a -> Imp a (** pure expressions *)
+| Impure {a : Set} : a -> Imp a
+  (** impure expressions, like function calls that may fail,
+      not sure if I need this *)
+| Loop {a b : Set} : list a -> Imp a (** may loop return values? *)
+| Control {a : Set} : Ctl_ty -> a -> Imp a (** return, break, exceptons ... *)
+| ReadMem {a b : Set} : Mem a b -> a -> Imp b (** read from memory *)
+| WriteMem {a b : Set} : Mem a b -> a -> b -> Imp unit (** write to memory *)
+| Sequence {a b : Set} : Imp a -> (a -> Imp b) -> Imp b
+  (** to represent a sequence of computations that may depend on
+      previous computations *)
+.


### PR DESCRIPTION
The idea is to discuss to find a good representation of the imperative/impure constructs from our source languages (solidity and Rust) that are not easily or possibly mappable directly to gallina