### PR TITLE
Fix bug in top_level.rs

### DIFF
--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -916,6 +916,7 @@ impl ImplItem {
                     text("Definition"),
                     line(),
                     text(name),
+                    text(" := "),
                     body.to_doc(false),
                     text("."),
                 ]),


### PR DESCRIPTION
The translation was producing
`Definition IS_RESULTRoot.ink.reflect.ConstructorOutput.IS_RESULT.`

Where before it was producing
`Definition IS_RESULT (_ : unit) := Root.ink.reflect.ConstructorOutput.IS_RESULT.`

This commit restore remove the `(_ : unit)` but restore the ` := `

So it produces

`Definition IS_RESULT := Root.ink.reflect.ConstructorOutput.IS_RESULT.`