### PR TITLE
Fix State.Trait in DoubleColonType bug

### DIFF
--- a/CoqOfRust/ink/ink.v
+++ b/CoqOfRust/ink/ink.v
@@ -125,12 +125,7 @@ Module codegen.
           Type_ := Type_;
         }.
         
-        Global Instance
-            Method_Type_
-            `{H : State.Trait}
-            {Type_}
-            `(Trait
-            (Type_ := Type_))
+        Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
           : Notation.DoubleColonType Self "Type_" := {
           Notation.double_colon_type := Type_;
         }.
@@ -181,7 +176,6 @@ Module codegen.
       
       Global Instance
           Method_EnvAccess
-          `{H : State.Trait}
           {EnvAccess}
           `(Trait
           (EnvAccess := EnvAccess))
@@ -202,7 +196,6 @@ Module codegen.
       
       Global Instance
           Method_EnvAccess
-          `{H : State.Trait}
           {EnvAccess}
           `(Trait
           (EnvAccess := EnvAccess))
@@ -277,7 +270,6 @@ Module codegen.
         
         Global Instance
             Method_LenTopics
-            `{H : State.Trait}
             {LenTopics}
             `(Trait
             (LenTopics := LenTopics))
@@ -309,12 +301,7 @@ Module codegen.
             (mut_ref Self) -> (M (H := H) (mut_ref Builder));
         }.
         
-        Global Instance
-            Method_Builder
-            `{H : State.Trait}
-            {Builder}
-            `(Trait
-            (Builder := Builder))
+        Global Instance Method_Builder {Builder} `(Trait (Builder := Builder))
           : Notation.DoubleColonType Self "Builder" := {
           Notation.double_colon_type := Builder;
         }.
@@ -340,7 +327,6 @@ Module codegen.
         
         Global Instance
             Method_Forwarder
-            `{H : State.Trait}
             {Forwarder}
             `(Trait
             (Forwarder := Forwarder))
@@ -383,7 +369,6 @@ Module codegen.
         
         Global Instance
             Method_Forwarder
-            `{H : State.Trait}
             {Forwarder}
             `(Trait
             (Forwarder := Forwarder))
@@ -465,12 +450,7 @@ Module dispatch.
         Type_ := Type_;
       }.
       
-      Global Instance
-          Method_Type_
-          `{H : State.Trait}
-          {Type_}
-          `(Trait
-          (Type_ := Type_))
+      Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
         : Notation.DoubleColonType Self "Type_" := {
         Notation.double_colon_type := Type_;
       }.
@@ -532,12 +512,7 @@ Module info.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -549,12 +524,7 @@ Module ContractCallBuilder.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -635,7 +605,6 @@ Module env.
     
     Global Instance
         Method_EnvAccess
-        `{H : State.Trait}
         {EnvAccess}
         `(Trait
         (EnvAccess := EnvAccess))
@@ -656,7 +625,6 @@ Module env.
     
     Global Instance
         Method_EnvAccess
-        `{H : State.Trait}
         {EnvAccess}
         `(Trait
         (EnvAccess := EnvAccess))
@@ -676,12 +644,7 @@ Module Env.
     env `{H : State.Trait} : Self -> (M (H := H) EnvAccess);
   }.
   
-  Global Instance
-      Method_EnvAccess
-      `{H : State.Trait}
-      {EnvAccess}
-      `(Trait
-      (EnvAccess := EnvAccess))
+  Global Instance Method_EnvAccess {EnvAccess} `(Trait (EnvAccess := EnvAccess))
     : Notation.DoubleColonType Self "EnvAccess" := {
     Notation.double_colon_type := EnvAccess;
   }.
@@ -697,12 +660,7 @@ Module StaticEnv.
     env `{H : State.Trait} : (M (H := H) EnvAccess);
   }.
   
-  Global Instance
-      Method_EnvAccess
-      `{H : State.Trait}
-      {EnvAccess}
-      `(Trait
-      (EnvAccess := EnvAccess))
+  Global Instance Method_EnvAccess {EnvAccess} `(Trait (EnvAccess := EnvAccess))
     : Notation.DoubleColonType Self "EnvAccess" := {
     Notation.double_colon_type := EnvAccess;
   }.
@@ -773,7 +731,6 @@ Module event.
       
       Global Instance
           Method_LenTopics
-          `{H : State.Trait}
           {LenTopics}
           `(Trait
           (LenTopics := LenTopics))
@@ -862,7 +819,6 @@ Module topics.
     
     Global Instance
         Method_LenTopics
-        `{H : State.Trait}
         {LenTopics}
         `(Trait
         (LenTopics := LenTopics))
@@ -905,12 +861,7 @@ Module EventLenTopics.
     LenTopics := LenTopics;
   }.
   
-  Global Instance
-      Method_LenTopics
-      `{H : State.Trait}
-      {LenTopics}
-      `(Trait
-      (LenTopics := LenTopics))
+  Global Instance Method_LenTopics {LenTopics} `(Trait (LenTopics := LenTopics))
     : Notation.DoubleColonType Self "LenTopics" := {
     Notation.double_colon_type := LenTopics;
   }.
@@ -944,12 +895,7 @@ Module trait_def.
           (mut_ref Self) -> (M (H := H) (mut_ref Builder));
       }.
       
-      Global Instance
-          Method_Builder
-          `{H : State.Trait}
-          {Builder}
-          `(Trait
-          (Builder := Builder))
+      Global Instance Method_Builder {Builder} `(Trait (Builder := Builder))
         : Notation.DoubleColonType Self "Builder" := {
         Notation.double_colon_type := Builder;
       }.
@@ -975,7 +921,6 @@ Module trait_def.
       
       Global Instance
           Method_Forwarder
-          `{H : State.Trait}
           {Forwarder}
           `(Trait
           (Forwarder := Forwarder))
@@ -1014,7 +959,6 @@ Module trait_def.
       
       Global Instance
           Method_Forwarder
-          `{H : State.Trait}
           {Forwarder}
           `(Trait
           (Forwarder := Forwarder))
@@ -1064,12 +1008,7 @@ Module call_builder.
         (mut_ref Self) -> (M (H := H) (mut_ref Builder));
     }.
     
-    Global Instance
-        Method_Builder
-        `{H : State.Trait}
-        {Builder}
-        `(Trait
-        (Builder := Builder))
+    Global Instance Method_Builder {Builder} `(Trait (Builder := Builder))
       : Notation.DoubleColonType Self "Builder" := {
       Notation.double_colon_type := Builder;
     }.
@@ -1094,7 +1033,6 @@ Module call_builder.
     
     Global Instance
         Method_Forwarder
-        `{H : State.Trait}
         {Forwarder}
         `(Trait
         (Forwarder := Forwarder))
@@ -1132,7 +1070,6 @@ Module call_builder.
     
     Global Instance
         Method_Forwarder
-        `{H : State.Trait}
         {Forwarder}
         `(Trait
         (Forwarder := Forwarder))
@@ -1168,12 +1105,7 @@ Module TraitCallBuilder.
       (mut_ref Self) -> (M (H := H) (mut_ref Builder));
   }.
   
-  Global Instance
-      Method_Builder
-      `{H : State.Trait}
-      {Builder}
-      `(Trait
-      (Builder := Builder))
+  Global Instance Method_Builder {Builder} `(Trait (Builder := Builder))
     : Notation.DoubleColonType Self "Builder" := {
     Notation.double_colon_type := Builder;
   }.
@@ -1196,12 +1128,7 @@ Module TraitCallForwarder.
     Forwarder := Forwarder;
   }.
   
-  Global Instance
-      Method_Forwarder
-      `{H : State.Trait}
-      {Forwarder}
-      `(Trait
-      (Forwarder := Forwarder))
+  Global Instance Method_Forwarder {Forwarder} `(Trait (Forwarder := Forwarder))
     : Notation.DoubleColonType Self "Forwarder" := {
     Notation.double_colon_type := Forwarder;
   }.
@@ -1233,12 +1160,7 @@ Module TraitCallForwarderFor.
         (mut_ref ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder));
   }.
   
-  Global Instance
-      Method_Forwarder
-      `{H : State.Trait}
-      {Forwarder}
-      `(Trait
-      (Forwarder := Forwarder))
+  Global Instance Method_Forwarder {Forwarder} `(Trait (Forwarder := Forwarder))
     : Notation.DoubleColonType Self "Forwarder" := {
     Notation.double_colon_type := Forwarder;
   }.
@@ -1390,30 +1312,15 @@ Module reflect.
         LABEL `{H : State.Trait} : ref str;
       }.
       
-      Global Instance
-          Method_Input
-          `{H : State.Trait}
-          {Input}
-          `(Trait
-          (Input := Input))
+      Global Instance Method_Input {Input} `(Trait (Input := Input))
         : Notation.DoubleColonType Self "Input" := {
         Notation.double_colon_type := Input;
       }.
-      Global Instance
-          Method_Output
-          `{H : State.Trait}
-          {Output}
-          `(Trait
-          (Output := Output))
+      Global Instance Method_Output {Output} `(Trait (Output := Output))
         : Notation.DoubleColonType Self "Output" := {
         Notation.double_colon_type := Output;
       }.
-      Global Instance
-          Method_Storage
-          `{H : State.Trait}
-          {Storage}
-          `(Trait
-          (Storage := Storage))
+      Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
         : Notation.DoubleColonType Self "Storage" := {
         Notation.double_colon_type := Storage;
       }.
@@ -1458,39 +1365,19 @@ Module reflect.
         LABEL `{H : State.Trait} : ref str;
       }.
       
-      Global Instance
-          Method_Input
-          `{H : State.Trait}
-          {Input}
-          `(Trait
-          (Input := Input))
+      Global Instance Method_Input {Input} `(Trait (Input := Input))
         : Notation.DoubleColonType Self "Input" := {
         Notation.double_colon_type := Input;
       }.
-      Global Instance
-          Method_Storage
-          `{H : State.Trait}
-          {Storage}
-          `(Trait
-          (Storage := Storage))
+      Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
         : Notation.DoubleColonType Self "Storage" := {
         Notation.double_colon_type := Storage;
       }.
-      Global Instance
-          Method_Output
-          `{H : State.Trait}
-          {Output}
-          `(Trait
-          (Output := Output))
+      Global Instance Method_Output {Output} `(Trait (Output := Output))
         : Notation.DoubleColonType Self "Output" := {
         Notation.double_colon_type := Output;
       }.
-      Global Instance
-          Method_Error
-          `{H : State.Trait}
-          {Error}
-          `(Trait
-          (Error := Error))
+      Global Instance Method_Error {Error} `(Trait (Error := Error))
         : Notation.DoubleColonType Self "Error" := {
         Notation.double_colon_type := Error;
       }.
@@ -1544,12 +1431,7 @@ Module reflect.
         : Notation.Dot "IS_RESULT" := {
         Notation.dot := IS_RESULT;
       }.
-      Global Instance
-          Method_Error
-          `{H : State.Trait}
-          {Error}
-          `(Trait
-          (Error := Error))
+      Global Instance Method_Error {Error} `(Trait (Error := Error))
         : Notation.DoubleColonType Self "Error" := {
         Notation.double_colon_type := Error;
       }.
@@ -1585,12 +1467,7 @@ Module reflect.
         Type_ := Type_;
       }.
       
-      Global Instance
-          Method_Type_
-          `{H : State.Trait}
-          {Type_}
-          `(Trait
-          (Type_ := Type_))
+      Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
         : Notation.DoubleColonType Self "Type_" := {
         Notation.double_colon_type := Type_;
       }.
@@ -1606,12 +1483,7 @@ Module reflect.
         Type_ := Type_;
       }.
       
-      Global Instance
-          Method_Type_
-          `{H : State.Trait}
-          {Type_}
-          `(Trait
-          (Type_ := Type_))
+      Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
         : Notation.DoubleColonType Self "Type_" := {
         Notation.double_colon_type := Type_;
       }.
@@ -1670,12 +1542,7 @@ Module reflect.
         Type_ := Type_;
       }.
       
-      Global Instance
-          Method_Type_
-          `{H : State.Trait}
-          {Type_}
-          `(Trait
-          (Type_ := Type_))
+      Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
         : Notation.DoubleColonType Self "Type_" := {
         Notation.double_colon_type := Type_;
       }.
@@ -1787,30 +1654,15 @@ Module dispatch.
       LABEL `{H : State.Trait} : ref str;
     }.
     
-    Global Instance
-        Method_Input
-        `{H : State.Trait}
-        {Input}
-        `(Trait
-        (Input := Input))
+    Global Instance Method_Input {Input} `(Trait (Input := Input))
       : Notation.DoubleColonType Self "Input" := {
       Notation.double_colon_type := Input;
     }.
-    Global Instance
-        Method_Output
-        `{H : State.Trait}
-        {Output}
-        `(Trait
-        (Output := Output))
+    Global Instance Method_Output {Output} `(Trait (Output := Output))
       : Notation.DoubleColonType Self "Output" := {
       Notation.double_colon_type := Output;
     }.
-    Global Instance
-        Method_Storage
-        `{H : State.Trait}
-        {Storage}
-        `(Trait
-        (Storage := Storage))
+    Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
       : Notation.DoubleColonType Self "Storage" := {
       Notation.double_colon_type := Storage;
     }.
@@ -1855,39 +1707,19 @@ Module dispatch.
       LABEL `{H : State.Trait} : ref str;
     }.
     
-    Global Instance
-        Method_Input
-        `{H : State.Trait}
-        {Input}
-        `(Trait
-        (Input := Input))
+    Global Instance Method_Input {Input} `(Trait (Input := Input))
       : Notation.DoubleColonType Self "Input" := {
       Notation.double_colon_type := Input;
     }.
-    Global Instance
-        Method_Storage
-        `{H : State.Trait}
-        {Storage}
-        `(Trait
-        (Storage := Storage))
+    Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
       : Notation.DoubleColonType Self "Storage" := {
       Notation.double_colon_type := Storage;
     }.
-    Global Instance
-        Method_Output
-        `{H : State.Trait}
-        {Output}
-        `(Trait
-        (Output := Output))
+    Global Instance Method_Output {Output} `(Trait (Output := Output))
       : Notation.DoubleColonType Self "Output" := {
       Notation.double_colon_type := Output;
     }.
-    Global Instance
-        Method_Error
-        `{H : State.Trait}
-        {Error}
-        `(Trait
-        (Error := Error))
+    Global Instance Method_Error {Error} `(Trait (Error := Error))
       : Notation.DoubleColonType Self "Error" := {
       Notation.double_colon_type := Error;
     }.
@@ -1939,12 +1771,7 @@ Module dispatch.
       : Notation.Dot "IS_RESULT" := {
       Notation.dot := IS_RESULT;
     }.
-    Global Instance
-        Method_Error
-        `{H : State.Trait}
-        {Error}
-        `(Trait
-        (Error := Error))
+    Global Instance Method_Error {Error} `(Trait (Error := Error))
       : Notation.DoubleColonType Self "Error" := {
       Notation.double_colon_type := Error;
     }.
@@ -1980,12 +1807,7 @@ Module dispatch.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -2001,12 +1823,7 @@ Module dispatch.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -2079,30 +1896,15 @@ Module DispatchableMessageInfo.
     LABEL `{H : State.Trait} : ref str;
   }.
   
-  Global Instance
-      Method_Input
-      `{H : State.Trait}
-      {Input}
-      `(Trait
-      (Input := Input))
+  Global Instance Method_Input {Input} `(Trait (Input := Input))
     : Notation.DoubleColonType Self "Input" := {
     Notation.double_colon_type := Input;
   }.
-  Global Instance
-      Method_Output
-      `{H : State.Trait}
-      {Output}
-      `(Trait
-      (Output := Output))
+  Global Instance Method_Output {Output} `(Trait (Output := Output))
     : Notation.DoubleColonType Self "Output" := {
     Notation.double_colon_type := Output;
   }.
-  Global Instance
-      Method_Storage
-      `{H : State.Trait}
-      {Storage}
-      `(Trait
-      (Storage := Storage))
+  Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
     : Notation.DoubleColonType Self "Storage" := {
     Notation.double_colon_type := Storage;
   }.
@@ -2147,39 +1949,19 @@ Module DispatchableConstructorInfo.
     LABEL `{H : State.Trait} : ref str;
   }.
   
-  Global Instance
-      Method_Input
-      `{H : State.Trait}
-      {Input}
-      `(Trait
-      (Input := Input))
+  Global Instance Method_Input {Input} `(Trait (Input := Input))
     : Notation.DoubleColonType Self "Input" := {
     Notation.double_colon_type := Input;
   }.
-  Global Instance
-      Method_Storage
-      `{H : State.Trait}
-      {Storage}
-      `(Trait
-      (Storage := Storage))
+  Global Instance Method_Storage {Storage} `(Trait (Storage := Storage))
     : Notation.DoubleColonType Self "Storage" := {
     Notation.double_colon_type := Storage;
   }.
-  Global Instance
-      Method_Output
-      `{H : State.Trait}
-      {Output}
-      `(Trait
-      (Output := Output))
+  Global Instance Method_Output {Output} `(Trait (Output := Output))
     : Notation.DoubleColonType Self "Output" := {
     Notation.double_colon_type := Output;
   }.
-  Global Instance
-      Method_Error
-      `{H : State.Trait}
-      {Error}
-      `(Trait
-      (Error := Error))
+  Global Instance Method_Error {Error} `(Trait (Error := Error))
     : Notation.DoubleColonType Self "Error" := {
     Notation.double_colon_type := Error;
   }.
@@ -2238,12 +2020,7 @@ Module ConstructorOutput.
     : Notation.Dot "IS_RESULT" := {
     Notation.dot := IS_RESULT;
   }.
-  Global Instance
-      Method_Error
-      `{H : State.Trait}
-      {Error}
-      `(Trait
-      (Error := Error))
+  Global Instance Method_Error {Error} `(Trait (Error := Error))
     : Notation.DoubleColonType Self "Error" := {
     Notation.double_colon_type := Error;
   }.
@@ -2279,12 +2056,7 @@ Module ContractMessageDecoder.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -2300,12 +2072,7 @@ Module ContractConstructorDecoder.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -2361,12 +2128,7 @@ Module event.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -2378,12 +2140,7 @@ Module ContractEventBase.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -2564,12 +2321,7 @@ Module chain_extension.
       instantiate `{H : State.Trait} : (M (H := H) Instance);
     }.
     
-    Global Instance
-        Method_Instance
-        `{H : State.Trait}
-        {Instance}
-        `(Trait
-        (Instance := Instance))
+    Global Instance Method_Instance {Instance} `(Trait (Instance := Instance))
       : Notation.DoubleColonType Self "Instance" := {
       Notation.double_colon_type := Instance;
     }.
@@ -2590,7 +2342,6 @@ Module chain_extension.
     
     Global Instance
         Method_ErrorCode
-        `{H : State.Trait}
         {ErrorCode}
         `(Trait
         (ErrorCode := ErrorCode))
@@ -2609,11 +2360,11 @@ Module chain_extension.
       Err := Err;
     }.
     
-    Global Instance Method_Ok `{H : State.Trait} {Ok} `(Trait (Ok := Ok))
+    Global Instance Method_Ok {Ok} `(Trait (Ok := Ok))
       : Notation.DoubleColonType Self "Ok" := {
       Notation.double_colon_type := Ok;
     }.
-    Global Instance Method_Err `{H : State.Trait} {Err} `(Trait (Err := Err))
+    Global Instance Method_Err {Err} `(Trait (Err := Err))
       : Notation.DoubleColonType Self "Err" := {
       Notation.double_colon_type := Err;
     }.
@@ -2631,7 +2382,6 @@ Module chain_extension.
     
     Global Instance
         Method_ReturnType
-        `{H : State.Trait}
         {ReturnType}
         `(Trait
         (ReturnType := ReturnType))
@@ -2668,12 +2418,7 @@ Module ChainExtensionInstance.
     instantiate `{H : State.Trait} : (M (H := H) Instance);
   }.
   
-  Global Instance
-      Method_Instance
-      `{H : State.Trait}
-      {Instance}
-      `(Trait
-      (Instance := Instance))
+  Global Instance Method_Instance {Instance} `(Trait (Instance := Instance))
     : Notation.DoubleColonType Self "Instance" := {
     Notation.double_colon_type := Instance;
   }.
@@ -2692,12 +2437,7 @@ Module ChainExtension.
     ErrorCode := ErrorCode;
   }.
   
-  Global Instance
-      Method_ErrorCode
-      `{H : State.Trait}
-      {ErrorCode}
-      `(Trait
-      (ErrorCode := ErrorCode))
+  Global Instance Method_ErrorCode {ErrorCode} `(Trait (ErrorCode := ErrorCode))
     : Notation.DoubleColonType Self "ErrorCode" := {
     Notation.double_colon_type := ErrorCode;
   }.
@@ -2713,11 +2453,11 @@ Module IsResultType.
     Err := Err;
   }.
   
-  Global Instance Method_Ok `{H : State.Trait} {Ok} `(Trait (Ok := Ok))
+  Global Instance Method_Ok {Ok} `(Trait (Ok := Ok))
     : Notation.DoubleColonType Self "Ok" := {
     Notation.double_colon_type := Ok;
   }.
-  Global Instance Method_Err `{H : State.Trait} {Err} `(Trait (Err := Err))
+  Global Instance Method_Err {Err} `(Trait (Err := Err))
     : Notation.DoubleColonType Self "Err" := {
     Notation.double_colon_type := Err;
   }.
@@ -2735,7 +2475,6 @@ Module Output.
   
   Global Instance
       Method_ReturnType
-      `{H : State.Trait}
       {ReturnType}
       `(Trait
       (ReturnType := ReturnType))

--- a/CoqOfRust/ink/ink_env.v
+++ b/CoqOfRust/ink/ink_env.v
@@ -22,12 +22,7 @@ Module types.
       from_le_bytes `{H : State.Trait} : Bytes -> (M (H := H) Self);
     }.
     
-    Global Instance
-        Method_Bytes
-        `{H : State.Trait}
-        {Bytes}
-        `(Trait
-        (Bytes := Bytes))
+    Global Instance Method_Bytes {Bytes} `(Trait (Bytes := Bytes))
       : Notation.DoubleColonType Self "Bytes" := {
       Notation.double_colon_type := Bytes;
     }.
@@ -122,34 +117,22 @@ Module types.
     }.
     Global Instance
         Method_AccountId
-        `{H : State.Trait}
         {AccountId}
         `(Trait
         (AccountId := AccountId))
       : Notation.DoubleColonType Self "AccountId" := {
       Notation.double_colon_type := AccountId;
     }.
-    Global Instance
-        Method_Balance
-        `{H : State.Trait}
-        {Balance}
-        `(Trait
-        (Balance := Balance))
+    Global Instance Method_Balance {Balance} `(Trait (Balance := Balance))
       : Notation.DoubleColonType Self "Balance" := {
       Notation.double_colon_type := Balance;
     }.
-    Global Instance
-        Method_Hash
-        `{H : State.Trait}
-        {Hash}
-        `(Trait
-        (Hash := Hash))
+    Global Instance Method_Hash {Hash} `(Trait (Hash := Hash))
       : Notation.DoubleColonType Self "Hash" := {
       Notation.double_colon_type := Hash;
     }.
     Global Instance
         Method_Timestamp
-        `{H : State.Trait}
         {Timestamp}
         `(Trait
         (Timestamp := Timestamp))
@@ -158,7 +141,6 @@ Module types.
     }.
     Global Instance
         Method_BlockNumber
-        `{H : State.Trait}
         {BlockNumber}
         `(Trait
         (BlockNumber := BlockNumber))
@@ -167,7 +149,6 @@ Module types.
     }.
     Global Instance
         Method_ChainExtension
-        `{H : State.Trait}
         {ChainExtension}
         `(Trait
         (ChainExtension := ChainExtension))
@@ -209,12 +190,7 @@ Module FromLittleEndian.
     from_le_bytes `{H : State.Trait} : Bytes -> (M (H := H) Self);
   }.
   
-  Global Instance
-      Method_Bytes
-      `{H : State.Trait}
-      {Bytes}
-      `(Trait
-      (Bytes := Bytes))
+  Global Instance Method_Bytes {Bytes} `(Trait (Bytes := Bytes))
     : Notation.DoubleColonType Self "Bytes" := {
     Notation.double_colon_type := Bytes;
   }.
@@ -307,40 +283,24 @@ Module Environment.
     : Notation.Dot "MAX_EVENT_TOPICS" := {
     Notation.dot := MAX_EVENT_TOPICS;
   }.
-  Global Instance
-      Method_AccountId
-      `{H : State.Trait}
-      {AccountId}
-      `(Trait
-      (AccountId := AccountId))
+  Global Instance Method_AccountId {AccountId} `(Trait (AccountId := AccountId))
     : Notation.DoubleColonType Self "AccountId" := {
     Notation.double_colon_type := AccountId;
   }.
-  Global Instance
-      Method_Balance
-      `{H : State.Trait}
-      {Balance}
-      `(Trait
-      (Balance := Balance))
+  Global Instance Method_Balance {Balance} `(Trait (Balance := Balance))
     : Notation.DoubleColonType Self "Balance" := {
     Notation.double_colon_type := Balance;
   }.
-  Global Instance Method_Hash `{H : State.Trait} {Hash} `(Trait (Hash := Hash))
+  Global Instance Method_Hash {Hash} `(Trait (Hash := Hash))
     : Notation.DoubleColonType Self "Hash" := {
     Notation.double_colon_type := Hash;
   }.
-  Global Instance
-      Method_Timestamp
-      `{H : State.Trait}
-      {Timestamp}
-      `(Trait
-      (Timestamp := Timestamp))
+  Global Instance Method_Timestamp {Timestamp} `(Trait (Timestamp := Timestamp))
     : Notation.DoubleColonType Self "Timestamp" := {
     Notation.double_colon_type := Timestamp;
   }.
   Global Instance
       Method_BlockNumber
-      `{H : State.Trait}
       {BlockNumber}
       `(Trait
       (BlockNumber := BlockNumber))
@@ -349,7 +309,6 @@ Module Environment.
   }.
   Global Instance
       Method_ChainExtension
-      `{H : State.Trait}
       {ChainExtension}
       `(Trait
       (ChainExtension := ChainExtension))
@@ -2138,12 +2097,7 @@ Module call.
           Self -> F -> (M (H := H) Output);
       }.
       
-      Global Instance
-          Method_Output
-          `{H : State.Trait}
-          {Output}
-          `(Trait
-          (Output := Output))
+      Global Instance Method_Output {Output} `(Trait (Output := Output))
         : Notation.DoubleColonType Self "Output" := {
         Notation.double_colon_type := Output;
       }.
@@ -2196,21 +2150,11 @@ Module call.
         : Notation.Dot "IS_RESULT" := {
         Notation.dot := IS_RESULT;
       }.
-      Global Instance
-          Method_Output
-          `{H : State.Trait}
-          {Output}
-          `(Trait
-          (Output := Output))
+      Global Instance Method_Output {Output} `(Trait (Output := Output))
         : Notation.DoubleColonType Self "Output" := {
         Notation.double_colon_type := Output;
       }.
-      Global Instance
-          Method_Error
-          `{H : State.Trait}
-          {Error}
-          `(Trait
-          (Error := Error))
+      Global Instance Method_Error {Error} `(Trait (Error := Error))
         : Notation.DoubleColonType Self "Error" := {
         Notation.double_colon_type := Error;
       }.
@@ -2716,12 +2660,7 @@ Module common.
         Self -> F -> (M (H := H) Output);
     }.
     
-    Global Instance
-        Method_Output
-        `{H : State.Trait}
-        {Output}
-        `(Trait
-        (Output := Output))
+    Global Instance Method_Output {Output} `(Trait (Output := Output))
       : Notation.DoubleColonType Self "Output" := {
       Notation.double_colon_type := Output;
     }.
@@ -2791,12 +2730,7 @@ Module Unwrap.
       Self -> F -> (M (H := H) Output);
   }.
   
-  Global Instance
-      Method_Output
-      `{H : State.Trait}
-      {Output}
-      `(Trait
-      (Output := Output))
+  Global Instance Method_Output {Output} `(Trait (Output := Output))
     : Notation.DoubleColonType Self "Output" := {
     Notation.double_colon_type := Output;
   }.
@@ -2848,21 +2782,11 @@ Module create_builder.
       : Notation.Dot "IS_RESULT" := {
       Notation.dot := IS_RESULT;
     }.
-    Global Instance
-        Method_Output
-        `{H : State.Trait}
-        {Output}
-        `(Trait
-        (Output := Output))
+    Global Instance Method_Output {Output} `(Trait (Output := Output))
       : Notation.DoubleColonType Self "Output" := {
       Notation.double_colon_type := Output;
     }.
-    Global Instance
-        Method_Error
-        `{H : State.Trait}
-        {Error}
-        `(Trait
-        (Error := Error))
+    Global Instance Method_Error {Error} `(Trait (Error := Error))
       : Notation.DoubleColonType Self "Error" := {
       Notation.double_colon_type := Error;
     }.
@@ -3030,21 +2954,11 @@ Module ConstructorReturnType.
     : Notation.Dot "IS_RESULT" := {
     Notation.dot := IS_RESULT;
   }.
-  Global Instance
-      Method_Output
-      `{H : State.Trait}
-      {Output}
-      `(Trait
-      (Output := Output))
+  Global Instance Method_Output {Output} `(Trait (Output := Output))
     : Notation.DoubleColonType Self "Output" := {
     Notation.double_colon_type := Output;
   }.
-  Global Instance
-      Method_Error
-      `{H : State.Trait}
-      {Error}
-      `(Trait
-      (Error := Error))
+  Global Instance Method_Error {Error} `(Trait (Error := Error))
     : Notation.DoubleColonType Self "Error" := {
     Notation.double_colon_type := Error;
   }.
@@ -3396,11 +3310,11 @@ Module chain_extension.
       Err := Err;
     }.
     
-    Global Instance Method_Ok `{H : State.Trait} {Ok} `(Trait (Ok := Ok))
+    Global Instance Method_Ok {Ok} `(Trait (Ok := Ok))
       : Notation.DoubleColonType Self "Ok" := {
       Notation.double_colon_type := Ok;
     }.
-    Global Instance Method_Err `{H : State.Trait} {Err} `(Trait (Err := Err))
+    Global Instance Method_Err {Err} `(Trait (Err := Err))
       : Notation.DoubleColonType Self "Err" := {
       Notation.double_colon_type := Err;
     }.
@@ -3507,11 +3421,11 @@ Module IsResultType.
     Err := Err;
   }.
   
-  Global Instance Method_Ok `{H : State.Trait} {Ok} `(Trait (Ok := Ok))
+  Global Instance Method_Ok {Ok} `(Trait (Ok := Ok))
     : Notation.DoubleColonType Self "Ok" := {
     Notation.double_colon_type := Ok;
   }.
-  Global Instance Method_Err `{H : State.Trait} {Err} `(Trait (Err := Err))
+  Global Instance Method_Err {Err} `(Trait (Err := Err))
     : Notation.DoubleColonType Self "Err" := {
     Notation.double_colon_type := Err;
   }.
@@ -3543,7 +3457,7 @@ Module contract.
       Env := Env;
     }.
     
-    Global Instance Method_Env `{H : State.Trait} {Env} `(Trait (Env := Env))
+    Global Instance Method_Env {Env} `(Trait (Env := Env))
       : Notation.DoubleColonType Self "Env" := {
       Notation.double_colon_type := Env;
     }.
@@ -3554,12 +3468,7 @@ Module contract.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -3575,7 +3484,7 @@ Module ContractEnv.
     Env := Env;
   }.
   
-  Global Instance Method_Env `{H : State.Trait} {Env} `(Trait (Env := Env))
+  Global Instance Method_Env {Env} `(Trait (Env := Env))
     : Notation.DoubleColonType Self "Env" := {
     Notation.double_colon_type := Env;
   }.
@@ -3586,12 +3495,7 @@ Module ContractReference.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -4733,12 +4637,7 @@ Module hash.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -4807,12 +4706,7 @@ Module HashOutput.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
@@ -4895,12 +4789,7 @@ Module topics.
       output `{H : State.Trait} : Self -> (M (H := H) Output);
     }.
     
-    Global Instance
-        Method_Output
-        `{H : State.Trait}
-        {Output}
-        `(Trait
-        (Output := Output))
+    Global Instance Method_Output {Output} `(Trait (Output := Output))
       : Notation.DoubleColonType Self "Output" := {
       Notation.double_colon_type := Output;
     }.
@@ -4963,12 +4852,7 @@ Module topics.
       Next := Next;
     }.
     
-    Global Instance
-        Method_Next
-        `{H : State.Trait}
-        {Next}
-        `(Trait
-        (Next := Next))
+    Global Instance Method_Next {Next} `(Trait (Next := Next))
       : Notation.DoubleColonType Self "Next" := {
       Notation.double_colon_type := Next;
     }.
@@ -5005,7 +4889,6 @@ Module topics.
     
     Global Instance
         Method_RemainingTopics
-        `{H : State.Trait}
         {RemainingTopics}
         `(Trait
         (RemainingTopics := RemainingTopics))
@@ -5055,12 +4938,7 @@ Module TopicsBuilderBackend.
     output `{H : State.Trait} : Self -> (M (H := H) Output);
   }.
   
-  Global Instance
-      Method_Output
-      `{H : State.Trait}
-      {Output}
-      `(Trait
-      (Output := Output))
+  Global Instance Method_Output {Output} `(Trait (Output := Output))
     : Notation.DoubleColonType Self "Output" := {
     Notation.double_colon_type := Output;
   }.
@@ -5141,7 +5019,7 @@ Module SomeRemainingTopics.
     Next := Next;
   }.
   
-  Global Instance Method_Next `{H : State.Trait} {Next} `(Trait (Next := Next))
+  Global Instance Method_Next {Next} `(Trait (Next := Next))
     : Notation.DoubleColonType Self "Next" := {
     Notation.double_colon_type := Next;
   }.
@@ -5178,7 +5056,6 @@ Module Topics.
   
   Global Instance
       Method_RemainingTopics
-      `{H : State.Trait}
       {RemainingTopics}
       `(Trait
       (RemainingTopics := RemainingTopics))

--- a/CoqOfRust/ink/ink_storage_traits.v
+++ b/CoqOfRust/ink/ink_storage_traits.v
@@ -160,18 +160,12 @@ Module storage.
       PreferredKey := PreferredKey;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
     Global Instance
         Method_PreferredKey
-        `{H : State.Trait}
         {PreferredKey}
         `(Trait
         (PreferredKey := PreferredKey))
@@ -191,12 +185,7 @@ Module storage.
       Type_ := Type_;
     }.
     
-    Global Instance
-        Method_Type_
-        `{H : State.Trait}
-        {Type_}
-        `(Trait
-        (Type_ := Type_))
+    Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
       : Notation.DoubleColonType Self "Type_" := {
       Notation.double_colon_type := Type_;
     }.
@@ -289,18 +278,12 @@ Module StorableHint.
     PreferredKey := PreferredKey;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.
   Global Instance
       Method_PreferredKey
-      `{H : State.Trait}
       {PreferredKey}
       `(Trait
       (PreferredKey := PreferredKey))
@@ -320,12 +303,7 @@ Module AutoStorableHint.
     Type_ := Type_;
   }.
   
-  Global Instance
-      Method_Type_
-      `{H : State.Trait}
-      {Type_}
-      `(Trait
-      (Type_ := Type_))
+  Global Instance Method_Type_ {Type_} `(Trait (Type_ := Type_))
     : Notation.DoubleColonType Self "Type_" := {
     Notation.double_colon_type := Type_;
   }.

--- a/coq_translation/default/examples/generics/generics_associated_types_solution.v
+++ b/coq_translation/default/examples/generics/generics_associated_types_solution.v
@@ -31,11 +31,11 @@ Module Contains.
     a `{H : State.Trait} : (ref Self) -> (M (H := H) A);
   }.
   
-  Global Instance Method_A `{H : State.Trait} {A} `(Trait (A := A))
+  Global Instance Method_A {A} `(Trait (A := A))
     : Notation.DoubleColonType Self "A" := {
     Notation.double_colon_type := A;
   }.
-  Global Instance Method_B `{H : State.Trait} {B} `(Trait (B := B))
+  Global Instance Method_B {B} `(Trait (B := B))
     : Notation.DoubleColonType Self "B" := {
     Notation.double_colon_type := B;
   }.

--- a/coq_translation/default/examples/traits/traits_parms.v
+++ b/coq_translation/default/examples/traits/traits_parms.v
@@ -34,12 +34,7 @@ Module SomeTrait.
     some_fn `{H : State.Trait} : (M (H := H) unit);
   }.
   
-  Global Instance
-      Method_SomeType
-      `{H : State.Trait}
-      {SomeType}
-      `(Trait
-      (SomeType := SomeType))
+  Global Instance Method_SomeType {SomeType} `(Trait (SomeType := SomeType))
     : Notation.DoubleColonType Self "SomeType" := {
     Notation.double_colon_type := SomeType;
   }.

--- a/lib/src/render.rs
+++ b/lib/src/render.rs
@@ -457,6 +457,7 @@ pub(crate) fn trait_notation_instances(instances: Vec<Doc>) -> Doc {
 
 /// produces an instance of [Notation.Dot] or [Notation.DoubleColonType]
 pub(crate) fn new_instance<'a, U, V>(
+    is_monadic: bool,
     name: U,
     trait_parameters: &Vec<V>,
     kind: Doc<'a>,
@@ -468,7 +469,7 @@ where
     V: std::fmt::Display,
 {
     concat([
-        new_instance_header(name, trait_parameters, kind),
+        new_instance_header(is_monadic, name, trait_parameters, kind),
         nest([hardline(), new_instance_body(field, value)]),
         hardline(),
         text("}."),
@@ -477,6 +478,7 @@ where
 
 /// produces an instance of [Notation.Dot] or [Notation.DoubleColonType]
 pub(crate) fn new_instance_header<'a, U, V>(
+    is_monadic: bool,
     name: U,
     trait_parameters: &Vec<V>,
     kind: Doc<'a>,
@@ -490,8 +492,11 @@ where
             text("Global Instance"),
             line(),
             text(format!("Method_{name}")),
-            line(),
-            monadic_typeclass_parameter(),
+            if is_monadic {
+                concat([line(), monadic_typeclass_parameter()])
+            } else {
+                nil()
+            },
             line(),
             if trait_parameters.is_empty() {
                 text("`(Trait)")

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -2131,6 +2131,7 @@ impl TopLevelItem {
                     .map(|(name, item)| {
                         concat([match item {
                             TraitItem::Definition { .. } => new_instance::<_, String>(
+                                true,
                                 name,
                                 &vec![],
                                 text("Notation.Dot"),
@@ -2138,6 +2139,7 @@ impl TopLevelItem {
                                 text(name),
                             ),
                             TraitItem::Type { .. } => new_instance(
+                                true,
                                 name,
                                 &vec![name],
                                 group([text("Notation.DoubleColonType"), line(), text("Self")]),
@@ -2149,6 +2151,7 @@ impl TopLevelItem {
                                 where_predicates,
                                 signature_and_body,
                             } => new_instance::<_, String>(
+                                true,
                                 name,
                                 &vec![],
                                 text("Notation.Dot"),

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -2139,7 +2139,7 @@ impl TopLevelItem {
                                 text(name),
                             ),
                             TraitItem::Type { .. } => new_instance(
-                                true,
+                                false,
                                 name,
                                 &vec![name],
                                 group([text("Notation.DoubleColonType"), line(), text("Self")]),


### PR DESCRIPTION
Fixes the problem with `State.Trait` parameters appearing in instances of `Notation.DoubleColonType`.