### PR TITLE
Deduplicate definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "itertools",
  "pretty",
  "serde",
  "serde_json",
@@ -179,6 +180,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
@@ -257,6 +264,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/CoqOfRust/ink/ink.v
+++ b/CoqOfRust/ink/ink.v
@@ -51,7 +51,7 @@ Module result_info.
     
     Global Instance Method_value `{H : State.Trait} `(Trait)
       : Notation.Dot "value" := {
-      Notation.dot (self : ref Self) := (Pure false : M (H := H) bool);
+      Notation.dot (self : ref Self) := (axiom : M (H := H) bool);
     }.
   End IsResultErrFallback.
 End result_info.
@@ -105,7 +105,7 @@ Module IsResultErrFallback.
   
   Global Instance Method_value `{H : State.Trait} `(Trait)
     : Notation.Dot "value" := {
-    Notation.dot (self : ref Self) := (Pure false : M (H := H) bool);
+    Notation.dot (self : ref Self) := (axiom : M (H := H) bool);
   }.
 End IsResultErrFallback.
 

--- a/CoqOfRust/ink/ink_env.v
+++ b/CoqOfRust/ink/ink_env.v
@@ -2064,7 +2064,7 @@ Module call.
       Global Instance Method_err `{H : State.Trait} `(Trait)
         : Notation.Dot "err" := {
         Notation.dot (_err : Error) :=
-          (Pure core.option.Option.None
+          (axiom
           : M (H := H) (core.option.Option Output));
       }.
     End ConstructorReturnType.
@@ -2698,7 +2698,7 @@ Module create_builder.
     Global Instance Method_err `{H : State.Trait} `(Trait)
       : Notation.Dot "err" := {
       Notation.dot (_err : Error) :=
-        (Pure core.option.Option.None
+        (axiom
         : M (H := H) (core.option.Option Output));
     }.
   End ConstructorReturnType.
@@ -2869,7 +2869,7 @@ Module ConstructorReturnType.
   Global Instance Method_err `{H : State.Trait} `(Trait)
     : Notation.Dot "err" := {
     Notation.dot (_err : Error) :=
-      (Pure core.option.Option.None
+      (axiom
       : M (H := H) (core.option.Option Output));
   }.
 End ConstructorReturnType.

--- a/CoqOfRust/ink/ink_macro.v
+++ b/CoqOfRust/ink/ink_macro.v
@@ -53,16 +53,6 @@ Module contract.
       M (H := H) (syn.error.Result proc_macro2.TokenStream).
 End contract.
 
-Parameter generate : forall `{H : State.Trait},
-    proc_macro2.TokenStream ->
-    proc_macro2.TokenStream ->
-    M (H := H) proc_macro2.TokenStream.
-
-Parameter generate_or_err : forall `{H : State.Trait},
-    proc_macro2.TokenStream ->
-    proc_macro2.TokenStream ->
-    M (H := H) (syn.error.Result proc_macro2.TokenStream).
-
 Module ink_test.
   Parameter generate : forall `{H : State.Trait},
       proc_macro2.TokenStream ->
@@ -74,16 +64,6 @@ Module ink_test.
       proc_macro2.TokenStream ->
       M (H := H) (syn.error.Result proc_macro2.TokenStream).
 End ink_test.
-
-Parameter generate : forall `{H : State.Trait},
-    proc_macro2.TokenStream ->
-    proc_macro2.TokenStream ->
-    M (H := H) proc_macro2.TokenStream.
-
-Parameter generate_or_err : forall `{H : State.Trait},
-    proc_macro2.TokenStream ->
-    proc_macro2.TokenStream ->
-    M (H := H) (syn.error.Result proc_macro2.TokenStream).
 
 Module selector.
   Parameter generate_selector_id : forall `{H : State.Trait},

--- a/CoqOfRust/ink/ink_storage_traits.v
+++ b/CoqOfRust/ink/ink_storage_traits.v
@@ -137,7 +137,7 @@ Module storage.
     (* Global Instance Method_key `{H : State.Trait} `(Trait)
       : Notation.Dot "key" := {
       Notation.dot (self : ref Self) :=
-        (Pure Self::["KEY"]
+        (axiom
         : M (H := H) ink_primitives.key.Key);
     }.
   *) End StorageKey.
@@ -243,7 +243,7 @@ Module StorageKey.
   (* Global Instance Method_key `{H : State.Trait} `(Trait)
     : Notation.Dot "key" := {
     Notation.dot (self : ref Self) :=
-      (Pure Self::["KEY"]
+      (axiom
       : M (H := H) ink_primitives.key.Key);
   }.
 *) End StorageKey.

--- a/CoqOfRust/ink/update_after_translation.py
+++ b/CoqOfRust/ink/update_after_translation.py
@@ -29,12 +29,6 @@ def update_ink_primitives():
         content = f.read()
     content = \
         sub_exactly_once(
-            r"Definition Hash := @Hash\.t\.\n\nModule Visitor\..*Definition Visitor := @Visitor\.t\.",
-            "Definition Hash := @Hash.t.",
-            content,
-        )
-    content = \
-        sub_exactly_once(
             "Definition MessageResult",
             "Definition MessageResult (T : Set)",
             content,

--- a/coq_translation/axiomatized/examples/modules/super_and_self.v
+++ b/coq_translation/axiomatized/examples/modules/super_and_self.v
@@ -15,10 +15,4 @@ Module my.
   Parameter indirect_call : forall `{H : State.Trait}, M (H := H) unit.
 End my.
 
-Module cool.
-  Parameter function : forall `{H : State.Trait}, M (H := H) unit.
-End cool.
-
-Parameter function : forall `{H : State.Trait}, M (H := H) unit.
-
 Parameter indirect_call : forall `{H : State.Trait}, M (H := H) unit.

--- a/coq_translation/axiomatized/examples/modules/visibility.v
+++ b/coq_translation/axiomatized/examples/modules/visibility.v
@@ -27,8 +27,6 @@ Module nested.
   Parameter function : forall `{H : State.Trait}, M (H := H) unit.
 End nested.
 
-Parameter function : forall `{H : State.Trait}, M (H := H) unit.
-
 Parameter call_public_function_in_my_mod : forall `{H : State.Trait},
     M (H := H) unit.
 

--- a/coq_translation/axiomatized/examples/subtle.v
+++ b/coq_translation/axiomatized/examples/subtle.v
@@ -29,8 +29,7 @@ Module ConstantTimeEq.
   Global Instance Method_ct_ne `{H : State.Trait} `(Trait)
     : Notation.Dot "ct_ne" := {
     Notation.dot (self : ref Self) (other : ref Self) :=
-      (let* α0 := self.["ct_eq"] other in
-      α0.["not"]
+      (axiom
       : M (H := H) subtle.Choice);
   }.
 End ConstantTimeEq.
@@ -53,11 +52,7 @@ Module ConditionallySelectable.
         (self : mut_ref Self)
         (other : ref Self)
         (choice : subtle.Choice) :=
-      (let* _ :=
-        let* α0 := self.["deref"] in
-        let* α1 := Self::["conditional_select"] self other choice in
-        assign α0 α1 in
-      Pure tt
+      (axiom
       : M (H := H) unit);
   }.
   Global Instance Method_conditional_swap `{H : State.Trait} `(Trait)
@@ -66,10 +61,7 @@ Module ConditionallySelectable.
         (a : mut_ref Self)
         (b : mut_ref Self)
         (choice : subtle.Choice) :=
-      (let* t := a.["deref"] in
-      let* _ := a.["conditional_assign"] (addr_of b) choice in
-      let* _ := b.["conditional_assign"] (addr_of t) choice in
-      Pure tt
+      (axiom
       : M (H := H) unit);
   }.
 End ConditionallySelectable.
@@ -129,11 +121,7 @@ Module ConstantTimeLess.
   Global Instance Method_ct_lt `{H : State.Trait} `(Trait)
     : Notation.Dot "ct_lt" := {
     Notation.dot (self : ref Self) (other : ref Self) :=
-      (let* α0 := self.["ct_gt"] other in
-      let* α1 := α0.["not"] in
-      let* α2 := self.["ct_eq"] other in
-      let* α3 := α2.["not"] in
-      α1.["bitand"] α3
+      (axiom
       : M (H := H) subtle.Choice);
   }.
 End ConstantTimeLess.

--- a/coq_translation/default/examples/functions/functions_closures_as_output_parameters.v
+++ b/coq_translation/default/examples/functions/functions_closures_as_output_parameters.v
@@ -31,8 +31,6 @@ Definition create_fnmut `{H : State.Trait} : M (H := H) OpaqueDef :=
         std.io.stdio._print α1 in
       Pure tt).
 
-Error OpaqueTy.
-
 Definition create_fnonce `{H : State.Trait} : M (H := H) OpaqueDef :=
   let* text := "FnOnce".["to_owned"] in
   Pure
@@ -46,8 +44,6 @@ Definition create_fnonce `{H : State.Trait} : M (H := H) OpaqueDef :=
             (addr_of [ α0 ]) in
         std.io.stdio._print α1 in
       Pure tt).
-
-Error OpaqueTy.
 
 (* #[allow(dead_code)] - function was ignored by the compiler *)
 Definition main `{H : State.Trait} : M (H := H) unit :=

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -10,6 +10,7 @@ inherits = "dev"
 [dependencies]
 chrono = "0.4.23"
 clap = { version = "4.1.4", features = ["derive", "env"] }
+itertools = "0.11.0"
 pretty = "0.11.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/lib/src/expression.rs
+++ b/lib/src/expression.rs
@@ -26,7 +26,7 @@ impl FreshVars {
 
 /// Struct [MatchArm] represents a pattern-matching branch: [pat] is the
 /// matched pattern and [body] the expression on which it is mapped
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct MatchArm {
     pat: Pattern,
     body: Expr,
@@ -34,14 +34,14 @@ pub struct MatchArm {
 
 /// [LoopControlFlow] represents the expressions responsible for
 /// the flow of control in a loop
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum LoopControlFlow {
     Continue,
     Break,
 }
 
 /// Enum [Expr] represents the AST of rust terms.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum Expr {
     Pure(Box<Expr>),
     LocalVar(String),
@@ -130,7 +130,7 @@ pub(crate) enum Expr {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum Stmt {
     Expr(Box<Expr>),
     Let {

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -143,7 +143,7 @@ pub(crate) fn compile_qpath(env: &Env, qpath: &QPath) -> Path {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum StructOrVariant {
     Struct,
     Variant,

--- a/lib/src/pattern.rs
+++ b/lib/src/pattern.rs
@@ -7,7 +7,7 @@ use rustc_hir::{ExprKind, Pat, PatKind, RangeEnd};
 use rustc_span::source_map::Spanned;
 
 /// The enum [Pat] represents the patterns which can be matched
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum Pattern {
     Wild,
     Variable(String),


### PR DESCRIPTION
Fixes https://github.com/formal-land/coq-of-rust/issues/172

We also make the definitions opaque in the AST with the axiom mode, instead of making them opaque when pretty-printing. This creates more duplicate definitions, what is useful when de-duplicating. It also avoids translating code in the AST when it will be ignored later, preventing potential errors there.