### PR TITLE
More for erc20.v

### DIFF
--- a/CoqOfRust/CoqOfRust.v
+++ b/CoqOfRust/CoqOfRust.v
@@ -520,11 +520,15 @@ Module core.
   Module ops.
     Module arith.
       Module Add.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           add `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_add `{State.Trait} `(Trait) :
           Notation.Dot "add" := {
@@ -533,10 +537,14 @@ Module core.
       End Add.
 
       Module AddAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           add_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_add_assign `{State.Trait} `(Trait) :
           Notation.Dot "add_assign" := {
@@ -545,11 +553,15 @@ Module core.
       End AddAssign.
 
       Module Sub.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           sub `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_sub `{State.Trait} `(Trait) :
           Notation.Dot "sub" := {
@@ -558,10 +570,14 @@ Module core.
       End Sub.
 
       Module SubAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           sub_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_sub_assign `{State.Trait} `(Trait) :
           Notation.Dot "sub_assign" := {
@@ -570,11 +586,15 @@ Module core.
       End SubAssign.
 
       Module Mul.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           mul `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_mul `{State.Trait} `(Trait) :
           Notation.Dot "mul" := {
@@ -583,10 +603,14 @@ Module core.
       End Mul.
 
       Module MulAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           mul_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_mul_assign `{State.Trait} `(Trait) :
           Notation.Dot "mul_assign" := {
@@ -595,11 +619,15 @@ Module core.
       End MulAssign.
 
       Module Div.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           div `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_div `{State.Trait} `(Trait) :
           Notation.Dot "div" := {
@@ -608,10 +636,14 @@ Module core.
       End Div.
 
       Module DivAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           div_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_div_assign `{State.Trait} `(Trait) :
           Notation.Dot "div_assign" := {
@@ -620,11 +652,15 @@ Module core.
       End DivAssign.
 
       Module Rem.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           rem `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_rem `{State.Trait} `(Trait) :
           Notation.Dot "rem" := {
@@ -633,10 +669,14 @@ Module core.
       End Rem.
 
       Module RemAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           rem_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_rem_assign `{State.Trait} `(Trait) :
           Notation.Dot "rem_assign" := {
@@ -645,11 +685,15 @@ Module core.
       End RemAssign.
 
       Module BitXor.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           bitxor `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitxor `{State.Trait} `(Trait) :
           Notation.Dot "bitxor" := {
@@ -658,10 +702,14 @@ Module core.
       End BitXor.
 
       Module BitXorAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           bitxor_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitxor_assign `{State.Trait} `(Trait) :
           Notation.Dot "bitxor_assign" := {
@@ -670,11 +718,15 @@ Module core.
       End BitXorAssign.
 
       Module BitAnd.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           bitand `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitand `{State.Trait} `(Trait) :
           Notation.Dot "bitand" := {
@@ -683,10 +735,14 @@ Module core.
       End BitAnd.
 
       Module BitAndAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           bitand_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitand_assign `{State.Trait} `(Trait) :
           Notation.Dot "bitand_assign" := {
@@ -695,11 +751,15 @@ Module core.
       End BitAndAssign.
 
       Module BitOr.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           bitor `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitor `{State.Trait} `(Trait) :
           Notation.Dot "bitor" := {
@@ -708,10 +768,14 @@ Module core.
       End BitOr.
 
       Module BitOrAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           bitor_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_bitor_assign `{State.Trait} `(Trait) :
           Notation.Dot "bitor_assign" := {
@@ -720,11 +784,15 @@ Module core.
       End BitOrAssign.
 
       Module Shl.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           shl `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_shl `{State.Trait} `(Trait) :
           Notation.Dot "shl" := {
@@ -733,10 +801,14 @@ Module core.
       End Shl.
 
       Module ShlAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           shl_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_shl_assign `{State.Trait} `(Trait) :
           Notation.Dot "shl_assign" := {
@@ -745,11 +817,15 @@ Module core.
       End ShlAssign.
 
       Module Shr.
-        Class Trait (Self : Set) {Rhs : option Set} : Type := {
+        Class Trait (Self : Set) {Rhs : Set} : Type := {
           Output : Set;
-          Rhs := defaultType Rhs Self;
+          Rhs := Rhs;
           shr `{State.Trait} : Self -> Rhs -> M Output;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_shr `{State.Trait} `(Trait) :
           Notation.Dot "shr" := {
@@ -758,10 +834,14 @@ Module core.
       End Shr.
 
       Module ShrAssign.
-        Class Trait (Self : Set) {Rhs : option Set} : Set := {
-          Rhs := defaultType Rhs Self;
+        Class Trait (Self : Set) {Rhs : Set} : Set := {
+          Rhs := Rhs;
           shr_assign `{State.Trait} : mut_ref Self -> Rhs -> M unit;
         }.
+
+        Module Default.
+          Definition Rhs (Self : Set) : Set := Self.
+        End Default.
 
         Global Instance Method_shr_assign `{State.Trait} `(Trait) :
           Notation.Dot "shr_assign" := {
@@ -832,7 +912,7 @@ Module core.
         Notation.dot := add;
       }.
 
-      Global Instance Add_for_Z : arith.Add.Trait Z (Rhs := None) := {
+      Global Instance Add_for_Z : arith.Add.Trait Z (Rhs := arith.Add.Default.Rhs Z) := {
         add `{State.Trait} := add;
       }.
     End Impl_Add_for_Z.
@@ -846,7 +926,7 @@ Module core.
       }.
 
       Global Instance AddAssign_for_Z :
-        arith.AddAssign.Trait Z (Rhs := None) := {
+        arith.AddAssign.Trait Z (Rhs := Z) := {
         add_assign `{State.Trait} := add_assign;
       }.
     End Impl_AddAssign_for_Z.
@@ -858,7 +938,7 @@ Module core.
         Notation.dot := sub;
       }.
 
-      Global Instance Sub_for_Z : arith.Sub.Trait Z (Rhs := None) := {
+      Global Instance Sub_for_Z : arith.Sub.Trait Z (Rhs := Z) := {
         sub `{State.Trait} := sub;
       }.
     End Impl_Sub_for_Z.
@@ -872,7 +952,7 @@ Module core.
       }.
 
       Global Instance SubAssign_for_Z :
-        arith.SubAssign.Trait Z (Rhs := None) := {
+        arith.SubAssign.Trait Z (Rhs := Z) := {
         sub_assign `{State.Trait} := sub_assign;
       }.
     End Impl_SubAssign_for_Z.
@@ -884,7 +964,7 @@ Module core.
         Notation.dot := mul;
       }.
 
-      Global Instance Mul_for_Z : arith.Mul.Trait Z (Rhs := None) := {
+      Global Instance Mul_for_Z : arith.Mul.Trait Z (Rhs := Z) := {
         mul `{State.Trait} := mul;
       }.
     End Impl_Mul_for_Z.
@@ -898,7 +978,7 @@ Module core.
       }.
 
       Global Instance MulAssign_for_Z :
-        arith.MulAssign.Trait Z (Rhs := None) := {
+        arith.MulAssign.Trait Z (Rhs := Z) := {
         mul_assign `{State.Trait} := mul_assign;
       }.
     End Impl_MulAssign_for_Z.
@@ -910,7 +990,7 @@ Module core.
         Notation.dot := div;
       }.
 
-      Global Instance Div_for_Z : arith.Div.Trait Z (Rhs := None) := {
+      Global Instance Div_for_Z : arith.Div.Trait Z (Rhs := Z) := {
         div `{State.Trait} := div;
       }.
     End Impl_Div_for_Z.
@@ -924,7 +1004,7 @@ Module core.
       }.
 
       Global Instance DivAssign_for_Z :
-        arith.DivAssign.Trait Z (Rhs := None) := {
+        arith.DivAssign.Trait Z (Rhs := Z) := {
         div_assign `{State.Trait} := div_assign;
       }.
     End Impl_DivAssign_for_Z.
@@ -936,7 +1016,7 @@ Module core.
         Notation.dot := rem;
       }.
 
-      Global Instance Rem_for_Z : arith.Rem.Trait Z (Rhs := None) := {
+      Global Instance Rem_for_Z : arith.Rem.Trait Z (Rhs := Z) := {
         rem `{State.Trait} := rem;
       }.
     End Impl_Rem_for_Z.
@@ -950,7 +1030,7 @@ Module core.
       }.
 
       Global Instance RemAssign_for_Z :
-        arith.RemAssign.Trait Z (Rhs := None) := {
+        arith.RemAssign.Trait Z (Rhs := Z) := {
         rem_assign `{State.Trait} := rem_assign;
       }.
     End Impl_RemAssign_for_Z.
@@ -1329,12 +1409,6 @@ Module _crate.
         assert_receiver_is_total_eq `{State.Trait} : ref Self -> M unit;
       }.
     End Eq.
-
-    Module PartialEq.
-      Class Trait (Self : Set) : Set := {
-        eq `{State.Trait} : ref Self -> ref Self -> M bool;
-      }.
-    End PartialEq.
   End cmp.
 
   Module fmt := core.fmt.

--- a/CoqOfRust/_std/ops.v
+++ b/CoqOfRust/_std/ops.v
@@ -267,8 +267,8 @@ Module RangeBounds.
     start_bound : ref Self -> Bound (ref T);
     end_bound : ref Self -> Bound (ref T);
     contains (U : Set) {T : Set}
-      `{PartialOrd.Trait U (Some T)}
-      `{PartialOrd.Trait T (Some U)}
+      `{PartialOrd.Trait U (Rhs := T)}
+      `{PartialOrd.Trait T (Rhs := U)}
       : ref Self -> ref U -> bool;
   }.
 End RangeBounds.

--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -116,7 +116,6 @@ examples/subtle.v
 examples/testing/documentation_testing.v
 examples/traits/clone.v
 examples/traits/derive.v
-examples/traits/disambiguating_overlapping_traits.v
 examples/traits/drop.v
 examples/traits/hash.v
 examples/traits/impl_trait_as_return_type.v

--- a/CoqOfRust/core/borrow.v
+++ b/CoqOfRust/core/borrow.v
@@ -54,7 +54,7 @@ pub trait ToOwned {
 Module ToOwned.
   Class Trait (Self Owned : Set) 
     `{Borrow.Trait Owned Self}
-  : Set := { 
+  : Set := {
     Owned := Owned;
 
     to_owned : ref Self -> Owned;

--- a/CoqOfRust/core/clone.v
+++ b/CoqOfRust/core/clone.v
@@ -18,6 +18,10 @@ Module Clone.
     clone `{H : State.Trait} : ref Self -> M (H := H) Self;
   }.
 
+  Global Instance Method_clone `{State.Trait} `(Trait) : Notation.Dot "clone" := {
+    Notation.dot := clone;
+  }.
+
   Module Impl_Clone_for_str.
     Global Instance I : Trait str. Admitted.
   End Impl_Clone_for_str.

--- a/CoqOfRust/core/cmp.v
+++ b/CoqOfRust/core/cmp.v
@@ -32,11 +32,15 @@ Traits
 [x] PartialOrd
 *)
 Module PartialEq.
-  Class Trait (Self : Set) {Rhs : option Set} : Set := {
-    Rhs := defaultType Rhs Self;
+  Class Trait (Self : Set) {Rhs : Set} : Set := {
+    Rhs := Rhs;
 
     eq `{State.Trait} : ref Self -> ref Rhs -> M bool;
   }.
+
+  Module Default.
+    Definition Rhs (Self : Set) : Set := Self.
+  End Default.
 
   Global Instance Method_eq `{State.Trait} `(Trait) : Notation.Dot "eq" := {
     Notation.dot := eq;
@@ -48,13 +52,13 @@ Module PartialEq.
   }.
 
   Module Impl_PartialEq_for_str.
-    Global Instance I : Trait str (Rhs := None). Admitted.
+    Global Instance I : Trait str (Rhs := Default.Rhs str). Admitted.
   End Impl_PartialEq_for_str.
 End PartialEq.
 
 Module PartialOrd.
-  Class Trait (Self : Set) (Rhs : option Set) : Set := {
-    Rhs := defaultType Rhs Self;
+  Class Trait (Self : Set) {Rhs : Set} : Set := {
+    Rhs := Rhs;
     partial_cmp `{State.Trait} :
       ref Self -> ref Self -> M (core.option.Option (Ordering.t));
 
@@ -63,6 +67,10 @@ Module PartialOrd.
     gt `{State.Trait} : ref Self -> ref Rhs -> M bool;
     ge `{State.Trait} : ref Self -> ref Rhs -> M bool; *)
   }.
+
+  Module Default.
+    Definition Rhs (Self : Set) : Set := Self.
+  End Default.
 
   Global Instance Method_partial_cmp `{State.Trait} `(Trait) :
     Notation.Dot "partial_cmp" := {
@@ -81,8 +89,7 @@ Module PartialOrd.
     Notation.dot := ge;
   }. *)
   Module Impl_PartialOrd_for_str.
-    Global Instance I : Trait str None. Admitted.
-    Global Instance I' : Trait str (Some str). Admitted.
+    Global Instance I : Trait str (Rhs := str). Admitted.
   End Impl_PartialOrd_for_str.
 End PartialOrd.
 
@@ -91,7 +98,8 @@ pub trait Eq: PartialEq<Self> { }
  *)
 Module Eq.
   Unset Primitive Projections.
-  Class Trait (Self : Set) `{PartialEq.Trait Self (Rhs := None)} : Set := { }.
+  Class Trait (Self : Set)
+    `{PartialEq.Trait Self (Rhs := PartialEq.Default.Rhs Self)} : Set := { }.
   Set Primitive Projections.
 
   Module Impl_Eq_for_str.
@@ -116,11 +124,11 @@ pub trait Ord: Eq + PartialOrd<Self> {
 Module Ord.
   Class Trait (Self : Set) 
     `{Eq.Trait Self}
-    `{PartialOrd.Trait Self (Some Self)} :={
+    `{PartialOrd.Trait Self (Rhs := Self)} :={
     cmp : ref Self -> ref Self -> Ordering;
     max : Self -> Self -> Self;
     min : Self -> Self -> Self;
-    clamp `{PartialOrd.Trait Self (Some Self)} : Self -> Self -> Self;
+    clamp `{PartialOrd.Trait Self (Rhs := Self)} : Self -> Self -> Self;
 
     }.
 
@@ -159,7 +167,8 @@ Module Impls.
   Module Impl_PartialEq_for_unit.
     Definition eq `{State.Trait} (x y : unit) : M bool := Pure true.
 
-    Global Instance I : PartialEq.Trait unit (Rhs := None) := {
+    Global Instance I :
+      PartialEq.Trait unit (Rhs := PartialEq.Default.Rhs unit) := {
       eq `{State.Trait} := eq;
     }.
   End Impl_PartialEq_for_unit.

--- a/CoqOfRust/core/result_impl.v
+++ b/CoqOfRust/core/result_impl.v
@@ -15,7 +15,7 @@ Module Impl_PartialEq_for_Result.
 
     Global Instance I
       {T E : Set} `{core.cmp.PartialEq.Trait T} `{core.cmp.PartialEq.Trait E} :
-      core.cmp.PartialEq.Trait (Result T E) (Rhs := None) := {
+      core.cmp.PartialEq.Trait (Result T E) (Rhs := _) := {
       eq `{State.Trait} := eq (T := T) (E := E);
     }.
 

--- a/CoqOfRust/ink/erc20.v
+++ b/CoqOfRust/ink/erc20.v
@@ -3,51 +3,7 @@ Require Import CoqOfRust.CoqOfRust.
 
 Require CoqOfRust.ink.ink_storage.
 Require CoqOfRust.ink.ink_env.
-(* @TODO Require CoqOfRust.ink.ink. *)
-
-(** @TODO [erc20] dependencies which are WIP *)
-
-Module ink.
-  Module codegen.
-    Module event.
-      Module topics.
-        Module EventTopics.
-          Parameter t : Set.
-        End EventTopics.
-        Module EventLenTopics.
-          Class Trait (Self : Set) : Type := {
-              LenTopics : Set;
-            }.
-        End EventLenTopics.
-        Definition EventTopics := EventTopics.t.
-      End topics.
-    End event.
-  End codegen.
-  Module reflect.
-    Module dispatch.
-      Module ConstructorOutput.
-        Parameter Error : Set.
-        Definition IS_RESULT : bool. Admitted.
-      End ConstructorOutput.
-
-      Module DispatchableConstructorInfo.
-        Class Trait (Self : Set) := {
-
-            Input : Set;
-            Storage : Set;
-            Output : Set;
-            Error : Set;
-            IS_RESULT `{H' : State.Trait} : M bool;
-            CALLABLE `{H' : State.Trait} : M (unit -> M Self);
-            PAYABLE `{H' : State.Trait} : M bool;
-            SELECTOR `{H' : State.Trait} : M (list Z);
-            LABEL `{H' : State.Trait} : M string;
-          }.
-      End DispatchableConstructorInfo.
-    End dispatch.
-  End reflect.
-End ink.
-
+Require CoqOfRust.ink.ink.
 
 
 Module erc20.
@@ -63,11 +19,21 @@ Module erc20.
     Global Instance Get_total_supply : Notation.Dot "total_supply" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_total_supply
+      : Notation.DoubleColon t "total_supply" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_balances : Notation.Dot "balances" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_balances : Notation.DoubleColon t "balances" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_allowances : Notation.Dot "allowances" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_allowances : Notation.DoubleColon t "allowances" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
     Global Instance Erc20_New `{State.Trait} : Notation.DoubleColon t "new" (T := unit -> M t).
     Admitted.
@@ -152,11 +118,20 @@ Module erc20.
     Global Instance Get_from : Notation.Dot "from" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_from : Notation.DoubleColon t "from" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_to : Notation.Dot "to" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_to : Notation.DoubleColon t "to" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End Transfer.
   Definition Transfer : Set := Transfer.t.
@@ -173,11 +148,20 @@ Module erc20.
     Global Instance Get_owner : Notation.Dot "owner" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_owner : Notation.DoubleColon t "owner" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_spender : Notation.Dot "spender" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_spender : Notation.DoubleColon t "spender" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End Approval.
   Definition Approval : Set := Approval.t.
@@ -745,6 +729,9 @@ Module erc20.
     
     Global Instance Get_inner : Notation.Dot "inner" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_inner : Notation.DoubleColon t "inner" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End Erc20Ref.
   Definition Erc20Ref : Set := Erc20Ref.t.
@@ -1442,14 +1429,26 @@ Module Check.
   Global Instance Get_salt : Notation.Dot "salt" := {
     Notation.dot '(Build_t x0 _ _ _) := x0;
   }.
+  Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+    Notation.double_colon '(Build_t x0 _ _ _) := x0;
+  }.
   Global Instance Get_field_0 : Notation.Dot "field_0" := {
     Notation.dot '(Build_t _ x1 _ _) := x1;
+  }.
+  Global Instance Get_AF_field_0 : Notation.DoubleColon t "field_0" := {
+    Notation.double_colon '(Build_t _ x1 _ _) := x1;
   }.
   Global Instance Get_field_1 : Notation.Dot "field_1" := {
     Notation.dot '(Build_t _ _ x2 _) := x2;
   }.
+  Global Instance Get_AF_field_1 : Notation.DoubleColon t "field_1" := {
+    Notation.double_colon '(Build_t _ _ x2 _) := x2;
+  }.
   Global Instance Get_field_2 : Notation.Dot "field_2" := {
     Notation.dot '(Build_t _ _ _ x3) := x3;
+  }.
+  Global Instance Get_AF_field_2 : Notation.DoubleColon t "field_2" := {
+    Notation.double_colon '(Build_t _ _ _ x3) := x3;
   }.
 End Check.
 Definition Check : Set := Check.t.
@@ -1466,11 +1465,21 @@ Module Erc20.
   Global Instance Get_total_supply : Notation.Dot "total_supply" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_total_supply
+    : Notation.DoubleColon t "total_supply" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_balances : Notation.Dot "balances" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_balances : Notation.DoubleColon t "balances" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_allowances : Notation.Dot "allowances" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_allowances : Notation.DoubleColon t "allowances" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Erc20.
 Definition Erc20 : Set := Erc20.t.
@@ -2101,11 +2110,20 @@ Module Transfer.
   Global Instance Get_from : Notation.Dot "from" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_from : Notation.DoubleColon t "from" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_to : Notation.Dot "to" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_to : Notation.DoubleColon t "to" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Transfer.
 Definition Transfer : Set := Transfer.t.
@@ -2221,11 +2239,20 @@ Module Approval.
   Global Instance Get_owner : Notation.Dot "owner" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_owner : Notation.DoubleColon t "owner" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_spender : Notation.Dot "spender" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_spender : Notation.DoubleColon t "spender" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Approval.
 Definition Approval : Set := Approval.t.
@@ -4041,6 +4068,9 @@ Module CallBuilder.
   Global Instance Get_account_id : Notation.Dot "account_id" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_account_id : Notation.DoubleColon t "account_id" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End CallBuilder.
 Definition CallBuilder : Set := CallBuilder.t.
 
@@ -4767,6 +4797,9 @@ Module Erc20Ref.
   
   Global Instance Get_inner : Notation.Dot "inner" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_inner : Notation.DoubleColon t "inner" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End Erc20Ref.
 Definition Erc20Ref : Set := Erc20Ref.t.

--- a/CoqOfRust/ink/erc20.v
+++ b/CoqOfRust/ink/erc20.v
@@ -9,9 +9,22 @@ Module erc20.
   Module Erc20.
     Unset Primitive Projections.
     Record t : Set := {
-      total_supply `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
-      balances `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
-      allowances `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
+      total_supply
+        :
+        ink_storage_traits.storage.AutoStorableHint.Type_
+          (Self := erc20.erc20.Balance);
+      balances
+        :
+        ink_storage_traits.storage.AutoStorableHint.Type_
+          (Self := ink_storage.lazy.mapping.Mapping
+            erc20.erc20.AccountId
+            erc20.erc20.Balance);
+      allowances
+        :
+        ink_storage_traits.storage.AutoStorableHint.Type_
+          (Self := ink_storage.lazy.mapping.Mapping
+            (erc20.erc20.AccountId * erc20.erc20.AccountId)
+            erc20.erc20.Balance);
     }.
     Global Set Primitive Projections.
     
@@ -57,25 +70,39 @@ Module erc20.
     Global Hint Resolve I : core.
   End Impl_ink_env_contract_ContractEnv_for_erc20_erc20_Erc20.
   
-  Definition Environment : Set := ink_env.contract.ContractEnv.Env.
+  Definition Environment : Set :=
+    ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20).
   
-  Definition AccountId : Set := ink_env.types.Environment.AccountId.
+  Definition AccountId : Set :=
+    ink_env.types.Environment.AccountId
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
-  Definition Balance : Set := ink_env.types.Environment.Balance.
+  Definition Balance : Set :=
+    ink_env.types.Environment.Balance
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
-  Definition Hash : Set := ink_env.types.Environment.Hash.
+  Definition Hash : Set :=
+    ink_env.types.Environment.Hash
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
-  Definition Timestamp : Set := ink_env.types.Environment.Timestamp.
+  Definition Timestamp : Set :=
+    ink_env.types.Environment.Timestamp
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
-  Definition BlockNumber : Set := ink_env.types.Environment.BlockNumber.
+  Definition BlockNumber : Set :=
+    ink_env.types.Environment.BlockNumber
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
-  Definition ChainExtension : Set := ink_env.types.Environment.ChainExtension.
+  Definition ChainExtension : Set :=
+    ink_env.types.Environment.ChainExtension
+      (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
   Definition MAX_EVENT_TOPICS `{H' : State.Trait} : usize :=
     run
       (Pure
         (ink_env.types.Environment.MAX_EVENT_TOPICS
-          (Self := ink_env.contract.ContractEnv.Env))).
+          (Self :=
+            (ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20))))).
   
   Module Impl_core_default_Default_for_erc20_erc20_Erc20.
     Definition Self := erc20.erc20.Erc20.
@@ -207,7 +234,9 @@ Module erc20.
     
     Definition Storage : Set := erc20.erc20.Erc20.
     
-    Definition Error : Set := ink.reflect.dispatch.ConstructorOutput.Error.
+    Definition Error : Set :=
+      ink.reflect.dispatch.ConstructorOutput.Error
+        (Self := ink.reflect.dispatch.ConstructorOutputValue Self).
     
     Definition
       IS_RESULT
@@ -735,7 +764,10 @@ Module erc20.
   Module Erc20Ref.
     Unset Primitive Projections.
     Record t : Set := {
-      inner : ink.codegen.dispatch.info.ContractCallBuilder.Type_;
+      inner
+        :
+        ink.codegen.dispatch.info.ContractCallBuilder.Type_
+          (Self := erc20.erc20.Erc20);
     }.
     Global Set Primitive Projections.
     
@@ -755,7 +787,8 @@ Module erc20.
         core.fmt.Formatter ->
           string ->
             string ->
-            ink_codegen_dispatch_info_ContractCallBuilder_Type_ ->
+            erc20_erc20_Erc20_ink_codegen_dispatch_info_ContractCallBuilder_Type_
+            ->
             M (H := H') core.fmt.Result.
     
     Global Instance Deb_debug_struct_field1_finish : Notation.DoubleColon
@@ -856,7 +889,8 @@ Module erc20.
       let
           _ :
           core.cmp.AssertParamIsEq
-            ink.codegen.dispatch.info.ContractCallBuilder.Type_ :=
+            (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+              (Self := erc20.erc20.Erc20)) :=
         tt in
       Pure tt.
     
@@ -1227,7 +1261,9 @@ Module erc20.
         : M (H := H') Self :=
       let* α0 :=
         (ink_env.call.create_builder.FromAccountId.from_account_id
-            (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+            (Self :=
+              (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+                (Self := erc20.erc20.Erc20))))
           account_id in
       Pure {| Self.inner := α0; |}.
     
@@ -1256,7 +1292,9 @@ Module erc20.
         (self : ref Self)
         : M (H := H') erc20.erc20.AccountId :=
       (ink.contract_ref.ToAccountId.to_account_id
-          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+          (Self :=
+            (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+              (Self := erc20.erc20.Erc20))))
         (addr_of self.["inner"]).
     
     Global Instance Method_to_account_id `{H' : State.Trait} :
@@ -1425,25 +1463,39 @@ Module Impl_ink_env_contract_ContractEnv_for_erc20_erc20_Erc20.
   Global Hint Resolve I : core.
 End Impl_ink_env_contract_ContractEnv_for_erc20_erc20_Erc20.
 
-Definition Environment : Set := ink_env.contract.ContractEnv.Env.
+Definition Environment : Set :=
+  ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20).
 
-Definition AccountId : Set := ink_env.types.Environment.AccountId.
+Definition AccountId : Set :=
+  ink_env.types.Environment.AccountId
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
-Definition Balance : Set := ink_env.types.Environment.Balance.
+Definition Balance : Set :=
+  ink_env.types.Environment.Balance
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
-Definition Hash : Set := ink_env.types.Environment.Hash.
+Definition Hash : Set :=
+  ink_env.types.Environment.Hash
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
-Definition Timestamp : Set := ink_env.types.Environment.Timestamp.
+Definition Timestamp : Set :=
+  ink_env.types.Environment.Timestamp
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
-Definition BlockNumber : Set := ink_env.types.Environment.BlockNumber.
+Definition BlockNumber : Set :=
+  ink_env.types.Environment.BlockNumber
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
-Definition ChainExtension : Set := ink_env.types.Environment.ChainExtension.
+Definition ChainExtension : Set :=
+  ink_env.types.Environment.ChainExtension
+    (Self := ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
 
 Definition MAX_EVENT_TOPICS `{H' : State.Trait} : usize :=
   run
     (Pure
       (ink_env.types.Environment.MAX_EVENT_TOPICS
-        (Self := ink_env.contract.ContractEnv.Env))).
+        (Self :=
+          (ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20))))).
 
 Module Check.
   Unset Primitive Projections.
@@ -1493,9 +1545,22 @@ Definition Check : Set := Check.t.
 Module Erc20.
   Unset Primitive Projections.
   Record t : Set := {
-    total_supply `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
-    balances `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
-    allowances `{ink_storage_traits.storage.AutoStorableHint.Trait} : ink_storage_traits.storage.AutoStorableHint.Type_;
+    total_supply
+      :
+      ink_storage_traits.storage.AutoStorableHint.Type_
+        (Self := erc20.erc20.Balance);
+    balances
+      :
+      ink_storage_traits.storage.AutoStorableHint.Type_
+        (Self := ink_storage.lazy.mapping.Mapping
+          erc20.erc20.AccountId
+          erc20.erc20.Balance);
+    allowances
+      :
+      ink_storage_traits.storage.AutoStorableHint.Type_
+        (Self := ink_storage.lazy.mapping.Mapping
+          (erc20.erc20.AccountId * erc20.erc20.AccountId)
+          erc20.erc20.Balance);
   }.
   Global Set Primitive Projections.
   
@@ -1571,7 +1636,9 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* α0 :=
       (ink_storage_traits.storage.Storable.decode
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self := erc20.erc20.Balance))))
         __input in
     let* α1 := α0.["branch"] in
     let* α2 :=
@@ -1583,7 +1650,12 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
       end in
     let* α3 :=
       (ink_storage_traits.storage.Storable.decode
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self :=
+                ink_storage.lazy.mapping.Mapping
+                  erc20.erc20.AccountId
+                  erc20.erc20.Balance))))
         __input in
     let* α4 := α3.["branch"] in
     let* α5 :=
@@ -1595,7 +1667,12 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
       end in
     let* α6 :=
       (ink_storage_traits.storage.Storable.decode
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self :=
+                ink_storage.lazy.mapping.Mapping
+                  (erc20.erc20.AccountId * erc20.erc20.AccountId)
+                  erc20.erc20.Balance))))
         __input in
     let* α7 := α6.["branch"] in
     let* α8 :=
@@ -1674,7 +1751,9 @@ Module Impl_scale_info_TypeInfo_for_erc20_erc20_Erc20.
       α6.["field"]
         (fun f =>
           let* α0 :=
-            f.["ty"] : M ink_storage_traits.storage.AutoStorableHint.Type_ in
+            f.["ty"] : M
+              (ink_storage_traits.storage.AutoStorableHint.Type_
+                (Self := erc20.erc20.Balance)) in
           let* α1 := α0.["name"] "total_supply" in
           let* α2 :=
             α1.["type_name"]
@@ -1685,7 +1764,12 @@ storage::traits::ManualKey<375105693u32, ()>,>>::Type" in
       α7.["field"]
         (fun f =>
           let* α0 :=
-            f.["ty"] : M ink_storage_traits.storage.AutoStorableHint.Type_ in
+            f.["ty"] : M
+              (ink_storage_traits.storage.AutoStorableHint.Type_
+                (Self :=
+                  ink_storage.lazy.mapping.Mapping
+                    erc20.erc20.AccountId
+                    erc20.erc20.Balance)) in
           let* α1 := α0.["name"] "balances" in
           let* α2 :=
             α1.["type_name"]
@@ -1698,7 +1782,12 @@ AutoStorableHint<::ink::storage::traits::ManualKey<639884519u32, ()
       α8.["field"]
         (fun f =>
           let* α0 :=
-            f.["ty"] : M ink_storage_traits.storage.AutoStorableHint.Type_ in
+            f.["ty"] : M
+              (ink_storage_traits.storage.AutoStorableHint.Type_
+                (Self :=
+                  ink_storage.lazy.mapping.Mapping
+                    (erc20.erc20.AccountId * erc20.erc20.AccountId)
+                    erc20.erc20.Balance)) in
           let* α1 := α0.["name"] "allowances" in
           let* α2 :=
             α1.["type_name"]
@@ -1734,17 +1823,29 @@ Module Impl_ink_storage_traits_layout_StorageLayout_for_erc20_erc20_Erc20.
       : M (H := H') ink_metadata.layout.Layout :=
     let* α0 :=
       (ink_storage_traits.layout.StorageLayout.layout
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self := erc20.erc20.Balance))))
         __key in
     let* α1 := ink_metadata.layout.FieldLayout::["new"] "total_supply" α0 in
     let* α2 :=
       (ink_storage_traits.layout.StorageLayout.layout
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self :=
+                ink_storage.lazy.mapping.Mapping
+                  erc20.erc20.AccountId
+                  erc20.erc20.Balance))))
         __key in
     let* α3 := ink_metadata.layout.FieldLayout::["new"] "balances" α2 in
     let* α4 :=
       (ink_storage_traits.layout.StorageLayout.layout
-          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+          (Self :=
+            (ink_storage_traits.storage.AutoStorableHint.Type_
+              (Self :=
+                ink_storage.lazy.mapping.Mapping
+                  (erc20.erc20.AccountId * erc20.erc20.AccountId)
+                  erc20.erc20.Balance))))
         __key in
     let* α5 := ink_metadata.layout.FieldLayout::["new"] "allowances" α4 in
     let* α6 :=
@@ -1809,10 +1910,12 @@ Module Impl_ink_codegen_env_Env_for_StaticRef_erc20_erc20_Erc20.
   Definition Self := ref erc20.erc20.Erc20.
   
   Definition EnvAccess : Set :=
-    ink.env_access.EnvAccess ink_env.contract.ContractEnv.Env.
+    ink.env_access.EnvAccess
+      (ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
   Definition env `{H' : State.Trait} (self : Self) : M (H := H') EnvAccess :=
-    (core.default.Default.default (Self := ink.codegen.env.Env.EnvAccess)).
+    (core.default.Default.default
+        (Self := (ink.codegen.env.Env.EnvAccess (Self := Self)))).
   
   Global Instance Method_env `{H' : State.Trait} : Notation.Dot "env" := {
     Notation.dot := env;
@@ -1829,11 +1932,12 @@ Module Impl_ink_codegen_env_StaticEnv_for_erc20_erc20_Erc20.
   Definition Self := erc20.erc20.Erc20.
   
   Definition EnvAccess : Set :=
-    ink.env_access.EnvAccess ink_env.contract.ContractEnv.Env.
+    ink.env_access.EnvAccess
+      (ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20)).
   
   Definition env `{H' : State.Trait} : M (H := H') EnvAccess :=
     (core.default.Default.default
-        (Self := ink.codegen.env.StaticEnv.EnvAccess)).
+        (Self := (ink.codegen.env.StaticEnv.EnvAccess (Self := Self)))).
   
   Global Instance AssociatedFunction_env `{H' : State.Trait} :
     Notation.DoubleColon Self "env" := {
@@ -1855,7 +1959,8 @@ Module
       `{H' : State.Trait}
       {E : Set}
       `{core.convert.Into.Trait E
-          (T := ink.reflect.event.ContractEventBase.Type_)}
+          (T := ink.reflect.event.ContractEventBase.Type_
+            (Self := erc20.erc20.Erc20))}
       (self : Self)
       (event : E)
       : M (H := H') unit :=
@@ -2119,7 +2224,7 @@ Module Impl_ink_env_topics_Topics_for_erc20_erc20___ink_EventBase.
       `{ink_env.topics.TopicsBuilderBackend.Trait B (E := E)}
       (self : ref Self)
       (builder : ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B)
-      : M (H := H') ink_env.topics.TopicsBuilderBackend.Output :=
+      : M (H := H') (ink_env.topics.TopicsBuilderBackend.Output (Self := B)) :=
     match self with
     | Transfer.Build_t event =>
       (ink_env.topics.Topics.topics (Self := erc20.erc20.Transfer))
@@ -2449,7 +2554,7 @@ Module Impl_ink_env_topics_Topics_for_erc20_erc20_Transfer.
       `{ink_env.topics.TopicsBuilderBackend.Trait B (E := E)}
       (self : ref Self)
       (builder : ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B)
-      : M (H := H') ink_env.topics.TopicsBuilderBackend.Output :=
+      : M (H := H') (ink_env.topics.TopicsBuilderBackend.Output (Self := B)) :=
     let* α0 := builder.["build"] : M Self in
     let* α1 :=
       α0.["push_topic"]
@@ -2506,7 +2611,7 @@ Module Impl_ink_env_topics_Topics_for_erc20_erc20_Approval.
       `{ink_env.topics.TopicsBuilderBackend.Trait B (E := E)}
       (self : ref Self)
       (builder : ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B)
-      : M (H := H') ink_env.topics.TopicsBuilderBackend.Output :=
+      : M (H := H') (ink_env.topics.TopicsBuilderBackend.Output (Self := B)) :=
     let* α0 := builder.["build"] : M Self in
     let* α1 :=
       α0.["push_topic"]
@@ -2558,7 +2663,9 @@ Module
   
   Definition Storage : Set := erc20.erc20.Erc20.
   
-  Definition Error : Set := ink.reflect.dispatch.ConstructorOutput.Error.
+  Definition Error : Set :=
+    ink.reflect.dispatch.ConstructorOutput.Error
+      (Self := ink.reflect.dispatch.ConstructorOutputValue Self).
   
   Definition
     IS_RESULT
@@ -3074,7 +3181,12 @@ End Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
 
 Module __ink_ConstructorDecoder.
   Inductive t : Set :=
-  | Constructor0 (_ : ink.reflect.dispatch.DispatchableConstructorInfo.Input).
+  |
+    Constructor0
+    (_
+      :
+      ink.reflect.dispatch.DispatchableConstructorInfo.Input
+        (Self := erc20.erc20.Erc20)).
 End __ink_ConstructorDecoder.
 Definition __ink_ConstructorDecoder := __ink_ConstructorDecoder.t.
 
@@ -3109,7 +3221,9 @@ Module
     | erc20.erc20._.decode_dispatch.CONSTRUCTOR_0 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableConstructorInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableConstructorInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3223,7 +3337,8 @@ Module
         (ink.reflect.dispatch.ConstructorOutput.as_result
             (Self :=
               (ink.reflect.dispatch.ConstructorOutputValue
-                ink.reflect.dispatch.DispatchableConstructorInfo.Output)))
+                (ink.reflect.dispatch.DispatchableConstructorInfo.Output
+                  (Self := erc20.erc20.Erc20)))))
           (addr_of output_value) in
       let* _ :=
         let* α0 := output_result.["as_ref"] in
@@ -3279,12 +3394,42 @@ End Impl_ink_reflect_dispatch_ContractConstructorDecoder_for_erc20_erc20_Erc20.
 
 Module __ink_MessageDecoder.
   Inductive t : Set :=
-  | Message0 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input)
-  | Message1 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input)
-  | Message2 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input)
-  | Message3 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input)
-  | Message4 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input)
-  | Message5 (_ : ink.reflect.dispatch.DispatchableMessageInfo.Input).
+  |
+    Message0
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20))
+  |
+    Message1
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20))
+  |
+    Message2
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20))
+  |
+    Message3
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20))
+  |
+    Message4
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20))
+  |
+    Message5
+    (_
+      :
+      ink.reflect.dispatch.DispatchableMessageInfo.Input
+        (Self := erc20.erc20.Erc20)).
 End __ink_MessageDecoder.
 Definition __ink_MessageDecoder := __ink_MessageDecoder.t.
 
@@ -3319,7 +3464,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_0 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3338,7 +3485,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_1 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3357,7 +3506,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_2 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3376,7 +3527,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_3 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3395,7 +3548,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_4 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3414,7 +3569,9 @@ Module
     | erc20.erc20._.decode_dispatch.MESSAGE_5 =>
       let* α0 :=
         (parity_scale_codec.codec.Decode.decode
-            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+            (Self :=
+              (ink.reflect.dispatch.DispatchableMessageInfo.Input
+                (Self := erc20.erc20.Erc20))))
           input in
       let* α1 :=
         α0.["map_err"]
@@ -3617,7 +3774,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -3693,7 +3851,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -3769,7 +3928,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -3845,7 +4005,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -3921,7 +4082,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -3997,7 +4159,8 @@ Module
           let* α0 :=
             (ink.result_info.IsResultErr.Build_t (addr_of result)).["value"] in
           (ink.result_info.IsResultType
-                ink.reflect.dispatch.DispatchableMessageInfo.Output)::["VALUE"].["andb"]
+                (ink.reflect.dispatch.DispatchableMessageInfo.Output
+                  (Self := erc20.erc20.Erc20)))::["VALUE"].["andb"]
             α0 in
         let* _ :=
           let* α0 := is_reverted.["not"] in
@@ -4684,7 +4847,8 @@ End Impl_ink_codegen_dispatch_info_ContractCallBuilder_for_erc20_erc20_Erc20.
 Module Impl_ink_env_contract_ContractEnv_for_erc20_erc20___CallBuilder.
   Definition Self := erc20.erc20._.CallBuilder.
   
-  Definition Env : Set := ink_env.contract.ContractEnv.Env.
+  Definition Env : Set :=
+    ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20).
   
   Global Instance I : ink_env.contract.ContractEnv.Trait Self := {
     ink_env.contract.ContractEnv.Env := Env;
@@ -5011,7 +5175,10 @@ End Impl_erc20_erc20___CallBuilder_18.
 Module Erc20Ref.
   Unset Primitive Projections.
   Record t : Set := {
-    inner : ink.codegen.dispatch.info.ContractCallBuilder.Type_;
+    inner
+      :
+      ink.codegen.dispatch.info.ContractCallBuilder.Type_
+        (Self := erc20.erc20.Erc20);
   }.
   Global Set Primitive Projections.
   
@@ -5031,7 +5198,8 @@ Module Impl_core_fmt_Debug_for_erc20_erc20_Erc20Ref.
       core.fmt.Formatter ->
         string ->
           string ->
-          ink_codegen_dispatch_info_ContractCallBuilder_Type_ ->
+          erc20_erc20_Erc20_ink_codegen_dispatch_info_ContractCallBuilder_Type_
+          ->
           M (H := H') core.fmt.Result.
   
   Global Instance Deb_debug_struct_field1_finish : Notation.DoubleColon
@@ -5132,7 +5300,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Erc20Ref.
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* __codec_res_edqy :=
       (parity_scale_codec.codec.Decode.decode
-          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+          (Self :=
+            (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+              (Self := erc20.erc20.Erc20))))
         __codec_input_edqy in
     let* α0 :=
       match __codec_res_edqy with
@@ -5226,7 +5396,8 @@ Module Impl_core_cmp_Eq_for_erc20_erc20_Erc20Ref.
     let
         _ :
         core.cmp.AssertParamIsEq
-          ink.codegen.dispatch.info.ContractCallBuilder.Type_ :=
+          (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+            (Self := erc20.erc20.Erc20)) :=
       tt in
     Pure tt.
   
@@ -5277,7 +5448,9 @@ Module Impl_scale_info_TypeInfo_for_erc20_erc20_Erc20Ref.
       α6.["field"]
         (fun f =>
           let* α0 :=
-            f.["ty"] : M ink.codegen.dispatch.info.ContractCallBuilder.Type_ in
+            f.["ty"] : M
+              (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+                (Self := erc20.erc20.Erc20)) in
           let* α1 := α0.["name"] "inner" in
           α1.["type_name"]
             "<Erc20 as::ink::codegen::ContractCallBuilder>::Type") in
@@ -5304,7 +5477,9 @@ Module Impl_ink_storage_traits_layout_StorageLayout_for_erc20_erc20_Erc20Ref.
       : M (H := H') ink_metadata.layout.Layout :=
     let* α0 :=
       (ink_storage_traits.layout.StorageLayout.layout
-          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+          (Self :=
+            (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+              (Self := erc20.erc20.Erc20))))
         __key in
     let* α1 := ink_metadata.layout.FieldLayout::["new"] "inner" α0 in
     let* α2 := ink_metadata.layout.StructLayout::["new"] "Erc20Ref" [ α1 ] in
@@ -5426,7 +5601,8 @@ End
 Module Impl_ink_env_contract_ContractEnv_for_erc20_erc20_Erc20Ref.
   Definition Self := erc20.erc20.Erc20Ref.
   
-  Definition Env : Set := ink_env.contract.ContractEnv.Env.
+  Definition Env : Set :=
+    ink_env.contract.ContractEnv.Env (Self := erc20.erc20.Erc20).
   
   Global Instance I : ink_env.contract.ContractEnv.Trait Self := {
     ink_env.contract.ContractEnv.Env := Env;
@@ -5752,7 +5928,8 @@ Module
   Definition Self := erc20.erc20.Erc20Ref.
   
   Definition Builder : Set :=
-    ink.codegen.dispatch.info.ContractCallBuilder.Type_.
+    ink.codegen.dispatch.info.ContractCallBuilder.Type_
+      (Self := erc20.erc20.Erc20).
   
   Definition call
       `{H' : State.Trait}
@@ -5799,7 +5976,9 @@ Module Impl_ink_env_call_create_builder_FromAccountId_for_erc20_erc20_Erc20Ref.
       : M (H := H') Self :=
     let* α0 :=
       (ink_env.call.create_builder.FromAccountId.from_account_id
-          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+          (Self :=
+            (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+              (Self := erc20.erc20.Erc20))))
         account_id in
     Pure {| Self.inner := α0; |}.
   
@@ -5828,7 +6007,9 @@ Module Impl_ink_contract_ref_ToAccountId_for_erc20_erc20_Erc20Ref.
       (self : ref Self)
       : M (H := H') erc20.erc20.AccountId :=
     (ink.contract_ref.ToAccountId.to_account_id
-        (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+        (Self :=
+          (ink.codegen.dispatch.info.ContractCallBuilder.Type_
+            (Self := erc20.erc20.Erc20))))
       (addr_of self.["inner"]).
   
   Global Instance Method_to_account_id `{H' : State.Trait} :

--- a/CoqOfRust/ink/erc20.v
+++ b/CoqOfRust/ink/erc20.v
@@ -5,7 +5,6 @@ Require CoqOfRust.ink.ink_storage.
 Require CoqOfRust.ink.ink_env.
 Require CoqOfRust.ink.ink.
 
-
 Module erc20.
   Module Erc20.
     Unset Primitive Projections.
@@ -73,7 +72,10 @@ Module erc20.
   Definition ChainExtension : Set := ink_env.types.Environment.ChainExtension.
   
   Definition MAX_EVENT_TOPICS `{H' : State.Trait} : usize :=
-    run (Pure ink_env.types.Environment.MAX_EVENT_TOPICS).
+    run
+      (Pure
+        (ink_env.types.Environment.MAX_EVENT_TOPICS
+          (Self := ink_env.contract.ContractEnv.Env))).
   
   Module Impl_core_default_Default_for_erc20_erc20_Erc20.
     Definition Self := erc20.erc20.Erc20.
@@ -208,7 +210,10 @@ Module erc20.
     Definition Error : Set := ink.reflect.dispatch.ConstructorOutput.Error.
     
     Definition
-      IS_RESULT `{State.Trait} := Pure ink.reflect.dispatch.ConstructorOutput.IS_RESULT.
+      IS_RESULT
+      `{H' : State.Trait} := Pure
+        (ink.reflect.dispatch.ConstructorOutput.IS_RESULT
+          (Self := (ink.reflect.dispatch.ConstructorOutputValue Self))).
     
     Global Instance AssociatedFunction_IS_RESULT `{H' : State.Trait} :
       Notation.DoubleColon Self "IS_RESULT" := {
@@ -216,7 +221,8 @@ Module erc20.
     }.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun __ink_binding_0 => erc20.erc20.Erc20::["new"] __ink_binding_0).
     
     Global Instance AssociatedFunction_CALLABLE `{H' : State.Trait} :
@@ -224,21 +230,21 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 155; 174; 157; 94 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 155; 174; 157; 94 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition LABEL `{State.Trait} := Pure "new".
+    Definition LABEL `{H' : State.Trait} := Pure "new".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -286,7 +292,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage _ => erc20.erc20.Erc20::["total_supply"] storage).
     
     Global Instance AssociatedFunction_CALLABLE `{H' : State.Trait} :
@@ -294,28 +301,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 219; 99; 117; 168 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 219; 99; 117; 168 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure false.
+    Definition MUTATES `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "total_supply".
+    Definition LABEL `{H' : State.Trait} := Pure "total_supply".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -357,7 +364,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage __ink_binding_0 =>
           erc20.erc20.Erc20::["balance_of"] storage __ink_binding_0).
     
@@ -366,28 +374,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 15; 117; 90; 86 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 15; 117; 90; 86 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure false.
+    Definition MUTATES `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "balance_of".
+    Definition LABEL `{H' : State.Trait} := Pure "balance_of".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -429,7 +437,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage (__ink_binding_0, __ink_binding_1) =>
           erc20.erc20.Erc20::["allowance"]
             storage
@@ -441,28 +450,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 106; 0; 22; 94 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 106; 0; 22; 94 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure false.
+    Definition MUTATES `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "allowance".
+    Definition LABEL `{H' : State.Trait} := Pure "allowance".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -504,7 +513,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage (__ink_binding_0, __ink_binding_1) =>
           erc20.erc20.Erc20::["transfer"]
             storage
@@ -516,28 +526,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 132; 161; 93; 161 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 132; 161; 93; 161 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure true.
+    Definition MUTATES `{H' : State.Trait} := Pure true.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "transfer".
+    Definition LABEL `{H' : State.Trait} := Pure "transfer".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -579,7 +589,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage (__ink_binding_0, __ink_binding_1) =>
           erc20.erc20.Erc20::["approve"]
             storage
@@ -591,28 +602,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 104; 18; 102; 160 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 104; 18; 102; 160 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure true.
+    Definition MUTATES `{H' : State.Trait} := Pure true.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "approve".
+    Definition LABEL `{H' : State.Trait} := Pure "approve".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -655,7 +666,8 @@ Module erc20.
     Definition Storage : Set := erc20.erc20.Erc20.
     
     Definition
-      CALLABLE `{State.Trait} := Pure
+      CALLABLE
+      `{H' : State.Trait} := Pure
         (fun storage (__ink_binding_0, __ink_binding_1, __ink_binding_2) =>
           erc20.erc20.Erc20::["transfer_from"]
             storage
@@ -668,28 +680,28 @@ Module erc20.
       Notation.double_colon := CALLABLE;
     }.
     
-    Definition SELECTOR `{State.Trait} := Pure [ 11; 57; 111; 24 ].
+    Definition SELECTOR `{H' : State.Trait} := Pure [ 11; 57; 111; 24 ].
     
     Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
       Notation.DoubleColon Self "SELECTOR" := {
       Notation.double_colon := SELECTOR;
     }.
     
-    Definition PAYABLE `{State.Trait} := Pure false.
+    Definition PAYABLE `{H' : State.Trait} := Pure false.
     
     Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
       Notation.DoubleColon Self "PAYABLE" := {
       Notation.double_colon := PAYABLE;
     }.
     
-    Definition MUTATES := Pure true.
+    Definition MUTATES `{H' : State.Trait} := Pure true.
     
     Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
       Notation.DoubleColon Self "MUTATES" := {
       Notation.double_colon := MUTATES;
     }.
     
-    Definition LABEL := Pure "transfer_from".
+    Definition LABEL `{H' : State.Trait} := Pure "transfer_from".
     
     Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
       Notation.DoubleColon Self "LABEL" := {
@@ -816,7 +828,10 @@ Module erc20.
       Notation.dot := eq;
     }.
     
-    Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+    Global Instance I
+      : core.cmp.PartialEq.Trait Self
+          (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+        := {
       core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
     }.
     Global Hint Resolve I : core.
@@ -936,7 +951,9 @@ Module erc20.
         (self : ref Self)
         : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call
+            (Self := Self))
+          self in
       let* α1 := α0.["total_supply"] in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -981,7 +998,9 @@ Module erc20.
         (owner : erc20.erc20.AccountId)
         : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call
+            (Self := Self))
+          self in
       let* α1 := α0.["balance_of"] owner in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -1027,7 +1046,9 @@ Module erc20.
         (spender : erc20.erc20.AccountId)
         : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call
+            (Self := Self))
+          self in
       let* α1 := α0.["allowance"] owner spender in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -1074,7 +1095,9 @@ Module erc20.
           M (H := H')
             (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+            (Self := Self))
+          self in
       let* α1 := α0.["transfer"] to value in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -1121,7 +1144,9 @@ Module erc20.
           M (H := H')
             (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+            (Self := Self))
+          self in
       let* α1 := α0.["approve"] spender value in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -1171,7 +1196,9 @@ Module erc20.
           M (H := H')
             (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
       let* α0 :=
-        ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+        (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+            (Self := Self))
+          self in
       let* α1 := α0.["transfer_from"] from to value in
       let* α2 := α1.["try_invoke"] in
       α2.["unwrap_or_else"]
@@ -1199,7 +1226,9 @@ Module erc20.
         (account_id : erc20.erc20.AccountId)
         : M (H := H') Self :=
       let* α0 :=
-        ink_env.call.create_builder.FromAccountId.from_account_id account_id in
+        (ink_env.call.create_builder.FromAccountId.from_account_id
+            (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+          account_id in
       Pure {| Self.inner := α0; |}.
     
     Global Instance AssociatedFunction_from_account_id `{H' : State.Trait} :
@@ -1226,7 +1255,9 @@ Module erc20.
         `{H' : State.Trait}
         (self : ref Self)
         : M (H := H') erc20.erc20.AccountId :=
-      ink.contract_ref.ToAccountId.to_account_id (addr_of self.["inner"]).
+      (ink.contract_ref.ToAccountId.to_account_id
+          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+        (addr_of self.["inner"]).
     
     Global Instance Method_to_account_id `{H' : State.Trait} :
       Notation.Dot "to_account_id" := {
@@ -1250,7 +1281,7 @@ Module erc20.
         `{H' : State.Trait}
         (self : ref Self)
         : M (H := H') (ref erc20.erc20.AccountId) :=
-      core.convert.AsRef.as_ref (addr_of self.["inner"]).
+      (core.convert.AsRef.as_ref (Self := _)) (addr_of self.["inner"]).
     
     Global Instance Method_as_ref `{H' : State.Trait} :
       Notation.Dot "as_ref" := {
@@ -1271,7 +1302,7 @@ Module erc20.
         `{H' : State.Trait}
         (self : mut_ref Self)
         : M (H := H') (mut_ref erc20.erc20.AccountId) :=
-      core.convert.AsMut.as_mut (addr_of self.["inner"]).
+      (core.convert.AsMut.as_mut (Self := _)) (addr_of self.["inner"]).
     
     Global Instance Method_as_mut `{H' : State.Trait} :
       Notation.Dot "as_mut" := {
@@ -1343,7 +1374,10 @@ Module erc20.
       Notation.dot := eq;
     }.
     
-    Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+    Global Instance I
+      : core.cmp.PartialEq.Trait Self
+          (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+        := {
       core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
     }.
     Global Hint Resolve I : core.
@@ -1406,7 +1440,10 @@ Definition BlockNumber : Set := ink_env.types.Environment.BlockNumber.
 Definition ChainExtension : Set := ink_env.types.Environment.ChainExtension.
 
 Definition MAX_EVENT_TOPICS `{H' : State.Trait} : usize :=
-  run (Pure ink_env.types.Environment.MAX_EVENT_TOPICS).
+  run
+    (Pure
+      (ink_env.types.Environment.MAX_EVENT_TOPICS
+        (Self := ink_env.contract.ContractEnv.Env))).
 
 Module Check.
   Unset Primitive Projections.
@@ -1507,7 +1544,10 @@ End Impl_ink_storage_traits_storage_StorableHint_for_erc20_erc20_Erc20.
 Module Impl_ink_storage_traits_storage_StorageKey_for_erc20_erc20_Erc20.
   Definition Self := erc20.erc20.Erc20.
   
-  Definition KEY := Pure ink_storage_traits.storage.StorageKey.KEY.
+  Definition
+    KEY
+    `{H' : State.Trait} := Pure
+      (ink_storage_traits.storage.StorageKey.KEY (Self := unit)).
   
   Global Instance AssociatedFunction_KEY `{H' : State.Trait} :
     Notation.DoubleColon Self "KEY" := {
@@ -1529,7 +1569,10 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
       `{parity_scale_codec.codec.Input.Trait __ink_I}
       (__input : mut_ref __ink_I)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
-    let* α0 := ink_storage_traits.storage.Storable.decode __input in
+    let* α0 :=
+      (ink_storage_traits.storage.Storable.decode
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __input in
     let* α1 := α0.["branch"] in
     let* α2 :=
       match α1 with
@@ -1538,7 +1581,10 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
         Return α0
       | LanguageItem.Continue val => Pure val
       end in
-    let* α3 := ink_storage_traits.storage.Storable.decode __input in
+    let* α3 :=
+      (ink_storage_traits.storage.Storable.decode
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __input in
     let* α4 := α3.["branch"] in
     let* α5 :=
       match α4 with
@@ -1547,7 +1593,10 @@ Module Impl_ink_storage_traits_storage_Storable_for_erc20_erc20_Erc20.
         Return α0
       | LanguageItem.Continue val => Pure val
       end in
-    let* α6 := ink_storage_traits.storage.Storable.decode __input in
+    let* α6 :=
+      (ink_storage_traits.storage.Storable.decode
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __input in
     let* α7 := α6.["branch"] in
     let* α8 :=
       match α7 with
@@ -1683,11 +1732,20 @@ Module Impl_ink_storage_traits_layout_StorageLayout_for_erc20_erc20_Erc20.
       `{H' : State.Trait}
       (__key : ref ink_primitives.key.Key)
       : M (H := H') ink_metadata.layout.Layout :=
-    let* α0 := ink_storage_traits.layout.StorageLayout.layout __key in
+    let* α0 :=
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __key in
     let* α1 := ink_metadata.layout.FieldLayout::["new"] "total_supply" α0 in
-    let* α2 := ink_storage_traits.layout.StorageLayout.layout __key in
+    let* α2 :=
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __key in
     let* α3 := ink_metadata.layout.FieldLayout::["new"] "balances" α2 in
-    let* α4 := ink_storage_traits.layout.StorageLayout.layout __key in
+    let* α4 :=
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := ink_storage_traits.storage.AutoStorableHint.Type_))
+        __key in
     let* α5 := ink_metadata.layout.FieldLayout::["new"] "allowances" α4 in
     let* α6 :=
       ink_metadata.layout.StructLayout::["new"] "Erc20" [ α1; α3; α5 ] in
@@ -1734,7 +1792,7 @@ End Impl_core_default_Default_for_erc20_erc20_Erc20.
 Module Impl_ink_reflect_contract_ContractName_for_erc20_erc20_Erc20.
   Definition Self := erc20.erc20.Erc20.
   
-  Definition NAME := Pure "Erc20".
+  Definition NAME `{H' : State.Trait} := Pure "Erc20".
   
   Global Instance AssociatedFunction_NAME `{H' : State.Trait} :
     Notation.DoubleColon Self "NAME" := {
@@ -1754,7 +1812,7 @@ Module Impl_ink_codegen_env_Env_for_StaticRef_erc20_erc20_Erc20.
     ink.env_access.EnvAccess ink_env.contract.ContractEnv.Env.
   
   Definition env `{H' : State.Trait} (self : Self) : M (H := H') EnvAccess :=
-    core.default.Default.default.
+    (core.default.Default.default (Self := ink.codegen.env.Env.EnvAccess)).
   
   Global Instance Method_env `{H' : State.Trait} : Notation.Dot "env" := {
     Notation.dot := env;
@@ -1774,7 +1832,8 @@ Module Impl_ink_codegen_env_StaticEnv_for_erc20_erc20_Erc20.
     ink.env_access.EnvAccess ink_env.contract.ContractEnv.Env.
   
   Definition env `{H' : State.Trait} : M (H := H') EnvAccess :=
-    core.default.Default.default.
+    (core.default.Default.default
+        (Self := ink.codegen.env.StaticEnv.EnvAccess)).
   
   Global Instance AssociatedFunction_env `{H' : State.Trait} :
     Notation.DoubleColon Self "env" := {
@@ -1870,7 +1929,8 @@ Module
   Definition Self := erc20.erc20.__ink_EventBase.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End
@@ -1905,7 +1965,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20___ink_EventBase.
         let* α0 :=
           (fun  =>
               let* __codec_res_edqy :=
-                parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+                (parity_scale_codec.codec.Decode.decode
+                    (Self := erc20.erc20.Transfer))
+                  __codec_input_edqy in
               let* α0 :=
                 match __codec_res_edqy with
                 | core.result.Result.Err e =>
@@ -1926,7 +1988,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20___ink_EventBase.
         let* α0 :=
           (fun  =>
               let* __codec_res_edqy :=
-                parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+                (parity_scale_codec.codec.Decode.decode
+                    (Self := erc20.erc20.Approval))
+                  __codec_input_edqy in
               let* α0 :=
                 match __codec_res_edqy with
                 | core.result.Result.Err e =>
@@ -1947,7 +2011,7 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20___ink_EventBase.
         let* α0 :=
           (fun  =>
               let* α0 :=
-                core.convert.Into.into
+                (core.convert.Into.into (Self := _))
                   "Could not decode `__ink_EventBase`, variant doesn't exist" in
               Pure (core.result.Result.Err α0)) in
         Return α0 in
@@ -2028,7 +2092,7 @@ Module
   Impl_ink_env_topics_EventTopicsAmount_for_erc20_erc20_____ink_UndefinedAmountOfTopics.
   Definition Self := erc20.erc20._.__ink_UndefinedAmountOfTopics.
   
-  Definition AMOUNT := Pure 0.
+  Definition AMOUNT `{H' : State.Trait} := Pure 0.
   
   Global Instance AssociatedFunction_AMOUNT `{H' : State.Trait} :
     Notation.DoubleColon Self "AMOUNT" := {
@@ -2057,8 +2121,14 @@ Module Impl_ink_env_topics_Topics_for_erc20_erc20___ink_EventBase.
       (builder : ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B)
       : M (H := H') ink_env.topics.TopicsBuilderBackend.Output :=
     match self with
-    | Transfer.Build_t event => ink_env.topics.Topics.topics event builder
-    | Approval.Build_t event => ink_env.topics.Topics.topics event builder
+    | Transfer.Build_t event =>
+      (ink_env.topics.Topics.topics (Self := erc20.erc20.Transfer))
+        event
+        builder
+    | Approval.Build_t event =>
+      (ink_env.topics.Topics.topics (Self := erc20.erc20.Approval))
+        event
+        builder
     | _ =>
       let* α0 :=
         format_arguments::["new_const"] (addr_of [ "Event does not exist!" ]) in
@@ -2167,7 +2237,8 @@ Module Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Transfer.
   Definition Self := erc20.erc20.Transfer.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Transfer.
@@ -2182,7 +2253,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Transfer.
       (__codec_input_edqy : mut_ref __CodecInputEdqy)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode
+          (Self := (core.option.Option erc20.erc20.AccountId)))
+        __codec_input_edqy in
     let* α0 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2191,7 +2264,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Transfer.
       | core.result.Result.Ok __codec_res_edqy => Pure __codec_res_edqy
       end in
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode
+          (Self := (core.option.Option erc20.erc20.AccountId)))
+        __codec_input_edqy in
     let* α1 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2200,7 +2275,8 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Transfer.
       | core.result.Result.Ok __codec_res_edqy => Pure __codec_res_edqy
       end in
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode (Self := erc20.erc20.Balance))
+        __codec_input_edqy in
     let* α2 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2296,7 +2372,8 @@ Module Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Approval.
   Definition Self := erc20.erc20.Approval.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Approval.
@@ -2311,7 +2388,8 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Approval.
       (__codec_input_edqy : mut_ref __CodecInputEdqy)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode (Self := erc20.erc20.AccountId))
+        __codec_input_edqy in
     let* α0 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2320,7 +2398,8 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Approval.
       | core.result.Result.Ok __codec_res_edqy => Pure __codec_res_edqy
       end in
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode (Self := erc20.erc20.AccountId))
+        __codec_input_edqy in
     let* α1 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2329,7 +2408,8 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Approval.
       | core.result.Result.Ok __codec_res_edqy => Pure __codec_res_edqy
       end in
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode (Self := erc20.erc20.Balance))
+        __codec_input_edqy in
     let* α2 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -2480,7 +2560,11 @@ Module
   
   Definition Error : Set := ink.reflect.dispatch.ConstructorOutput.Error.
   
-  Definition IS_RESULT `{State.Trait} := Pure ink.reflect.dispatch.ConstructorOutput.IS_RESULT.
+  Definition
+    IS_RESULT
+    `{H' : State.Trait} := Pure
+      (ink.reflect.dispatch.ConstructorOutput.IS_RESULT
+        (Self := (ink.reflect.dispatch.ConstructorOutputValue Self))).
   
   Global Instance AssociatedFunction_IS_RESULT `{H' : State.Trait} :
     Notation.DoubleColon Self "IS_RESULT" := {
@@ -2488,7 +2572,8 @@ Module
   }.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun __ink_binding_0 => erc20.erc20.Erc20::["new"] __ink_binding_0).
   
   Global Instance AssociatedFunction_CALLABLE `{H' : State.Trait} :
@@ -2496,21 +2581,21 @@ Module
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition SELECTOR := Pure [ 155; 174; 157; 94 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 155; 174; 157; 94 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition LABEL := Pure "new".
+  Definition LABEL `{H' : State.Trait} := Pure "new".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2555,7 +2640,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage _ => erc20.erc20.Erc20::["total_supply"] storage).
   
   Global Instance AssociatedFunction_CALLABLE `{H' : State.Trait} :
@@ -2563,28 +2649,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 219; 99; 117; 168 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 219; 99; 117; 168 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure false.
+  Definition MUTATES `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "total_supply".
+  Definition LABEL `{H' : State.Trait} := Pure "total_supply".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2625,7 +2711,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage __ink_binding_0 =>
         erc20.erc20.Erc20::["balance_of"] storage __ink_binding_0).
   
@@ -2634,28 +2721,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 15; 117; 90; 86 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 15; 117; 90; 86 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure false.
+  Definition MUTATES `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "balance_of".
+  Definition LABEL `{H' : State.Trait} := Pure "balance_of".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2696,7 +2783,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage (__ink_binding_0, __ink_binding_1) =>
         erc20.erc20.Erc20::["allowance"]
           storage
@@ -2708,28 +2796,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 106; 0; 22; 94 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 106; 0; 22; 94 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure false.
+  Definition MUTATES `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "allowance".
+  Definition LABEL `{H' : State.Trait} := Pure "allowance".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2770,7 +2858,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage (__ink_binding_0, __ink_binding_1) =>
         erc20.erc20.Erc20::["transfer"]
           storage
@@ -2782,28 +2871,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 132; 161; 93; 161 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 132; 161; 93; 161 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure true.
+  Definition MUTATES `{H' : State.Trait} := Pure true.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "transfer".
+  Definition LABEL `{H' : State.Trait} := Pure "transfer".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2844,7 +2933,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage (__ink_binding_0, __ink_binding_1) =>
         erc20.erc20.Erc20::["approve"] storage __ink_binding_0 __ink_binding_1).
   
@@ -2853,28 +2943,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 104; 18; 102; 160 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 104; 18; 102; 160 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure true.
+  Definition MUTATES `{H' : State.Trait} := Pure true.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "approve".
+  Definition LABEL `{H' : State.Trait} := Pure "approve".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2916,7 +3006,8 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
   Definition Storage : Set := erc20.erc20.Erc20.
   
   Definition
-    CALLABLE `{State.Trait} := Pure
+    CALLABLE
+    `{H' : State.Trait} := Pure
       (fun storage (__ink_binding_0, __ink_binding_1, __ink_binding_2) =>
         erc20.erc20.Erc20::["transfer_from"]
           storage
@@ -2929,28 +3020,28 @@ Module Impl_ink_reflect_dispatch_DispatchableMessageInfo_for_erc20_erc20_Erc20.
     Notation.double_colon := CALLABLE;
   }.
   
-  Definition SELECTOR := Pure [ 11; 57; 111; 24 ].
+  Definition SELECTOR `{H' : State.Trait} := Pure [ 11; 57; 111; 24 ].
   
   Global Instance AssociatedFunction_SELECTOR `{H' : State.Trait} :
     Notation.DoubleColon Self "SELECTOR" := {
     Notation.double_colon := SELECTOR;
   }.
   
-  Definition PAYABLE := Pure false.
+  Definition PAYABLE `{H' : State.Trait} := Pure false.
   
   Global Instance AssociatedFunction_PAYABLE `{H' : State.Trait} :
     Notation.DoubleColon Self "PAYABLE" := {
     Notation.double_colon := PAYABLE;
   }.
   
-  Definition MUTATES := Pure true.
+  Definition MUTATES `{H' : State.Trait} := Pure true.
   
   Global Instance AssociatedFunction_MUTATES `{H' : State.Trait} :
     Notation.DoubleColon Self "MUTATES" := {
     Notation.double_colon := MUTATES;
   }.
   
-  Definition LABEL := Pure "transfer_from".
+  Definition LABEL `{H' : State.Trait} := Pure "transfer_from".
   
   Global Instance AssociatedFunction_LABEL `{H' : State.Trait} :
     Notation.DoubleColon Self "LABEL" := {
@@ -2999,7 +3090,10 @@ Module
       :
         M (H := H')
           (core.result.Result Self ink.reflect.dispatch.DispatchError) :=
-    let* α0 := parity_scale_codec.codec.Decode.decode input in
+    let* α0 :=
+      (parity_scale_codec.codec.Decode.decode
+          (Self := (list Root.core.primitive.u8)))
+        input in
     let* α1 :=
       α0.["map_err"]
         (fun _ => Pure ink.reflect.dispatch.DispatchError.InvalidSelector) in
@@ -3013,7 +3107,10 @@ Module
       end in
     match α3 with
     | erc20.erc20._.decode_dispatch.CONSTRUCTOR_0 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableConstructorInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3049,7 +3146,10 @@ End
   Impl_ink_reflect_dispatch_DecodeDispatch_for_erc20_erc20_____ink_ConstructorDecoder.
 
 Definition CONSTRUCTOR_0 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableConstructorInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableConstructorInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Module
   Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_____ink_ConstructorDecoder.
@@ -3061,7 +3161,9 @@ Module
       `{parity_scale_codec.codec.Input.Trait I}
       (input : mut_ref I)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
-    let* α0 := ink.reflect.dispatch.DecodeDispatch.decode_dispatch input in
+    let* α0 :=
+      (ink.reflect.dispatch.DecodeDispatch.decode_dispatch (Self := Self))
+        input in
     α0.["map_err"] core.convert.Into.into.
   
   Global Instance AssociatedFunction_decode `{H' : State.Trait} :
@@ -3091,10 +3193,12 @@ Module
       let* _ :=
         let constructor_0 := false in
         let constructor_0 :=
-          ink.reflect.dispatch.DispatchableConstructorInfo.PAYABLE in
+          ink.reflect.dispatch.DispatchableConstructorInfo.PAYABLE
+            (Self := erc20.erc20.Erc20) in
         let* α0 := false.["or"] constructor_0 in
         let* α1 :=
-          ink.reflect.dispatch.DispatchableConstructorInfo.PAYABLE.["not"] in
+          (ink.reflect.dispatch.DispatchableConstructorInfo.PAYABLE
+              (Self := erc20.erc20.Erc20)).["not"] in
         let* α2 := α0.["andb"] α1 in
         if (α2 : bool) then
           let* _ :=
@@ -3110,11 +3214,16 @@ Module
         else
           Pure tt in
       let* result :=
-        ink.reflect.dispatch.DispatchableConstructorInfo.CALLABLE input in
+        (ink.reflect.dispatch.DispatchableConstructorInfo.CALLABLE
+            (Self := erc20.erc20.Erc20))
+          input in
       let* output_value :=
         ink.reflect.dispatch.ConstructorOutputValue::["new"] result in
       let* output_result :=
-        ink.reflect.dispatch.ConstructorOutput.as_result
+        (ink.reflect.dispatch.ConstructorOutput.as_result
+            (Self :=
+              (ink.reflect.dispatch.ConstructorOutputValue
+                ink.reflect.dispatch.DispatchableConstructorInfo.Output)))
           (addr_of output_value) in
       let* _ :=
         let* α0 := output_result.["as_ref"] in
@@ -3122,7 +3231,9 @@ Module
         | core.result.Result.Ok contract =>
           let* _ :=
             ink_env.api.set_contract_storage
-              (addr_of ink_storage_traits.storage.StorageKey.KEY)
+              (addr_of
+                (ink_storage_traits.storage.StorageKey.KEY
+                  (Self := erc20.erc20.Erc20)))
               contract in
           Pure tt
         | _ => Pure tt
@@ -3189,7 +3300,10 @@ Module
       :
         M (H := H')
           (core.result.Result Self ink.reflect.dispatch.DispatchError) :=
-    let* α0 := parity_scale_codec.codec.Decode.decode input in
+    let* α0 :=
+      (parity_scale_codec.codec.Decode.decode
+          (Self := (list Root.core.primitive.u8)))
+        input in
     let* α1 :=
       α0.["map_err"]
         (fun _ => Pure ink.reflect.dispatch.DispatchError.InvalidSelector) in
@@ -3203,7 +3317,10 @@ Module
       end in
     match α3 with
     | erc20.erc20._.decode_dispatch.MESSAGE_0 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3219,7 +3336,10 @@ Module
       let* α4 := Self::["Message0"] α3 in
       Pure (core.result.Result.Ok α4)
     | erc20.erc20._.decode_dispatch.MESSAGE_1 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3235,7 +3355,10 @@ Module
       let* α4 := Self::["Message1"] α3 in
       Pure (core.result.Result.Ok α4)
     | erc20.erc20._.decode_dispatch.MESSAGE_2 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3251,7 +3374,10 @@ Module
       let* α4 := Self::["Message2"] α3 in
       Pure (core.result.Result.Ok α4)
     | erc20.erc20._.decode_dispatch.MESSAGE_3 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3267,7 +3393,10 @@ Module
       let* α4 := Self::["Message3"] α3 in
       Pure (core.result.Result.Ok α4)
     | erc20.erc20._.decode_dispatch.MESSAGE_4 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3283,7 +3412,10 @@ Module
       let* α4 := Self::["Message4"] α3 in
       Pure (core.result.Result.Ok α4)
     | erc20.erc20._.decode_dispatch.MESSAGE_5 =>
-      let* α0 := parity_scale_codec.codec.Decode.decode input in
+      let* α0 :=
+        (parity_scale_codec.codec.Decode.decode
+            (Self := ink.reflect.dispatch.DispatchableMessageInfo.Input))
+          input in
       let* α1 :=
         α0.["map_err"]
           (fun _ =>
@@ -3319,22 +3451,40 @@ End
   Impl_ink_reflect_dispatch_DecodeDispatch_for_erc20_erc20_____ink_MessageDecoder.
 
 Definition MESSAGE_0 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Definition MESSAGE_1 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Definition MESSAGE_2 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Definition MESSAGE_3 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Definition MESSAGE_4 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Definition MESSAGE_5 `{H' : State.Trait} : list Root.core.primitive.u8 :=
-  run (Pure ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR).
+  run
+    (Pure
+      (ink.reflect.dispatch.DispatchableMessageInfo.SELECTOR
+        (Self := erc20.erc20.Erc20))).
 
 Module
   Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_____ink_MessageDecoder.
@@ -3346,7 +3496,9 @@ Module
       `{parity_scale_codec.codec.Input.Trait I}
       (input : mut_ref I)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
-    let* α0 := ink.reflect.dispatch.DecodeDispatch.decode_dispatch input in
+    let* α0 :=
+      (ink.reflect.dispatch.DecodeDispatch.decode_dispatch (Self := Self))
+        input in
     α0.["map_err"] core.convert.Into.into.
   
   Global Instance AssociatedFunction_decode `{H' : State.Trait} :
@@ -3368,7 +3520,9 @@ Definition push_contract
   if (mutates : bool) then
     let* _ :=
       ink_env.api.set_contract_storage
-        (addr_of ink_storage_traits.storage.StorageKey.KEY)
+        (addr_of
+          (ink_storage_traits.storage.StorageKey.KEY
+            (Self := erc20.erc20.Erc20)))
         (addr_of contract) in
     Pure tt
   else
@@ -3384,7 +3538,8 @@ Module
       :
         M (H := H')
           (core.result.Result unit ink.reflect.dispatch.DispatchError) :=
-    let key := ink_storage_traits.storage.StorageKey.KEY in
+    let key :=
+      ink_storage_traits.storage.StorageKey.KEY (Self := erc20.erc20.Erc20) in
     let* contract :=
       let* α0 := ink_env.api.get_contract_storage (addr_of key) in
       let* α1 :=
@@ -3408,30 +3563,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3447,7 +3609,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3462,7 +3625,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -3475,30 +3639,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3514,7 +3685,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3529,7 +3701,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -3542,30 +3715,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3581,7 +3761,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3596,7 +3777,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -3609,30 +3791,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3648,7 +3837,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3663,7 +3853,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -3676,30 +3867,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3715,7 +3913,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3730,7 +3929,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -3743,30 +3943,37 @@ Module
         let* _ :=
           let message_0 := false in
           let message_0 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := false.["or"] message_0 in
           let message_1 := false in
           let message_1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α1 := α0.["or"] message_1 in
           let message_2 := false in
           let message_2 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α2 := α1.["or"] message_2 in
           let message_3 := false in
           let message_3 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α3 := α2.["or"] message_3 in
           let message_4 := false in
           let message_4 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α4 := α3.["or"] message_4 in
           let message_5 := false in
           let message_5 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE in
+            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+              (Self := erc20.erc20.Erc20) in
           let* α0 := α4.["or"] message_5 in
           let* α1 :=
-            ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE.["not"] in
+            (ink.reflect.dispatch.DispatchableMessageInfo.PAYABLE
+                (Self := erc20.erc20.Erc20)).["not"] in
           let* α2 := α0.["andb"] α1 in
           if (α2 : bool) then
             let* _ :=
@@ -3782,7 +3989,8 @@ Module
           else
             Pure tt in
         let* result :=
-          ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+          (ink.reflect.dispatch.DispatchableMessageInfo.CALLABLE
+              (Self := erc20.erc20.Erc20))
             (addr_of contract)
             input in
         let* is_reverted :=
@@ -3797,7 +4005,8 @@ Module
             let* _ :=
               erc20.erc20._.push_contract
                 contract
-                ink.reflect.dispatch.DispatchableMessageInfo.MUTATES in
+                (ink.reflect.dispatch.DispatchableMessageInfo.MUTATES
+                  (Self := erc20.erc20.Erc20)) in
             Pure tt
           else
             Pure tt in
@@ -4167,7 +4376,8 @@ Module
   Definition Self := erc20.erc20._.CallBuilder.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End
@@ -4183,7 +4393,8 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20___CallBuilder.
       (__codec_input_edqy : mut_ref __CodecInputEdqy)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode (Self := erc20.erc20.AccountId))
+        __codec_input_edqy in
     let* α0 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -4259,7 +4470,10 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20___CallBuilder.
         Pure (addr_of α2) in
       let* _ :=
         let* α0 :=
-          parity_scale_codec.codec.Decode.decode_into __codec_input_edqy dst_ in
+          (parity_scale_codec.codec.Decode.decode_into
+              (Self := erc20.erc20.AccountId))
+            __codec_input_edqy
+            dst_ in
         let* α1 := α0.["branch"] in
         match α1 with
         | LanguageItem.Break residual =>
@@ -4328,7 +4542,9 @@ Module Impl_core_cmp_PartialEq_for_erc20_erc20___CallBuilder.
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.
@@ -4432,7 +4648,10 @@ Module
       `{H' : State.Trait}
       (__key : ref ink_primitives.key.Key)
       : M (H := H') ink_metadata.layout.Layout :=
-    let* α0 := ink_storage_traits.layout.StorageLayout.layout __key in
+    let* α0 :=
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := erc20.erc20.AccountId))
+        __key in
     let* α1 := ink_metadata.layout.FieldLayout::["new"] "account_id" α0 in
     let* α2 := ink_metadata.layout.StructLayout::["new"] "CallBuilder" [ α1 ] in
     Pure (ink_metadata.layout.Layout.Struct α2).
@@ -4508,7 +4727,8 @@ Module Impl_ink_contract_ref_ToAccountId_for_erc20_erc20___CallBuilder.
       `{H' : State.Trait}
       (self : ref Self)
       : M (H := H') erc20.erc20.AccountId :=
-    core.clone.Clone.clone (addr_of self.["account_id"]).
+    (core.clone.Clone.clone (Self := erc20.erc20.AccountId))
+      (addr_of self.["account_id"]).
   
   Global Instance Method_to_account_id `{H' : State.Trait} :
     Notation.Dot "to_account_id" := {
@@ -4895,7 +5115,8 @@ Module Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Erc20Ref.
   Definition Self := erc20.erc20.Erc20Ref.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Erc20Ref.
@@ -4910,7 +5131,9 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Erc20Ref.
       (__codec_input_edqy : mut_ref __CodecInputEdqy)
       : M (H := H') (core.result.Result Self parity_scale_codec.error.Error) :=
     let* __codec_res_edqy :=
-      parity_scale_codec.codec.Decode.decode __codec_input_edqy in
+      (parity_scale_codec.codec.Decode.decode
+          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+        __codec_input_edqy in
     let* α0 :=
       match __codec_res_edqy with
       | core.result.Result.Err e =>
@@ -4976,7 +5199,9 @@ Module Impl_core_cmp_PartialEq_for_erc20_erc20_Erc20Ref.
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.
@@ -5077,7 +5302,10 @@ Module Impl_ink_storage_traits_layout_StorageLayout_for_erc20_erc20_Erc20Ref.
       `{H' : State.Trait}
       (__key : ref ink_primitives.key.Key)
       : M (H := H') ink_metadata.layout.Layout :=
-    let* α0 := ink_storage_traits.layout.StorageLayout.layout __key in
+    let* α0 :=
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+        __key in
     let* α1 := ink_metadata.layout.FieldLayout::["new"] "inner" α0 in
     let* α2 := ink_metadata.layout.StructLayout::["new"] "Erc20Ref" [ α1 ] in
     Pure (ink_metadata.layout.Layout.Struct α2).
@@ -5146,7 +5374,7 @@ Module
     Context {E : Set}.
     Definition Self := core.result.Result erc20.erc20.Erc20 E.
     
-    Definition IS_RESULT := Pure true.
+    Definition IS_RESULT `{H' : State.Trait} := Pure true.
     
     Global Instance AssociatedFunction_IS_RESULT `{H' : State.Trait} :
       Notation.DoubleColon Self "IS_RESULT" := {
@@ -5263,7 +5491,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       `{H' : State.Trait}
       (self : ref Self)
       : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
-    let* α0 := ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+    let* α0 :=
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call (Self := Self))
+        self in
     let* α1 := α0.["total_supply"] in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5306,7 +5536,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       (self : ref Self)
       (owner : erc20.erc20.AccountId)
       : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
-    let* α0 := ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+    let* α0 :=
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call (Self := Self))
+        self in
     let* α1 := α0.["balance_of"] owner in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5350,7 +5582,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       (owner : erc20.erc20.AccountId)
       (spender : erc20.erc20.AccountId)
       : M (H := H') (ink_primitives.MessageResult erc20.erc20.Balance) :=
-    let* α0 := ink.codegen.trait_def.call_builder.TraitCallBuilder.call self in
+    let* α0 :=
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call (Self := Self))
+        self in
     let* α1 := α0.["allowance"] owner spender in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5395,7 +5629,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       (value : erc20.erc20.Balance)
       : M (H := H') (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
     let* α0 :=
-      ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+          (Self := Self))
+        self in
     let* α1 := α0.["transfer"] to value in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5440,7 +5676,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       (value : erc20.erc20.Balance)
       : M (H := H') (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
     let* α0 :=
-      ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+          (Self := Self))
+        self in
     let* α1 := α0.["approve"] spender value in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5488,7 +5726,9 @@ Module Impl_erc20_erc20_Erc20Ref_26.
       (value : erc20.erc20.Balance)
       : M (H := H') (ink_primitives.MessageResult (erc20.erc20.Result unit)) :=
     let* α0 :=
-      ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut self in
+      (ink.codegen.trait_def.call_builder.TraitCallBuilder.call_mut
+          (Self := Self))
+        self in
     let* α1 := α0.["transfer_from"] from to value in
     let* α2 := α1.["try_invoke"] in
     α2.["unwrap_or_else"]
@@ -5558,7 +5798,9 @@ Module Impl_ink_env_call_create_builder_FromAccountId_for_erc20_erc20_Erc20Ref.
       (account_id : erc20.erc20.AccountId)
       : M (H := H') Self :=
     let* α0 :=
-      ink_env.call.create_builder.FromAccountId.from_account_id account_id in
+      (ink_env.call.create_builder.FromAccountId.from_account_id
+          (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+        account_id in
     Pure {| Self.inner := α0; |}.
   
   Global Instance AssociatedFunction_from_account_id `{H' : State.Trait} :
@@ -5585,7 +5827,9 @@ Module Impl_ink_contract_ref_ToAccountId_for_erc20_erc20_Erc20Ref.
       `{H' : State.Trait}
       (self : ref Self)
       : M (H := H') erc20.erc20.AccountId :=
-    ink.contract_ref.ToAccountId.to_account_id (addr_of self.["inner"]).
+    (ink.contract_ref.ToAccountId.to_account_id
+        (Self := ink.codegen.dispatch.info.ContractCallBuilder.Type_))
+      (addr_of self.["inner"]).
   
   Global Instance Method_to_account_id `{H' : State.Trait} :
     Notation.Dot "to_account_id" := {
@@ -5609,7 +5853,7 @@ Module Impl_core_convert_AsRef_for_erc20_erc20_Erc20Ref.
       `{H' : State.Trait}
       (self : ref Self)
       : M (H := H') (ref erc20.erc20.AccountId) :=
-    core.convert.AsRef.as_ref (addr_of self.["inner"]).
+    (core.convert.AsRef.as_ref (Self := _)) (addr_of self.["inner"]).
   
   Global Instance Method_as_ref `{H' : State.Trait} : Notation.Dot "as_ref" := {
     Notation.dot := as_ref;
@@ -5629,7 +5873,7 @@ Module Impl_core_convert_AsMut_for_erc20_erc20_Erc20Ref.
       `{H' : State.Trait}
       (self : mut_ref Self)
       : M (H := H') (mut_ref erc20.erc20.AccountId) :=
-    core.convert.AsMut.as_mut (addr_of self.["inner"]).
+    (core.convert.AsMut.as_mut (Self := _)) (addr_of self.["inner"]).
   
   Global Instance Method_as_mut `{H' : State.Trait} : Notation.Dot "as_mut" := {
     Notation.dot := as_mut;
@@ -5647,10 +5891,15 @@ Definition __ink_generate_metadata
     : M (H := H') ink_metadata.InkProject :=
   let* layout :=
     let* α0 :=
-      core.convert.From.from ink_storage_traits.storage.StorageKey.KEY in
+      (core.convert.From.from (Self := ink_metadata.layout.LayoutKey))
+        (ink_storage_traits.storage.StorageKey.KEY
+          (Self := erc20.erc20.Erc20)) in
     let* α1 :=
-      ink_storage_traits.layout.StorageLayout.layout
-        (addr_of ink_storage_traits.storage.StorageKey.KEY) in
+      (ink_storage_traits.layout.StorageLayout.layout
+          (Self := erc20.erc20.Erc20))
+        (addr_of
+          (ink_storage_traits.storage.StorageKey.KEY
+            (Self := erc20.erc20.Erc20))) in
     let* α2 := ink_metadata.layout.RootLayout::["new"] α0 α1 in
     Pure (ink_metadata.layout.Layout.Root α2) in
   let* _ :=
@@ -5679,7 +5928,11 @@ Definition __ink_generate_metadata
   let* α10 := α9.["payable"] false in
   let* α11 := α10.["default"] false in
   let* α12 :=
-    if (ink.reflect.dispatch.DispatchableConstructorInfo.IS_RESULT : bool) then
+    if
+      (ink.reflect.dispatch.DispatchableConstructorInfo.IS_RESULT
+        (Self := erc20.erc20.Erc20)
+      : bool)
+    then
       let* α0 :=
         ink_metadata.specs.TypeSpec::["with_name_str"]
           "ink_primitives::ConstructorResult" in
@@ -6139,7 +6392,9 @@ Module Impl_core_cmp_PartialEq_for_erc20_erc20_Error.
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.
@@ -6211,7 +6466,8 @@ Module Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Error.
   Definition Self := erc20.erc20.Error.
   
   Global Instance I
-    : parity_scale_codec.encode_like.EncodeLike.Trait Self (T := None)
+    : parity_scale_codec.encode_like.EncodeLike.Trait Self
+        (T := parity_scale_codec.encode_like.EncodeLike.Default.T Self)
       := parity_scale_codec.encode_like.EncodeLike.Build_Trait _.
   Global Hint Resolve I : core.
 End Impl_parity_scale_codec_encode_like_EncodeLike_for_erc20_erc20_Error.
@@ -6263,7 +6519,7 @@ Module Impl_parity_scale_codec_codec_Decode_for_erc20_erc20_Error.
         let* α0 :=
           (fun  =>
               let* α0 :=
-                core.convert.Into.into
+                (core.convert.Into.into (Self := _))
                   "Could not decode `Error`, variant doesn't exist" in
               Pure (core.result.Result.Err α0)) in
         Return α0 in

--- a/CoqOfRust/ink/ink.v
+++ b/CoqOfRust/ink/ink.v
@@ -15,6 +15,9 @@ Module result_info.
       Global Instance Get_marker : Notation.Dot "marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End IsResultType.
   End IsResultType.
   Definition IsResultType (T : Set) : Set := IsResultType.t (T := T).
@@ -69,6 +72,9 @@ Module IsResultType.
     
     Global Instance Get_marker : Notation.Dot "marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End IsResultType.
 End IsResultType.
@@ -425,6 +431,9 @@ Module reflect.
           Global Instance Get_marker : Notation.Dot "marker" := {
             Notation.dot '(Build_t x0) := x0;
           }.
+          Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+            Notation.double_colon '(Build_t x0) := x0;
+          }.
         End TraitDefinitionRegistry.
       End TraitDefinitionRegistry.
       Definition TraitDefinitionRegistry (E : Set) : Set :=
@@ -595,6 +604,9 @@ Module codegen.
           Global Instance Get_marker : Notation.Dot "marker" := {
             Notation.dot '(Build_t x0) := x0;
           }.
+          Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+            Notation.double_colon '(Build_t x0) := x0;
+          }.
         End EventRespectsTopicLimit.
       End EventRespectsTopicLimit.
       Definition EventRespectsTopicLimit
@@ -747,6 +759,9 @@ Module codegen.
           
           Global Instance Get__marker : Notation.Dot "_marker" := {
             Notation.dot '(Build_t x0) := x0;
+          }.
+          Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+            Notation.double_colon '(Build_t x0) := x0;
           }.
         End IsSameType.
       End IsSameType.
@@ -1048,6 +1063,9 @@ Module event.
         Global Instance Get_marker : Notation.Dot "marker" := {
           Notation.dot '(Build_t x0) := x0;
         }.
+        Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+          Notation.double_colon '(Build_t x0) := x0;
+        }.
       End EventRespectsTopicLimit.
     End EventRespectsTopicLimit.
     Definition EventRespectsTopicLimit
@@ -1162,6 +1180,9 @@ Module topics.
       Global Instance Get_marker : Notation.Dot "marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End EventRespectsTopicLimit.
   End EventRespectsTopicLimit.
   Definition EventRespectsTopicLimit
@@ -1193,6 +1214,9 @@ Module EventRespectsTopicLimit.
     
     Global Instance Get_marker : Notation.Dot "marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End EventRespectsTopicLimit.
 End EventRespectsTopicLimit.
@@ -1564,6 +1588,9 @@ Module utils.
         Global Instance Get__marker : Notation.Dot "_marker" := {
           Notation.dot '(Build_t x0) := x0;
         }.
+        Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+          Notation.double_colon '(Build_t x0) := x0;
+        }.
       End IsSameType.
     End IsSameType.
     Definition IsSameType (T : Set) : Set := IsSameType.t (T := T).
@@ -1591,6 +1618,9 @@ Module same_type.
       Global Instance Get__marker : Notation.Dot "_marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End IsSameType.
   End IsSameType.
   Definition IsSameType (T : Set) : Set := IsSameType.t (T := T).
@@ -1607,6 +1637,9 @@ Module IsSameType.
     
     Global Instance Get__marker : Notation.Dot "_marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End IsSameType.
 End IsSameType.
@@ -2191,6 +2224,9 @@ Module Wrap_trait_def_1.
           Global Instance Get_marker : Notation.Dot "marker" := {
             Notation.dot '(Build_t x0) := x0;
           }.
+          Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+            Notation.double_colon '(Build_t x0) := x0;
+          }.
         End TraitDefinitionRegistry.
       End TraitDefinitionRegistry.
       Definition TraitDefinitionRegistry (E : Set) : Set :=
@@ -2292,6 +2328,9 @@ Module registry.
       Global Instance Get_marker : Notation.Dot "marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End TraitDefinitionRegistry.
   End TraitDefinitionRegistry.
   Definition TraitDefinitionRegistry (E : Set) : Set :=
@@ -2309,6 +2348,9 @@ Module TraitDefinitionRegistry.
     
     Global Instance Get_marker : Notation.Dot "marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End TraitDefinitionRegistry.
 End TraitDefinitionRegistry.
@@ -2540,6 +2582,9 @@ Module env_access.
       Global Instance Get_marker : Notation.Dot "marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End EnvAccess.
   End EnvAccess.
   Definition EnvAccess (E : Set) : Set := EnvAccess.t (E := E).
@@ -2556,6 +2601,9 @@ Module EnvAccess.
     
     Global Instance Get_marker : Notation.Dot "marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End EnvAccess.
 End EnvAccess.

--- a/CoqOfRust/ink/ink.v
+++ b/CoqOfRust/ink/ink.v
@@ -550,7 +550,7 @@ Module codegen.
             `{H'0
               :
               core.convert.Into.Trait E
-                (T := ink.reflect.event.ContractEventBase.Type_)}
+                (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
             :
             Self -> E -> M (H := H') unit;
         }.
@@ -562,7 +562,7 @@ Module codegen.
             `{H'0
               :
               core.convert.Into.Trait E
-                (T := ink.reflect.event.ContractEventBase.Type_)}
+                (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
             :=
             emit_event (E := E) (H'0 := H'0);
         }.
@@ -594,7 +594,8 @@ Module codegen.
           Context
             `{ink.codegen.event.topics.EventLenTopics.Trait Event}
             `{ink.codegen.event.topics.RespectTopicLimit.Trait
-                  ink.codegen.event.topics.EventLenTopics.LenTopics}.
+                  (ink.codegen.event.topics.EventLenTopics.LenTopics
+                    (Self := Event))}.
           Unset Primitive Projections.
           Record t : Set := {
             marker : core.marker.PhantomData (Event);
@@ -613,7 +614,8 @@ Module codegen.
           (Event : Set)
           `{ink.codegen.event.topics.EventLenTopics.Trait Event}
           `{ink.codegen.event.topics.RespectTopicLimit.Trait
-                ink.codegen.event.topics.EventLenTopics.LenTopics}
+                (ink.codegen.event.topics.EventLenTopics.LenTopics
+                  (Self := Event))}
           : Set :=
         EventRespectsTopicLimit.t (Event := Event).
       
@@ -695,13 +697,15 @@ Module codegen.
             (ref Self) ->
               M (H := H')
                 (ref
-                  ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+                  (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                    (Self := Forwarder)));
           build_mut `{H' : State.Trait}
             :
             (mut_ref Self) ->
               M (H := H')
                 (mut_ref
-                  ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+                  (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                    (Self := Forwarder)));
         }.
         
         Global Instance Method_Forwarder `(Trait)
@@ -1009,7 +1013,7 @@ Module event.
           `{H'0
             :
             core.convert.Into.Trait E
-              (T := ink.reflect.event.ContractEventBase.Type_)}
+              (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
           :
           Self -> E -> M (H := H') unit;
       }.
@@ -1021,7 +1025,7 @@ Module event.
           `{H'0
             :
             core.convert.Into.Trait E
-              (T := ink.reflect.event.ContractEventBase.Type_)}
+              (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
           :=
           emit_event (E := E) (H'0 := H'0);
       }.
@@ -1053,7 +1057,8 @@ Module event.
         Context
           `{ink.codegen.event.topics.EventLenTopics.Trait Event}
           `{ink.codegen.event.topics.RespectTopicLimit.Trait
-                ink.codegen.event.topics.EventLenTopics.LenTopics}.
+                (ink.codegen.event.topics.EventLenTopics.LenTopics
+                  (Self := Event))}.
         Unset Primitive Projections.
         Record t : Set := {
           marker : core.marker.PhantomData (Event);
@@ -1072,7 +1077,8 @@ Module event.
         (Event : Set)
         `{ink.codegen.event.topics.EventLenTopics.Trait Event}
         `{ink.codegen.event.topics.RespectTopicLimit.Trait
-              ink.codegen.event.topics.EventLenTopics.LenTopics}
+              (ink.codegen.event.topics.EventLenTopics.LenTopics
+                (Self := Event))}
         : Set :=
       EventRespectsTopicLimit.t (Event := Event).
     
@@ -1096,7 +1102,7 @@ Module emit.
         `{H'0
           :
           core.convert.Into.Trait E
-            (T := ink.reflect.event.ContractEventBase.Type_)}
+            (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
         :
         Self -> E -> M (H := H') unit;
     }.
@@ -1108,7 +1114,7 @@ Module emit.
         `{H'0
           :
           core.convert.Into.Trait E
-            (T := ink.reflect.event.ContractEventBase.Type_)}
+            (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
         :=
         emit_event (E := E) (H'0 := H'0);
     }.
@@ -1127,7 +1133,7 @@ Module EmitEvent.
       `{H'0
         :
         core.convert.Into.Trait E
-          (T := ink.reflect.event.ContractEventBase.Type_)}
+          (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
       :
       Self -> E -> M (H := H') unit;
   }.
@@ -1139,7 +1145,7 @@ Module EmitEvent.
       `{H'0
         :
         core.convert.Into.Trait E
-          (T := ink.reflect.event.ContractEventBase.Type_)}
+          (T := ink.reflect.event.ContractEventBase.Type_ (Self := C))}
       :=
       emit_event (E := E) (H'0 := H'0);
   }.
@@ -1170,7 +1176,8 @@ Module topics.
       Context
         `{ink.codegen.event.topics.EventLenTopics.Trait Event}
         `{ink.codegen.event.topics.RespectTopicLimit.Trait
-              ink.codegen.event.topics.EventLenTopics.LenTopics}.
+              (ink.codegen.event.topics.EventLenTopics.LenTopics
+                (Self := Event))}.
       Unset Primitive Projections.
       Record t : Set := {
         marker : core.marker.PhantomData (Event);
@@ -1189,7 +1196,7 @@ Module topics.
       (Event : Set)
       `{ink.codegen.event.topics.EventLenTopics.Trait Event}
       `{ink.codegen.event.topics.RespectTopicLimit.Trait
-            ink.codegen.event.topics.EventLenTopics.LenTopics}
+            (ink.codegen.event.topics.EventLenTopics.LenTopics (Self := Event))}
       : Set :=
     EventRespectsTopicLimit.t (Event := Event).
   
@@ -1205,7 +1212,8 @@ Module EventRespectsTopicLimit.
     Context
       `{ink.codegen.event.topics.EventLenTopics.Trait Event}
       `{ink.codegen.event.topics.RespectTopicLimit.Trait
-            ink.codegen.event.topics.EventLenTopics.LenTopics}.
+            (ink.codegen.event.topics.EventLenTopics.LenTopics
+              (Self := Event))}.
     Unset Primitive Projections.
     Record t : Set := {
       marker : core.marker.PhantomData (Event);
@@ -1224,7 +1232,7 @@ Definition EventRespectsTopicLimit
     (Event : Set)
     `{ink.codegen.event.topics.EventLenTopics.Trait Event}
     `{ink.codegen.event.topics.RespectTopicLimit.Trait
-          ink.codegen.event.topics.EventLenTopics.LenTopics}
+          (ink.codegen.event.topics.EventLenTopics.LenTopics (Self := Event))}
     : Set :=
   EventRespectsTopicLimit.t (Event := Event).
 
@@ -1326,13 +1334,16 @@ Module trait_def.
           :
           (ref Self) ->
             M (H := H')
-              (ref ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+              (ref
+                (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                  (Self := Forwarder)));
         build_mut `{H' : State.Trait}
           :
           (mut_ref Self) ->
             M (H := H')
               (mut_ref
-                ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+                (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                  (Self := Forwarder)));
       }.
       
       Global Instance Method_Forwarder `(Trait)
@@ -1429,13 +1440,16 @@ Module call_builder.
         :
         (ref Self) ->
           M (H := H')
-            (ref ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+            (ref
+              (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                (Self := Forwarder)));
       build_mut `{H' : State.Trait}
         :
         (mut_ref Self) ->
           M (H := H')
             (mut_ref
-              ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+              (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+                (Self := Forwarder)));
     }.
     
     Global Instance Method_Forwarder `(Trait)
@@ -1516,12 +1530,16 @@ End TraitCallForwarder.
       :
       (ref Self) ->
         M (H := H')
-          (ref ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+          (ref
+            (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+              (Self := Forwarder)));
     build_mut `{H' : State.Trait}
       :
       (mut_ref Self) ->
         M (H := H')
-          (mut_ref ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder);
+          (mut_ref
+            (ink.codegen.trait_def.call_builder.TraitCallBuilder.Builder
+              (Self := Forwarder)));
   }.
   
   Global Instance Method_Forwarder `(Trait)
@@ -2545,7 +2563,8 @@ Module contract_ref.
         Type := {
       to_account_id `{H' : State.Trait}
         :
-        (ref Self) -> M (H := H') ink_env.types.Environment.AccountId;
+        (ref Self) ->
+          M (H := H') (ink_env.types.Environment.AccountId (Self := T));
     }.
     
     Global Instance Method_to_account_id `{H' : State.Trait} `(Trait)
@@ -2560,7 +2579,8 @@ Module ToAccountId.
       Type := {
     to_account_id `{H' : State.Trait}
       :
-      (ref Self) -> M (H := H') ink_env.types.Environment.AccountId;
+      (ref Self) ->
+        M (H := H') (ink_env.types.Environment.AccountId (Self := T));
   }.
   
   Global Instance Method_to_account_id `{H' : State.Trait} `(Trait)

--- a/CoqOfRust/ink/ink_e2e.v
+++ b/CoqOfRust/ink/ink_e2e.v
@@ -6,9 +6,10 @@ Module builders.
     ink_env.call.create_builder.CreateBuilder
       E
       ContractRef
-      (ink_env.call.common.Unset_ ink_env.types.Environment.Hash)
+      (ink_env.call.common.Unset_ (ink_env.types.Environment.Hash (Self := E)))
       (ink_env.call.common.Unset_ u64)
-      (ink_env.call.common.Unset_ ink_env.types.Environment.Balance)
+      (ink_env.call.common.Unset_
+        (ink_env.types.Environment.Balance (Self := E)))
       (ink_env.call.common.Set_
         (ink_env.call.execution_input.ExecutionInput Args))
       (ink_env.call.common.Unset_ ink_env.call.create_builder.state.Salt)
@@ -28,9 +29,9 @@ Definition CreateBuilderPartial (E ContractRef Args R : Set) : Set :=
   ink_env.call.create_builder.CreateBuilder
     E
     ContractRef
-    (ink_env.call.common.Unset_ ink_env.types.Environment.Hash)
+    (ink_env.call.common.Unset_ (ink_env.types.Environment.Hash (Self := E)))
     (ink_env.call.common.Unset_ u64)
-    (ink_env.call.common.Unset_ ink_env.types.Environment.Balance)
+    (ink_env.call.common.Unset_ (ink_env.types.Environment.Balance (Self := E)))
     (ink_env.call.common.Set_
       (ink_env.call.execution_input.ExecutionInput Args))
     (ink_env.call.common.Unset_ ink_env.call.create_builder.state.Salt)

--- a/CoqOfRust/ink/ink_e2e.v
+++ b/CoqOfRust/ink/ink_e2e.v
@@ -77,11 +77,21 @@ Module client.
       Global Instance Get_account_id : Notation.Dot "account_id" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_account_id
+        : Notation.DoubleColon t "account_id" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_dry_run : Notation.Dot "dry_run" := {
         Notation.dot '(Build_t _ x1 _) := x1;
       }.
+      Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
+      }.
       Global Instance Get_events : Notation.Dot "events" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End InstantiationResult.
   End InstantiationResult.
@@ -113,11 +123,20 @@ Module client.
       Global Instance Get_code_hash : Notation.Dot "code_hash" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_dry_run : Notation.Dot "dry_run" := {
         Notation.dot '(Build_t _ x1 _) := x1;
       }.
+      Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
+      }.
       Global Instance Get_events : Notation.Dot "events" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End UploadResult.
   End UploadResult.
@@ -144,8 +163,14 @@ Module client.
       Global Instance Get_dry_run : Notation.Dot "dry_run" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_events : Notation.Dot "events" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End CallResult.
   End CallResult.
@@ -172,8 +197,15 @@ Module client.
       Global Instance Get_exec_result : Notation.Dot "exec_result" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_exec_result
+        : Notation.DoubleColon t "exec_result" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get__marker : Notation.Dot "_marker" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End CallDryRunResult.
   End CallDryRunResult.
@@ -231,8 +263,14 @@ Module client.
       Global Instance Get_api : Notation.Dot "api" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_api : Notation.DoubleColon t "api" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_contracts : Notation.Dot "contracts" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_contracts : Notation.DoubleColon t "contracts" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End Client.
   End Client.
@@ -273,11 +311,20 @@ Module InstantiationResult.
     Global Instance Get_account_id : Notation.Dot "account_id" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_account_id : Notation.DoubleColon t "account_id" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_dry_run : Notation.Dot "dry_run" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_events : Notation.Dot "events" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End InstantiationResult.
 End InstantiationResult.
@@ -307,11 +354,20 @@ Module UploadResult.
     Global Instance Get_code_hash : Notation.Dot "code_hash" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_dry_run : Notation.Dot "dry_run" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_events : Notation.Dot "events" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End UploadResult.
 End UploadResult.
@@ -336,8 +392,14 @@ Module CallResult.
     Global Instance Get_dry_run : Notation.Dot "dry_run" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_dry_run : Notation.DoubleColon t "dry_run" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_events : Notation.Dot "events" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_events : Notation.DoubleColon t "events" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End CallResult.
 End CallResult.
@@ -364,8 +426,15 @@ Module CallDryRunResult.
     Global Instance Get_exec_result : Notation.Dot "exec_result" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_exec_result
+      : Notation.DoubleColon t "exec_result" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get__marker : Notation.Dot "_marker" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End CallDryRunResult.
 End CallDryRunResult.
@@ -421,8 +490,14 @@ Module Client.
     Global Instance Get_api : Notation.Dot "api" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_api : Notation.DoubleColon t "api" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_contracts : Notation.Dot "contracts" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_contracts : Notation.DoubleColon t "contracts" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End Client.
 End Client.
@@ -635,11 +710,20 @@ Module node_proc.
       Global Instance Get_proc : Notation.Dot "proc" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_proc : Notation.DoubleColon t "proc" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_client : Notation.Dot "client" := {
         Notation.dot '(Build_t _ x1 _) := x1;
       }.
+      Global Instance Get_AF_client : Notation.DoubleColon t "client" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
+      }.
       Global Instance Get_url : Notation.Dot "url" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_url : Notation.DoubleColon t "url" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End TestNodeProcess.
   End TestNodeProcess.
@@ -660,11 +744,20 @@ Module node_proc.
       Global Instance Get_node_path : Notation.Dot "node_path" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_node_path : Notation.DoubleColon t "node_path" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_authority : Notation.Dot "authority" := {
         Notation.dot '(Build_t _ x1 _) := x1;
       }.
+      Global Instance Get_AF_authority : Notation.DoubleColon t "authority" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
+      }.
       Global Instance Get_marker : Notation.Dot "marker" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End TestNodeProcessBuilder.
   End TestNodeProcessBuilder.
@@ -687,11 +780,20 @@ Module TestNodeProcess.
     Global Instance Get_proc : Notation.Dot "proc" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_proc : Notation.DoubleColon t "proc" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_client : Notation.Dot "client" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_client : Notation.DoubleColon t "client" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_url : Notation.Dot "url" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_url : Notation.DoubleColon t "url" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End TestNodeProcess.
 End TestNodeProcess.
@@ -712,11 +814,20 @@ Module TestNodeProcessBuilder.
     Global Instance Get_node_path : Notation.Dot "node_path" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_node_path : Notation.DoubleColon t "node_path" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_authority : Notation.Dot "authority" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_authority : Notation.DoubleColon t "authority" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_marker : Notation.Dot "marker" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_marker : Notation.DoubleColon t "marker" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End TestNodeProcessBuilder.
 End TestNodeProcessBuilder.
@@ -735,8 +846,14 @@ Module xts.
     Global Instance Get_ref_time : Notation.Dot "ref_time" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_ref_time : Notation.DoubleColon t "ref_time" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_proof_size : Notation.Dot "proof_size" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_proof_size : Notation.DoubleColon t "proof_size" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End Weight.
   Definition Weight : Set := Weight.t.
@@ -759,21 +876,40 @@ Module xts.
       Global Instance Get_value : Notation.Dot "value" := {
         Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+      }.
       Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
         Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+      }.
+      Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
       }.
       Global Instance Get_storage_deposit_limit
         : Notation.Dot "storage_deposit_limit" := {
         Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
       }.
+      Global Instance Get_AF_storage_deposit_limit
+        : Notation.DoubleColon t "storage_deposit_limit" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+      }.
       Global Instance Get_code : Notation.Dot "code" := {
         Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+      }.
+      Global Instance Get_AF_code : Notation.DoubleColon t "code" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
       }.
       Global Instance Get_data : Notation.Dot "data" := {
         Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
       }.
+      Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+      }.
       Global Instance Get_salt : Notation.Dot "salt" := {
         Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+      }.
+      Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
       }.
     End InstantiateWithCode.
   End InstantiateWithCode.
@@ -800,18 +936,34 @@ Module xts.
       Global Instance Get_dest : Notation.Dot "dest" := {
         Notation.dot '(Build_t x0 _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_dest : Notation.DoubleColon t "dest" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+      }.
       Global Instance Get_value : Notation.Dot "value" := {
         Notation.dot '(Build_t _ x1 _ _ _) := x1;
       }.
+      Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
+      }.
       Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
         Notation.dot '(Build_t _ _ x2 _ _) := x2;
+      }.
+      Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
       }.
       Global Instance Get_storage_deposit_limit
         : Notation.Dot "storage_deposit_limit" := {
         Notation.dot '(Build_t _ _ _ x3 _) := x3;
       }.
+      Global Instance Get_AF_storage_deposit_limit
+        : Notation.DoubleColon t "storage_deposit_limit" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+      }.
       Global Instance Get_data : Notation.Dot "data" := {
         Notation.dot '(Build_t _ _ _ _ x4) := x4;
+      }.
+      Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
       }.
     End Call.
   End Call.
@@ -834,8 +986,14 @@ Module xts.
       Global Instance Get_dest : Notation.Dot "dest" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_dest : Notation.DoubleColon t "dest" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_value : Notation.Dot "value" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End Transfer.
   End Transfer.
@@ -868,12 +1026,23 @@ Module xts.
       Global Instance Get_code : Notation.Dot "code" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_code : Notation.DoubleColon t "code" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_storage_deposit_limit
         : Notation.Dot "storage_deposit_limit" := {
         Notation.dot '(Build_t _ x1 _) := x1;
       }.
+      Global Instance Get_AF_storage_deposit_limit
+        : Notation.DoubleColon t "storage_deposit_limit" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
+      }.
       Global Instance Get_determinism : Notation.Dot "determinism" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_determinism
+        : Notation.DoubleColon t "determinism" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End UploadCode.
   End UploadCode.
@@ -896,8 +1065,14 @@ Module xts.
       Global Instance Get_client : Notation.Dot "client" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_client : Notation.DoubleColon t "client" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get__phantom : Notation.Dot "_phantom" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End ContractsApi.
   End ContractsApi.
@@ -920,8 +1095,14 @@ Module Weight.
   Global Instance Get_ref_time : Notation.Dot "ref_time" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_ref_time : Notation.DoubleColon t "ref_time" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_proof_size : Notation.Dot "proof_size" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_proof_size : Notation.DoubleColon t "proof_size" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Weight.
 Definition Weight : Set := Weight.t.
@@ -944,21 +1125,40 @@ Module InstantiateWithCode.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+    }.
     Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
       Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+    }.
+    Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
     }.
     Global Instance Get_storage_deposit_limit
       : Notation.Dot "storage_deposit_limit" := {
       Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
     }.
+    Global Instance Get_AF_storage_deposit_limit
+      : Notation.DoubleColon t "storage_deposit_limit" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+    }.
     Global Instance Get_code : Notation.Dot "code" := {
       Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+    }.
+    Global Instance Get_AF_code : Notation.DoubleColon t "code" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
     }.
     Global Instance Get_data : Notation.Dot "data" := {
       Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
     }.
+    Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+    }.
     Global Instance Get_salt : Notation.Dot "salt" := {
       Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+    }.
+    Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
     }.
   End InstantiateWithCode.
 End InstantiateWithCode.
@@ -985,18 +1185,34 @@ Module Call.
     Global Instance Get_dest : Notation.Dot "dest" := {
       Notation.dot '(Build_t x0 _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_dest : Notation.DoubleColon t "dest" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+    }.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t _ x1 _ _ _) := x1;
     }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
+    }.
     Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
       Notation.dot '(Build_t _ _ x2 _ _) := x2;
+    }.
+    Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
     }.
     Global Instance Get_storage_deposit_limit
       : Notation.Dot "storage_deposit_limit" := {
       Notation.dot '(Build_t _ _ _ x3 _) := x3;
     }.
+    Global Instance Get_AF_storage_deposit_limit
+      : Notation.DoubleColon t "storage_deposit_limit" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+    }.
     Global Instance Get_data : Notation.Dot "data" := {
       Notation.dot '(Build_t _ _ _ _ x4) := x4;
+    }.
+    Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
     }.
   End Call.
 End Call.
@@ -1017,8 +1233,14 @@ Module Transfer.
     Global Instance Get_dest : Notation.Dot "dest" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_dest : Notation.DoubleColon t "dest" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End Transfer.
 End Transfer.
@@ -1051,12 +1273,23 @@ Module UploadCode.
     Global Instance Get_code : Notation.Dot "code" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_code : Notation.DoubleColon t "code" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_storage_deposit_limit
       : Notation.Dot "storage_deposit_limit" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_storage_deposit_limit
+      : Notation.DoubleColon t "storage_deposit_limit" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_determinism : Notation.Dot "determinism" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_determinism
+      : Notation.DoubleColon t "determinism" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End UploadCode.
 End UploadCode.
@@ -1077,8 +1310,14 @@ Module ContractsApi.
     Global Instance Get_client : Notation.Dot "client" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_client : Notation.DoubleColon t "client" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get__phantom : Notation.Dot "_phantom" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End ContractsApi.
 End ContractsApi.

--- a/CoqOfRust/ink/ink_e2e_macro.v
+++ b/CoqOfRust/ink/ink_e2e_macro.v
@@ -35,6 +35,9 @@ Module codegen.
     Global Instance Get_test : Notation.Dot "test" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_test : Notation.DoubleColon t "test" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End InkE2ETest.
   Definition InkE2ETest : Set := InkE2ETest.t.
 End codegen.
@@ -70,6 +73,9 @@ Module InkE2ETest.
   Global Instance Get_test : Notation.Dot "test" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_test : Notation.DoubleColon t "test" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End InkE2ETest.
 Definition InkE2ETest : Set := InkE2ETest.t.
 
@@ -87,12 +93,24 @@ Module config.
       : Notation.Dot "whitelisted_attributes" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_whitelisted_attributes
+      : Notation.DoubleColon t "whitelisted_attributes" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_additional_contracts
       : Notation.Dot "additional_contracts" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_additional_contracts
+      : Notation.DoubleColon t "additional_contracts" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_environment : Notation.Dot "environment" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_environment
+      : Notation.DoubleColon t "environment" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End E2EConfig.
   Definition E2EConfig : Set := E2EConfig.t.
@@ -111,12 +129,23 @@ Module E2EConfig.
     : Notation.Dot "whitelisted_attributes" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_whitelisted_attributes
+    : Notation.DoubleColon t "whitelisted_attributes" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_additional_contracts
     : Notation.Dot "additional_contracts" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_additional_contracts
+    : Notation.DoubleColon t "additional_contracts" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_environment : Notation.Dot "environment" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_environment : Notation.DoubleColon t "environment" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End E2EConfig.
 Definition E2EConfig : Set := E2EConfig.t.
@@ -133,8 +162,14 @@ Module ir.
     Global Instance Get_item_fn : Notation.Dot "item_fn" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_item_fn : Notation.DoubleColon t "item_fn" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_config : Notation.Dot "config" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_config : Notation.DoubleColon t "config" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End InkE2ETest.
   Definition InkE2ETest : Set := InkE2ETest.t.
@@ -148,6 +183,9 @@ Module ir.
     
     Global Instance Get_item_fn : Notation.Dot "item_fn" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_item_fn : Notation.DoubleColon t "item_fn" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End E2EFn.
   Definition E2EFn : Set := E2EFn.t.
@@ -164,8 +202,14 @@ Module InkE2ETest.
   Global Instance Get_item_fn : Notation.Dot "item_fn" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_item_fn : Notation.DoubleColon t "item_fn" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_config : Notation.Dot "config" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_config : Notation.DoubleColon t "config" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End InkE2ETest.
 Definition InkE2ETest : Set := InkE2ETest.t.
@@ -179,6 +223,9 @@ Module E2EFn.
   
   Global Instance Get_item_fn : Notation.Dot "item_fn" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_item_fn : Notation.DoubleColon t "item_fn" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End E2EFn.
 Definition E2EFn : Set := E2EFn.t.

--- a/CoqOfRust/ink/ink_engine.v
+++ b/CoqOfRust/ink/ink_engine.v
@@ -22,6 +22,9 @@ Module database.
     Global Instance Get_hmap : Notation.Dot "hmap" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_hmap : Notation.DoubleColon t "hmap" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End Database.
   Definition Database : Set := Database.t.
 End database.
@@ -72,18 +75,35 @@ Module ext.
     Global Instance Get_database : Notation.Dot "database" := {
       Notation.dot '(Build_t x0 _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_database : Notation.DoubleColon t "database" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+    }.
     Global Instance Get_exec_context : Notation.Dot "exec_context" := {
       Notation.dot '(Build_t _ x1 _ _ _) := x1;
+    }.
+    Global Instance Get_AF_exec_context
+      : Notation.DoubleColon t "exec_context" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
     }.
     Global Instance Get_debug_info : Notation.Dot "debug_info" := {
       Notation.dot '(Build_t _ _ x2 _ _) := x2;
     }.
+    Global Instance Get_AF_debug_info : Notation.DoubleColon t "debug_info" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+    }.
     Global Instance Get_chain_spec : Notation.Dot "chain_spec" := {
       Notation.dot '(Build_t _ _ _ x3 _) := x3;
+    }.
+    Global Instance Get_AF_chain_spec : Notation.DoubleColon t "chain_spec" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
     }.
     Global Instance Get_chain_extension_handler
       : Notation.Dot "chain_extension_handler" := {
       Notation.dot '(Build_t _ _ _ _ x4) := x4;
+    }.
+    Global Instance Get_AF_chain_extension_handler
+      : Notation.DoubleColon t "chain_extension_handler" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
     }.
   End Engine.
   Definition Engine : Set := Engine.t.
@@ -100,11 +120,21 @@ Module ext.
     Global Instance Get_gas_price : Notation.Dot "gas_price" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_gas_price : Notation.DoubleColon t "gas_price" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_minimum_balance : Notation.Dot "minimum_balance" := {
       Notation.dot '(Build_t _ x1 _) := x1;
     }.
+    Global Instance Get_AF_minimum_balance
+      : Notation.DoubleColon t "minimum_balance" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
+    }.
     Global Instance Get_block_time : Notation.Dot "block_time" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_block_time : Notation.DoubleColon t "block_time" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End ChainSpec.
   Definition ChainSpec : Set := ChainSpec.t.
@@ -153,18 +183,35 @@ Module Engine.
   Global Instance Get_database : Notation.Dot "database" := {
     Notation.dot '(Build_t x0 _ _ _ _) := x0;
   }.
+  Global Instance Get_AF_database : Notation.DoubleColon t "database" := {
+    Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+  }.
   Global Instance Get_exec_context : Notation.Dot "exec_context" := {
     Notation.dot '(Build_t _ x1 _ _ _) := x1;
+  }.
+  Global Instance Get_AF_exec_context
+    : Notation.DoubleColon t "exec_context" := {
+    Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
   }.
   Global Instance Get_debug_info : Notation.Dot "debug_info" := {
     Notation.dot '(Build_t _ _ x2 _ _) := x2;
   }.
+  Global Instance Get_AF_debug_info : Notation.DoubleColon t "debug_info" := {
+    Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+  }.
   Global Instance Get_chain_spec : Notation.Dot "chain_spec" := {
     Notation.dot '(Build_t _ _ _ x3 _) := x3;
+  }.
+  Global Instance Get_AF_chain_spec : Notation.DoubleColon t "chain_spec" := {
+    Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
   }.
   Global Instance Get_chain_extension_handler
     : Notation.Dot "chain_extension_handler" := {
     Notation.dot '(Build_t _ _ _ _ x4) := x4;
+  }.
+  Global Instance Get_AF_chain_extension_handler
+    : Notation.DoubleColon t "chain_extension_handler" := {
+    Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
   }.
 End Engine.
 Definition Engine : Set := Engine.t.
@@ -181,11 +228,21 @@ Module ChainSpec.
   Global Instance Get_gas_price : Notation.Dot "gas_price" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_gas_price : Notation.DoubleColon t "gas_price" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_minimum_balance : Notation.Dot "minimum_balance" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_minimum_balance
+    : Notation.DoubleColon t "minimum_balance" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_block_time : Notation.Dot "block_time" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_block_time : Notation.DoubleColon t "block_time" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End ChainSpec.
 Definition ChainSpec : Set := ChainSpec.t.
@@ -202,8 +259,14 @@ Module test_api.
     Global Instance Get_topics : Notation.Dot "topics" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_data : Notation.Dot "data" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End EmittedEvent.
   Definition EmittedEvent : Set := EmittedEvent.t.
@@ -217,6 +280,10 @@ Module test_api.
     
     Global Instance Get_debug_messages : Notation.Dot "debug_messages" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_debug_messages
+      : Notation.DoubleColon t "debug_messages" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End RecordedDebugMessages.
   Definition RecordedDebugMessages : Set := RecordedDebugMessages.t.
@@ -243,19 +310,39 @@ Module test_api.
     Global Instance Get_emitted_events : Notation.Dot "emitted_events" := {
       Notation.dot '(Build_t x0 _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_emitted_events
+      : Notation.DoubleColon t "emitted_events" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+    }.
     Global Instance Get_emitted_debug_messages
       : Notation.Dot "emitted_debug_messages" := {
       Notation.dot '(Build_t _ x1 _ _ _) := x1;
     }.
+    Global Instance Get_AF_emitted_debug_messages
+      : Notation.DoubleColon t "emitted_debug_messages" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
+    }.
     Global Instance Get_count_reads : Notation.Dot "count_reads" := {
       Notation.dot '(Build_t _ _ x2 _ _) := x2;
+    }.
+    Global Instance Get_AF_count_reads
+      : Notation.DoubleColon t "count_reads" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
     }.
     Global Instance Get_count_writes : Notation.Dot "count_writes" := {
       Notation.dot '(Build_t _ _ _ x3 _) := x3;
     }.
+    Global Instance Get_AF_count_writes
+      : Notation.DoubleColon t "count_writes" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+    }.
     Global Instance Get_cells_per_account
       : Notation.Dot "cells_per_account" := {
       Notation.dot '(Build_t _ _ _ _ x4) := x4;
+    }.
+    Global Instance Get_AF_cells_per_account
+      : Notation.DoubleColon t "cells_per_account" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
     }.
   End DebugInfo.
   Definition DebugInfo : Set := DebugInfo.t.
@@ -272,8 +359,14 @@ Module EmittedEvent.
   Global Instance Get_topics : Notation.Dot "topics" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_data : Notation.Dot "data" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End EmittedEvent.
 Definition EmittedEvent : Set := EmittedEvent.t.
@@ -287,6 +380,10 @@ Module RecordedDebugMessages.
   
   Global Instance Get_debug_messages : Notation.Dot "debug_messages" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_debug_messages
+    : Notation.DoubleColon t "debug_messages" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End RecordedDebugMessages.
 Definition RecordedDebugMessages : Set := RecordedDebugMessages.t.
@@ -313,18 +410,37 @@ Module DebugInfo.
   Global Instance Get_emitted_events : Notation.Dot "emitted_events" := {
     Notation.dot '(Build_t x0 _ _ _ _) := x0;
   }.
+  Global Instance Get_AF_emitted_events
+    : Notation.DoubleColon t "emitted_events" := {
+    Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+  }.
   Global Instance Get_emitted_debug_messages
     : Notation.Dot "emitted_debug_messages" := {
     Notation.dot '(Build_t _ x1 _ _ _) := x1;
   }.
+  Global Instance Get_AF_emitted_debug_messages
+    : Notation.DoubleColon t "emitted_debug_messages" := {
+    Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
+  }.
   Global Instance Get_count_reads : Notation.Dot "count_reads" := {
     Notation.dot '(Build_t _ _ x2 _ _) := x2;
+  }.
+  Global Instance Get_AF_count_reads : Notation.DoubleColon t "count_reads" := {
+    Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
   }.
   Global Instance Get_count_writes : Notation.Dot "count_writes" := {
     Notation.dot '(Build_t _ _ _ x3 _) := x3;
   }.
+  Global Instance Get_AF_count_writes
+    : Notation.DoubleColon t "count_writes" := {
+    Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+  }.
   Global Instance Get_cells_per_account : Notation.Dot "cells_per_account" := {
     Notation.dot '(Build_t _ _ _ _ x4) := x4;
+  }.
+  Global Instance Get_AF_cells_per_account
+    : Notation.DoubleColon t "cells_per_account" := {
+    Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
   }.
 End DebugInfo.
 Definition DebugInfo : Set := DebugInfo.t.
@@ -345,8 +461,14 @@ Module chain_extension.
     Global Instance Get_registered : Notation.Dot "registered" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_registered : Notation.DoubleColon t "registered" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_output : Notation.Dot "output" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_output : Notation.DoubleColon t "output" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End ChainExtensionHandler.
   Definition ChainExtensionHandler : Set := ChainExtensionHandler.t.
@@ -401,8 +523,14 @@ Module ChainExtensionHandler.
   Global Instance Get_registered : Notation.Dot "registered" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_registered : Notation.DoubleColon t "registered" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_output : Notation.Dot "output" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_output : Notation.DoubleColon t "output" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End ChainExtensionHandler.
 Definition ChainExtensionHandler : Set := ChainExtensionHandler.t.
@@ -461,6 +589,9 @@ Module Database.
   Global Instance Get_hmap : Notation.Dot "hmap" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_hmap : Notation.DoubleColon t "hmap" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Database.
 Definition Database : Set := Database.t.
 
@@ -480,21 +611,42 @@ Module exec_context.
     Global Instance Get_caller : Notation.Dot "caller" := {
       Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_caller : Notation.DoubleColon t "caller" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+    }.
     Global Instance Get_callee : Notation.Dot "callee" := {
       Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+    }.
+    Global Instance Get_AF_callee : Notation.DoubleColon t "callee" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
     }.
     Global Instance Get_value_transferred
       : Notation.Dot "value_transferred" := {
       Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
     }.
+    Global Instance Get_AF_value_transferred
+      : Notation.DoubleColon t "value_transferred" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+    }.
     Global Instance Get_block_number : Notation.Dot "block_number" := {
       Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+    }.
+    Global Instance Get_AF_block_number
+      : Notation.DoubleColon t "block_number" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
     }.
     Global Instance Get_block_timestamp : Notation.Dot "block_timestamp" := {
       Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
     }.
+    Global Instance Get_AF_block_timestamp
+      : Notation.DoubleColon t "block_timestamp" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+    }.
     Global Instance Get_contracts : Notation.Dot "contracts" := {
       Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+    }.
+    Global Instance Get_AF_contracts : Notation.DoubleColon t "contracts" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
     }.
   End ExecContext.
   Definition ExecContext : Set := ExecContext.t.
@@ -515,20 +667,41 @@ Module ExecContext.
   Global Instance Get_caller : Notation.Dot "caller" := {
     Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
   }.
+  Global Instance Get_AF_caller : Notation.DoubleColon t "caller" := {
+    Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+  }.
   Global Instance Get_callee : Notation.Dot "callee" := {
     Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+  }.
+  Global Instance Get_AF_callee : Notation.DoubleColon t "callee" := {
+    Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
   }.
   Global Instance Get_value_transferred : Notation.Dot "value_transferred" := {
     Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
   }.
+  Global Instance Get_AF_value_transferred
+    : Notation.DoubleColon t "value_transferred" := {
+    Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+  }.
   Global Instance Get_block_number : Notation.Dot "block_number" := {
     Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+  }.
+  Global Instance Get_AF_block_number
+    : Notation.DoubleColon t "block_number" := {
+    Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
   }.
   Global Instance Get_block_timestamp : Notation.Dot "block_timestamp" := {
     Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
   }.
+  Global Instance Get_AF_block_timestamp
+    : Notation.DoubleColon t "block_timestamp" := {
+    Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+  }.
   Global Instance Get_contracts : Notation.Dot "contracts" := {
     Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+  }.
+  Global Instance Get_AF_contracts : Notation.DoubleColon t "contracts" := {
+    Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
   }.
 End ExecContext.
 Definition ExecContext : Set := ExecContext.t.

--- a/CoqOfRust/ink/ink_env.v
+++ b/CoqOfRust/ink/ink_env.v
@@ -660,7 +660,7 @@ Module call.
           Type := {
         from_account_id `{H' : State.Trait}
           :
-          ink_env.types.Environment.AccountId -> M (H := H') Self;
+          (ink_env.types.Environment.AccountId (Self := T)) -> M (H := H') Self;
       }.
       
       Global Instance Method_from_account_id `{H' : State.Trait} `(Trait)
@@ -946,7 +946,7 @@ Module hash.
       hash `{H' : State.Trait}
         :
         (ref (Slice u8)) ->
-          (mut_ref ink_env.hash.HashOutput.Type_) ->
+          (mut_ref (ink_env.hash.HashOutput.Type_ (Self := Self))) ->
           M (H := H') unit;
     }.
     
@@ -1097,7 +1097,7 @@ Module topics.
         :
         (ref Self) ->
           (ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B) ->
-          M (H := H') ink_env.topics.TopicsBuilderBackend.Output;
+          M (H := H') (ink_env.topics.TopicsBuilderBackend.Output (Self := B));
     }.
     
     Global Instance Method_RemainingTopics `(Trait)
@@ -1214,7 +1214,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{H' : State.Trait}
         {T : Set}
         `{ink_env.types.Environment.Trait T}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       T::type["AccountId"] -> M (H := H') unit.
   
@@ -1223,7 +1224,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{H' : State.Trait}
         {T : Set}
         `{ink_env.types.Environment.Trait T}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       T::type["AccountId"] -> M (H := H') unit.
   
@@ -1232,7 +1234,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{H' : State.Trait}
         {T : Set}
         `{ink_env.types.Environment.Trait T}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       T::type["AccountId"] -> M (H := H') unit.
   
@@ -1241,7 +1244,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{H' : State.Trait}
         {T : Set}
         `{ink_env.types.Environment.Trait T}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       T::type["AccountId"] -> M (H := H') bool.
   
@@ -1343,7 +1347,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{core.ops.function.FnOnce.Trait F
             (Args := ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.DefaultAccounts
               T)}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       F ->
         M (H := H')
@@ -1355,7 +1360,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{H' : State.Trait}
         {T : Set}
         `{ink_env.types.Environment.Trait T}
-        `{core.convert.From.Trait ink_env.types.Environment.AccountId
+        `{core.convert.From.Trait
+              (ink_env.types.Environment.AccountId (Self := T))
             (T := list u8)},
       M (H := H')
           (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.DefaultAccounts
@@ -1375,8 +1381,9 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         `{ink_env.types.Environment.Trait T}
         `{core.ops.function.FnMut.Trait F (Args := unit)}
         `{core.panic.unwind_safe.UnwindSafe.Trait F}
-        `{core.fmt.Debug.Trait ink_env.types.Environment.AccountId}
-        `{core.fmt.Debug.Trait ink_env.types.Environment.Balance},
+        `{core.fmt.Debug.Trait
+              (ink_env.types.Environment.AccountId (Self := T))}
+        `{core.fmt.Debug.Trait (ink_env.types.Environment.Balance (Self := T))},
       F -> T::type["AccountId"] -> T::type["Balance"] -> M (H := H') unit.
   
   Module CallFlags.
@@ -1628,7 +1635,7 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         :
         (mut_ref Self) ->
           (ref (Slice u8)) ->
-          (mut_ref ink_env.hash.HashOutput.Type_) ->
+          (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
           M (H := H') unit;
       hash_encoded
         `{H' : State.Trait}
@@ -1638,7 +1645,7 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
         :
         (mut_ref Self) ->
           (ref T) ->
-          (mut_ref ink_env.hash.HashOutput.Type_) ->
+          (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
           M (H := H') unit;
       ecdsa_recover `{H' : State.Trait}
         :
@@ -1923,7 +1930,8 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
           M (H := H')
             (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.Result
               (ink_primitives.ConstructorResult
-                ink_env.call.create_builder.ConstructorReturnType.Output));
+                (ink_env.call.create_builder.ConstructorReturnType.Output
+                  (Self := R))));
       terminate_contract
         `{H' : State.Trait}
         {E : Set}
@@ -2396,7 +2404,8 @@ Module api.
         M (H := H')
           (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.Result
             (ink_primitives.ConstructorResult
-              ink_env.call.create_builder.ConstructorReturnType.Output)).
+              (ink_env.call.create_builder.ConstructorReturnType.Output
+                (Self := R)))).
   
   Parameter terminate_contract :
       forall `{H' : State.Trait} {E : Set} `{ink_env.types.Environment.Trait E},
@@ -2436,7 +2445,7 @@ Module api.
   Parameter hash_bytes :
       forall `{H' : State.Trait} {H : Set} `{ink_env.hash.CryptoHash.Trait H},
       (ref (Slice u8)) ->
-        (mut_ref ink_env.hash.HashOutput.Type_) ->
+        (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
         M (H := H') unit.
   
   Parameter hash_encoded :
@@ -2445,7 +2454,9 @@ Module api.
         {H T : Set}
         `{ink_env.hash.CryptoHash.Trait H}
         `{parity_scale_codec.codec.Encode.Trait T},
-      (ref T) -> (mut_ref ink_env.hash.HashOutput.Type_) -> M (H := H') unit.
+      (ref T) ->
+        (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
+        M (H := H') unit.
   
   Parameter ecdsa_recover :
       forall `{H' : State.Trait},
@@ -2653,7 +2664,8 @@ Parameter instantiate_contract :
       M (H := H')
         (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.Result
           (ink_primitives.ConstructorResult
-            ink_env.call.create_builder.ConstructorReturnType.Output)).
+            (ink_env.call.create_builder.ConstructorReturnType.Output
+              (Self := R)))).
 
 Parameter terminate_contract :
     forall `{H' : State.Trait} {E : Set} `{ink_env.types.Environment.Trait E},
@@ -2693,7 +2705,7 @@ Parameter debug_message :
 Parameter hash_bytes :
     forall `{H' : State.Trait} {H : Set} `{ink_env.hash.CryptoHash.Trait H},
     (ref (Slice u8)) ->
-      (mut_ref ink_env.hash.HashOutput.Type_) ->
+      (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
       M (H := H') unit.
 
 Parameter hash_encoded :
@@ -2702,7 +2714,9 @@ Parameter hash_encoded :
       {H T : Set}
       `{ink_env.hash.CryptoHash.Trait H}
       `{parity_scale_codec.codec.Encode.Trait T},
-    (ref T) -> (mut_ref ink_env.hash.HashOutput.Type_) -> M (H := H') unit.
+    (ref T) ->
+      (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
+      M (H := H') unit.
 
 Parameter ecdsa_recover :
     forall `{H' : State.Trait},
@@ -2928,7 +2942,8 @@ Parameter set_caller :
       `{H' : State.Trait}
       {T : Set}
       `{ink_env.types.Environment.Trait T}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     T::type["AccountId"] -> M (H := H') unit.
 
@@ -2937,7 +2952,8 @@ Parameter set_callee :
       `{H' : State.Trait}
       {T : Set}
       `{ink_env.types.Environment.Trait T}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     T::type["AccountId"] -> M (H := H') unit.
 
@@ -2946,7 +2962,8 @@ Parameter set_contract :
       `{H' : State.Trait}
       {T : Set}
       `{ink_env.types.Environment.Trait T}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     T::type["AccountId"] -> M (H := H') unit.
 
@@ -2991,7 +3008,8 @@ Parameter run_test :
       `{core.ops.function.FnOnce.Trait F
           (Args := ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.DefaultAccounts
             T)}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     F ->
       M (H := H')
@@ -3003,7 +3021,8 @@ Parameter default_accounts :
       `{H' : State.Trait}
       {T : Set}
       `{ink_env.types.Environment.Trait T}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     M (H := H')
         (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.DefaultAccounts
@@ -3082,8 +3101,8 @@ Parameter assert_contract_termination :
       `{ink_env.types.Environment.Trait T}
       `{core.ops.function.FnMut.Trait F (Args := unit)}
       `{core.panic.unwind_safe.UnwindSafe.Trait F}
-      `{core.fmt.Debug.Trait ink_env.types.Environment.AccountId}
-      `{core.fmt.Debug.Trait ink_env.types.Environment.Balance},
+      `{core.fmt.Debug.Trait (ink_env.types.Environment.AccountId (Self := T))}
+      `{core.fmt.Debug.Trait (ink_env.types.Environment.Balance (Self := T))},
     F -> T::type["AccountId"] -> T::type["Balance"] -> M (H := H') unit.
 
 Module OnInstance.
@@ -3427,7 +3446,7 @@ Module EnvBackend.
       :
       (mut_ref Self) ->
         (ref (Slice u8)) ->
-        (mut_ref ink_env.hash.HashOutput.Type_) ->
+        (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
         M (H := H') unit;
     hash_encoded
       `{H' : State.Trait}
@@ -3437,7 +3456,7 @@ Module EnvBackend.
       :
       (mut_ref Self) ->
         (ref T) ->
-        (mut_ref ink_env.hash.HashOutput.Type_) ->
+        (mut_ref (ink_env.hash.HashOutput.Type_ (Self := H))) ->
         M (H := H') unit;
     ecdsa_recover `{H' : State.Trait}
       :
@@ -3714,7 +3733,8 @@ Module TypedEnvBackend.
         M (H := H')
           (ink_env.backend_and_call_builder_and_engine_and_engine_test_api_and_error.Result
             (ink_primitives.ConstructorResult
-              ink_env.call.create_builder.ConstructorReturnType.Output));
+              (ink_env.call.create_builder.ConstructorReturnType.Output
+                (Self := R))));
     terminate_contract
       `{H' : State.Trait}
       {E : Set}
@@ -4105,7 +4125,7 @@ Module create_builder.
         Type := {
       from_account_id `{H' : State.Trait}
         :
-        ink_env.types.Environment.AccountId -> M (H := H') Self;
+        (ink_env.types.Environment.AccountId (Self := T)) -> M (H := H') Self;
     }.
     
     Global Instance Method_from_account_id `{H' : State.Trait} `(Trait)
@@ -4318,7 +4338,7 @@ Module FromAccountId.
       Type := {
     from_account_id `{H' : State.Trait}
       :
-      ink_env.types.Environment.AccountId -> M (H := H') Self;
+      (ink_env.types.Environment.AccountId (Self := T)) -> M (H := H') Self;
   }.
   
   Global Instance Method_from_account_id `{H' : State.Trait} `(Trait)
@@ -4506,8 +4526,6 @@ Definition CreateBuilder
     (Args := Args)
     (Salt := Salt)
     (RetType := RetType).
-
-
 
 Module execution_input.
   Module ExecutionInput.
@@ -5133,7 +5151,7 @@ Module CryptoHash.
     hash `{H' : State.Trait}
       :
       (ref (Slice u8)) ->
-        (mut_ref ink_env.hash.HashOutput.Type_) ->
+        (mut_ref (ink_env.hash.HashOutput.Type_ (Self := Self))) ->
         M (H := H') unit;
   }.
   
@@ -5296,7 +5314,7 @@ Module Topics.
       :
       (ref Self) ->
         (ink_env.topics.TopicsBuilder ink_env.topics.state.Uninit E B) ->
-        M (H := H') ink_env.topics.TopicsBuilderBackend.Output;
+        M (H := H') (ink_env.topics.TopicsBuilderBackend.Output (Self := B));
   }.
   
   Global Instance Method_RemainingTopics `(Trait)

--- a/CoqOfRust/ink/ink_env.v
+++ b/CoqOfRust/ink/ink_env.v
@@ -44,18 +44,18 @@ Module arithmetic.
         `{core.convert.From.Trait Self (T := u8)}
         `{num_traits.bounds.Bounded.Trait Self}
         `{core.cmp.Ord.Trait Self}
-        `{core.cmp.PartialOrd.Trait Self (Rhs := Some Self)}
+        `{core.cmp.PartialOrd.Trait Self (Rhs := Self)}
         `{num_traits.identities.Zero.Trait Self}
         `{num_traits.identities.One.Trait Self}
         `{num_traits.bounds.Bounded.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.AddAssign.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.Sub.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.SubAssign.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.Mul.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.MulAssign.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.Div.Trait Self (Rhs := Some Self)}
-        `{core.ops.arith.DivAssign.Trait Self (Rhs := Some Self)}
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)}
+        `{core.ops.arith.AddAssign.Trait Self (Rhs := Self)}
+        `{core.ops.arith.Sub.Trait Self (Rhs := Self)}
+        `{core.ops.arith.SubAssign.Trait Self (Rhs := Self)}
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)}
+        `{core.ops.arith.MulAssign.Trait Self (Rhs := Self)}
+        `{core.ops.arith.Div.Trait Self (Rhs := Self)}
+        `{core.ops.arith.DivAssign.Trait Self (Rhs := Self)}
         `{num_traits.ops.checked.CheckedMul.Trait Self}
         `{ink_env.arithmetic.Saturating.Trait Self}
         `{core.convert.TryFrom.Trait Self (T := u16)}
@@ -149,7 +149,8 @@ Module types.
           `(parity_scale_codec.codec.Codec.Trait AccountId)
           `(ink_env.types.CodecAsType.Trait AccountId)
           `(core.clone.Clone.Trait AccountId)
-          `(core.cmp.PartialEq.Trait AccountId (Rhs := None))
+          `(core.cmp.PartialEq.Trait AccountId
+              (Rhs := core.cmp.PartialEq.Default.Rhs Self))
           `(core.cmp.Eq.Trait AccountId)
           `(core.cmp.Ord.Trait AccountId)
           `(core.convert.AsRef.Trait AccountId (T := Slice u8))
@@ -163,7 +164,8 @@ Module types.
           `(ink_env.types.CodecAsType.Trait Balance)
           `(core.marker.Copy.Trait Balance)
           `(core.clone.Clone.Trait Balance)
-          `(core.cmp.PartialEq.Trait Balance (Rhs := None))
+          `(core.cmp.PartialEq.Trait Balance
+              (Rhs := core.cmp.PartialEq.Default.Rhs Self))
           `(core.cmp.Eq.Trait Balance)
           `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait Balance)
           `(ink_env.types.FromLittleEndian.Trait Balance),
@@ -177,7 +179,8 @@ Module types.
           `(core.marker.Copy.Trait Hash)
           `(core.clone.Clone.Trait Hash)
           `(ink_primitives.types.Clear.Trait Hash)
-          `(core.cmp.PartialEq.Trait Hash (Rhs := None))
+          `(core.cmp.PartialEq.Trait Hash
+              (Rhs := core.cmp.PartialEq.Default.Rhs Self))
           `(core.cmp.Eq.Trait Hash)
           `(core.cmp.Ord.Trait Hash)
           `(core.convert.AsRef.Trait Hash (T := Slice u8))
@@ -191,7 +194,8 @@ Module types.
           `(ink_env.types.CodecAsType.Trait Timestamp)
           `(core.marker.Copy.Trait Timestamp)
           `(core.clone.Clone.Trait Timestamp)
-          `(core.cmp.PartialEq.Trait Timestamp (Rhs := None))
+          `(core.cmp.PartialEq.Trait Timestamp
+              (Rhs := core.cmp.PartialEq.Default.Rhs Self))
           `(core.cmp.Eq.Trait Timestamp)
           `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait Timestamp)
           `(ink_env.types.FromLittleEndian.Trait Timestamp),
@@ -204,7 +208,8 @@ Module types.
           `(ink_env.types.CodecAsType.Trait BlockNumber)
           `(core.marker.Copy.Trait BlockNumber)
           `(core.clone.Clone.Trait BlockNumber)
-          `(core.cmp.PartialEq.Trait BlockNumber (Rhs := None))
+          `(core.cmp.PartialEq.Trait BlockNumber
+              (Rhs := core.cmp.PartialEq.Default.Rhs Self))
           `(core.cmp.Eq.Trait BlockNumber)
           `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait BlockNumber)
           `(ink_env.types.FromLittleEndian.Trait BlockNumber),
@@ -314,7 +319,8 @@ Module Environment.
         `(parity_scale_codec.codec.Codec.Trait AccountId)
         `(ink_env.types.CodecAsType.Trait AccountId)
         `(core.clone.Clone.Trait AccountId)
-        `(core.cmp.PartialEq.Trait AccountId (Rhs := None))
+        `(core.cmp.PartialEq.Trait AccountId
+            (Rhs := core.cmp.PartialEq.Default.Rhs Self))
         `(core.cmp.Eq.Trait AccountId)
         `(core.cmp.Ord.Trait AccountId)
         `(core.convert.AsRef.Trait AccountId (T := Slice u8))
@@ -328,7 +334,8 @@ Module Environment.
         `(ink_env.types.CodecAsType.Trait Balance)
         `(core.marker.Copy.Trait Balance)
         `(core.clone.Clone.Trait Balance)
-        `(core.cmp.PartialEq.Trait Balance (Rhs := None))
+        `(core.cmp.PartialEq.Trait Balance
+            (Rhs := core.cmp.PartialEq.Default.Rhs Self))
         `(core.cmp.Eq.Trait Balance)
         `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait Balance)
         `(ink_env.types.FromLittleEndian.Trait Balance),
@@ -342,7 +349,8 @@ Module Environment.
         `(core.marker.Copy.Trait Hash)
         `(core.clone.Clone.Trait Hash)
         `(ink_primitives.types.Clear.Trait Hash)
-        `(core.cmp.PartialEq.Trait Hash (Rhs := None))
+        `(core.cmp.PartialEq.Trait Hash
+            (Rhs := core.cmp.PartialEq.Default.Rhs Self))
         `(core.cmp.Eq.Trait Hash)
         `(core.cmp.Ord.Trait Hash)
         `(core.convert.AsRef.Trait Hash (T := Slice u8))
@@ -356,7 +364,8 @@ Module Environment.
         `(ink_env.types.CodecAsType.Trait Timestamp)
         `(core.marker.Copy.Trait Timestamp)
         `(core.clone.Clone.Trait Timestamp)
-        `(core.cmp.PartialEq.Trait Timestamp (Rhs := None))
+        `(core.cmp.PartialEq.Trait Timestamp
+            (Rhs := core.cmp.PartialEq.Default.Rhs Self))
         `(core.cmp.Eq.Trait Timestamp)
         `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait Timestamp)
         `(ink_env.types.FromLittleEndian.Trait Timestamp),
@@ -369,7 +378,8 @@ Module Environment.
         `(ink_env.types.CodecAsType.Trait BlockNumber)
         `(core.marker.Copy.Trait BlockNumber)
         `(core.clone.Clone.Trait BlockNumber)
-        `(core.cmp.PartialEq.Trait BlockNumber (Rhs := None))
+        `(core.cmp.PartialEq.Trait BlockNumber
+            (Rhs := core.cmp.PartialEq.Default.Rhs Self))
         `(core.cmp.Eq.Trait BlockNumber)
         `(ink_env.arithmetic.AtLeast32BitUnsigned.Trait BlockNumber)
         `(ink_env.types.FromLittleEndian.Trait BlockNumber),
@@ -2765,18 +2775,18 @@ Module BaseArithmetic.
       `{core.convert.From.Trait Self (T := u8)}
       `{num_traits.bounds.Bounded.Trait Self}
       `{core.cmp.Ord.Trait Self}
-      `{core.cmp.PartialOrd.Trait Self (Rhs := Some Self)}
+      `{core.cmp.PartialOrd.Trait Self (Rhs := Self)}
       `{num_traits.identities.Zero.Trait Self}
       `{num_traits.identities.One.Trait Self}
       `{num_traits.bounds.Bounded.Trait Self}
-      `{core.ops.arith.Add.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.AddAssign.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.Sub.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.SubAssign.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.Mul.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.MulAssign.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.Div.Trait Self (Rhs := Some Self)}
-      `{core.ops.arith.DivAssign.Trait Self (Rhs := Some Self)}
+      `{core.ops.arith.Add.Trait Self (Rhs := Self)}
+      `{core.ops.arith.AddAssign.Trait Self (Rhs := Self)}
+      `{core.ops.arith.Sub.Trait Self (Rhs := Self)}
+      `{core.ops.arith.SubAssign.Trait Self (Rhs := Self)}
+      `{core.ops.arith.Mul.Trait Self (Rhs := Self)}
+      `{core.ops.arith.MulAssign.Trait Self (Rhs := Self)}
+      `{core.ops.arith.Div.Trait Self (Rhs := Self)}
+      `{core.ops.arith.DivAssign.Trait Self (Rhs := Self)}
       `{num_traits.ops.checked.CheckedMul.Trait Self}
       `{ink_env.arithmetic.Saturating.Trait Self}
       `{core.convert.TryFrom.Trait Self (T := u16)}

--- a/CoqOfRust/ink/ink_env.v
+++ b/CoqOfRust/ink/ink_env.v
@@ -539,6 +539,9 @@ Module call.
       Global Instance Get_bytes : Notation.Dot "bytes" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End Selector.
     Definition Selector : Set := Selector.t.
   End selector.
@@ -557,8 +560,14 @@ Module call.
         Global Instance Get_selector : Notation.Dot "selector" := {
           Notation.dot '(Build_t x0 _) := x0;
         }.
+        Global Instance Get_AF_selector : Notation.DoubleColon t "selector" := {
+          Notation.double_colon '(Build_t x0 _) := x0;
+        }.
         Global Instance Get_args : Notation.Dot "args" := {
           Notation.dot '(Build_t _ x1) := x1;
+        }.
+        Global Instance Get_AF_args : Notation.DoubleColon t "args" := {
+          Notation.double_colon '(Build_t _ x1) := x1;
         }.
       End ExecutionInput.
     End ExecutionInput.
@@ -578,8 +587,14 @@ Module call.
         Global Instance Get_head : Notation.Dot "head" := {
           Notation.dot '(Build_t x0 _) := x0;
         }.
+        Global Instance Get_AF_head : Notation.DoubleColon t "head" := {
+          Notation.double_colon '(Build_t x0 _) := x0;
+        }.
         Global Instance Get_rest : Notation.Dot "rest" := {
           Notation.dot '(Build_t _ x1) := x1;
+        }.
+        Global Instance Get_AF_rest : Notation.DoubleColon t "rest" := {
+          Notation.double_colon '(Build_t _ x1) := x1;
         }.
       End ArgumentList.
     End ArgumentList.
@@ -597,6 +612,9 @@ Module call.
         
         Global Instance Get_arg : Notation.Dot "arg" := {
           Notation.dot '(Build_t x0) := x0;
+        }.
+        Global Instance Get_AF_arg : Notation.DoubleColon t "arg" := {
+          Notation.double_colon '(Build_t x0) := x0;
         }.
       End Argument.
     End Argument.
@@ -693,23 +711,50 @@ Module call.
         Global Instance Get_code_hash : Notation.Dot "code_hash" := {
           Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
         }.
+        Global Instance Get_AF_code_hash
+          : Notation.DoubleColon t "code_hash" := {
+          Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+        }.
         Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
           Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+        }.
+        Global Instance Get_AF_gas_limit
+          : Notation.DoubleColon t "gas_limit" := {
+          Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
         }.
         Global Instance Get_endowment : Notation.Dot "endowment" := {
           Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
         }.
+        Global Instance Get_AF_endowment
+          : Notation.DoubleColon t "endowment" := {
+          Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+        }.
         Global Instance Get_exec_input : Notation.Dot "exec_input" := {
           Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+        }.
+        Global Instance Get_AF_exec_input
+          : Notation.DoubleColon t "exec_input" := {
+          Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
         }.
         Global Instance Get_salt_bytes : Notation.Dot "salt_bytes" := {
           Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
         }.
+        Global Instance Get_AF_salt_bytes
+          : Notation.DoubleColon t "salt_bytes" := {
+          Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+        }.
         Global Instance Get__return_type : Notation.Dot "_return_type" := {
           Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
         }.
+        Global Instance Get_AF__return_type
+          : Notation.DoubleColon t "_return_type" := {
+          Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+        }.
         Global Instance Get__phantom : Notation.Dot "_phantom" := {
           Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+        }.
+        Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+          Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
         }.
       End CreateParams.
     End CreateParams.
@@ -744,23 +789,49 @@ Module call.
         Global Instance Get_code_hash : Notation.Dot "code_hash" := {
           Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
         }.
+        Global Instance Get_AF_code_hash
+          : Notation.DoubleColon t "code_hash" := {
+          Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+        }.
         Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
           Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+        }.
+        Global Instance Get_AF_gas_limit
+          : Notation.DoubleColon t "gas_limit" := {
+          Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
         }.
         Global Instance Get_endowment : Notation.Dot "endowment" := {
           Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
         }.
+        Global Instance Get_AF_endowment
+          : Notation.DoubleColon t "endowment" := {
+          Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+        }.
         Global Instance Get_exec_input : Notation.Dot "exec_input" := {
           Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+        }.
+        Global Instance Get_AF_exec_input
+          : Notation.DoubleColon t "exec_input" := {
+          Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
         }.
         Global Instance Get_salt : Notation.Dot "salt" := {
           Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
         }.
+        Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+          Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+        }.
         Global Instance Get_return_type : Notation.Dot "return_type" := {
           Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
         }.
+        Global Instance Get_AF_return_type
+          : Notation.DoubleColon t "return_type" := {
+          Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+        }.
         Global Instance Get__phantom : Notation.Dot "_phantom" := {
           Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+        }.
+        Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+          Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
         }.
       End CreateBuilder.
     End CreateBuilder.
@@ -793,6 +864,9 @@ Module engine.
         Global Instance Get_bytes : Notation.Dot "bytes" := {
           Notation.dot '(Build_t x0) := x0;
         }.
+        Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+          Notation.double_colon '(Build_t x0) := x0;
+        }.
       End CallData.
       Definition CallData : Set := CallData.t.
     End call_data.
@@ -807,6 +881,9 @@ Module engine.
         
         Global Instance Get_topics : Notation.Dot "topics" := {
           Notation.dot '(Build_t x0) := x0;
+        }.
+        Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+          Notation.double_colon '(Build_t x0) := x0;
         }.
       End TopicsBuilder.
       Definition TopicsBuilder : Set := TopicsBuilder.t.
@@ -855,11 +932,7 @@ Module hash.
   End HashOutput.
   
   Module CryptoHash.
-    Class Trait
-        (Self : Set)
-        `{ink_env.hash.HashOutput.Trait Self}
-        `{ink_env.hash.private.Sealed.Trait Self} :
-        Type := {
+    Class Trait (Self : Set) `{ink_env.hash.HashOutput.Trait Self} : Type := {
       hash `{H' : State.Trait}
         :
         (ref (Slice u8)) ->
@@ -946,8 +1019,14 @@ Module topics.
       Global Instance Get_backend : Notation.Dot "backend" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_backend : Notation.DoubleColon t "backend" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_state : Notation.Dot "state" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_state : Notation.DoubleColon t "state" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End TopicsBuilder.
   End TopicsBuilder.
@@ -1039,8 +1118,14 @@ Module topics.
       Global Instance Get_prefix : Notation.Dot "prefix" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_prefix : Notation.DoubleColon t "prefix" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_value : Notation.Dot "value" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End PrefixedValue.
   End PrefixedValue.
@@ -1083,8 +1168,14 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
     Global Instance Get_topics : Notation.Dot "topics" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_data : Notation.Dot "data" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End EmittedEvent.
   Definition EmittedEvent : Set := EmittedEvent.t.
@@ -1193,20 +1284,38 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
       Global Instance Get_alice : Notation.Dot "alice" := {
         Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_alice : Notation.DoubleColon t "alice" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+      }.
       Global Instance Get_bob : Notation.Dot "bob" := {
         Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+      }.
+      Global Instance Get_AF_bob : Notation.DoubleColon t "bob" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
       }.
       Global Instance Get_charlie : Notation.Dot "charlie" := {
         Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
       }.
+      Global Instance Get_AF_charlie : Notation.DoubleColon t "charlie" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+      }.
       Global Instance Get_django : Notation.Dot "django" := {
         Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+      }.
+      Global Instance Get_AF_django : Notation.DoubleColon t "django" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
       }.
       Global Instance Get_eve : Notation.Dot "eve" := {
         Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
       }.
+      Global Instance Get_AF_eve : Notation.DoubleColon t "eve" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+      }.
       Global Instance Get_frank : Notation.Dot "frank" := {
         Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+      }.
+      Global Instance Get_AF_frank : Notation.DoubleColon t "frank" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
       }.
     End DefaultAccounts.
   End DefaultAccounts.
@@ -1273,14 +1382,29 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
     Global Instance Get_forward_input : Notation.Dot "forward_input" := {
       Notation.dot '(Build_t x0 _ _ _) := x0;
     }.
+    Global Instance Get_AF_forward_input
+      : Notation.DoubleColon t "forward_input" := {
+      Notation.double_colon '(Build_t x0 _ _ _) := x0;
+    }.
     Global Instance Get_clone_input : Notation.Dot "clone_input" := {
       Notation.dot '(Build_t _ x1 _ _) := x1;
+    }.
+    Global Instance Get_AF_clone_input
+      : Notation.DoubleColon t "clone_input" := {
+      Notation.double_colon '(Build_t _ x1 _ _) := x1;
     }.
     Global Instance Get_tail_call : Notation.Dot "tail_call" := {
       Notation.dot '(Build_t _ _ x2 _) := x2;
     }.
+    Global Instance Get_AF_tail_call : Notation.DoubleColon t "tail_call" := {
+      Notation.double_colon '(Build_t _ _ x2 _) := x2;
+    }.
     Global Instance Get_allow_reentry : Notation.Dot "allow_reentry" := {
       Notation.dot '(Build_t _ _ _ x3) := x3;
+    }.
+    Global Instance Get_AF_allow_reentry
+      : Notation.DoubleColon t "allow_reentry" := {
+      Notation.double_colon '(Build_t _ _ _ x3) := x3;
     }.
   End CallFlags.
   Definition CallFlags : Set := CallFlags.t.
@@ -1304,17 +1428,35 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
       Global Instance Get_call_type : Notation.Dot "call_type" := {
         Notation.dot '(Build_t x0 _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_call_type : Notation.DoubleColon t "call_type" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+      }.
       Global Instance Get_call_flags : Notation.Dot "call_flags" := {
         Notation.dot '(Build_t _ x1 _ _ _) := x1;
+      }.
+      Global Instance Get_AF_call_flags
+        : Notation.DoubleColon t "call_flags" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
       }.
       Global Instance Get__return_type : Notation.Dot "_return_type" := {
         Notation.dot '(Build_t _ _ x2 _ _) := x2;
       }.
+      Global Instance Get_AF__return_type
+        : Notation.DoubleColon t "_return_type" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+      }.
       Global Instance Get_exec_input : Notation.Dot "exec_input" := {
         Notation.dot '(Build_t _ _ _ x3 _) := x3;
       }.
+      Global Instance Get_AF_exec_input
+        : Notation.DoubleColon t "exec_input" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+      }.
       Global Instance Get__phantom : Notation.Dot "_phantom" := {
         Notation.dot '(Build_t _ _ _ _ x4) := x4;
+      }.
+      Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
       }.
     End CallParams.
   End CallParams.
@@ -1339,12 +1481,22 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
       Global Instance Get_callee : Notation.Dot "callee" := {
         Notation.dot '(Build_t x0 _ _) := x0;
       }.
+      Global Instance Get_AF_callee : Notation.DoubleColon t "callee" := {
+        Notation.double_colon '(Build_t x0 _ _) := x0;
+      }.
       Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
         Notation.dot '(Build_t _ x1 _) := x1;
+      }.
+      Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+        Notation.double_colon '(Build_t _ x1 _) := x1;
       }.
       Global Instance Get_transferred_value
         : Notation.Dot "transferred_value" := {
         Notation.dot '(Build_t _ _ x2) := x2;
+      }.
+      Global Instance Get_AF_transferred_value
+        : Notation.DoubleColon t "transferred_value" := {
+        Notation.double_colon '(Build_t _ _ x2) := x2;
       }.
     End Call.
   End Call.
@@ -1364,6 +1516,9 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
       Global Instance Get_code_hash : Notation.Dot "code_hash" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End DelegateCall.
   End DelegateCall.
   Definition DelegateCall
@@ -1381,6 +1536,9 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
     
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End ReturnFlags.
   Definition ReturnFlags : Set := ReturnFlags.t.
@@ -2029,17 +2187,35 @@ Module backend_and_call_builder_and_engine_and_engine_test_api_and_error.
       Global Instance Get_call_type : Notation.Dot "call_type" := {
         Notation.dot '(Build_t x0 _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_call_type : Notation.DoubleColon t "call_type" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+      }.
       Global Instance Get_call_flags : Notation.Dot "call_flags" := {
         Notation.dot '(Build_t _ x1 _ _ _) := x1;
+      }.
+      Global Instance Get_AF_call_flags
+        : Notation.DoubleColon t "call_flags" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
       }.
       Global Instance Get_exec_input : Notation.Dot "exec_input" := {
         Notation.dot '(Build_t _ _ x2 _ _) := x2;
       }.
+      Global Instance Get_AF_exec_input
+        : Notation.DoubleColon t "exec_input" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+      }.
       Global Instance Get_return_type : Notation.Dot "return_type" := {
         Notation.dot '(Build_t _ _ _ x3 _) := x3;
       }.
+      Global Instance Get_AF_return_type
+        : Notation.DoubleColon t "return_type" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+      }.
       Global Instance Get__phantom : Notation.Dot "_phantom" := {
         Notation.dot '(Build_t _ _ _ _ x4) := x4;
+      }.
+      Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
       }.
     End CallBuilder.
   End CallBuilder.
@@ -2702,8 +2878,14 @@ Module EmittedEvent.
   Global Instance Get_topics : Notation.Dot "topics" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_data : Notation.Dot "data" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_data : Notation.DoubleColon t "data" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End EmittedEvent.
 Definition EmittedEvent : Set := EmittedEvent.t.
@@ -2835,20 +3017,38 @@ Module DefaultAccounts.
     Global Instance Get_alice : Notation.Dot "alice" := {
       Notation.dot '(Build_t x0 _ _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_alice : Notation.DoubleColon t "alice" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _ _) := x0;
+    }.
     Global Instance Get_bob : Notation.Dot "bob" := {
       Notation.dot '(Build_t _ x1 _ _ _ _) := x1;
+    }.
+    Global Instance Get_AF_bob : Notation.DoubleColon t "bob" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _ _) := x1;
     }.
     Global Instance Get_charlie : Notation.Dot "charlie" := {
       Notation.dot '(Build_t _ _ x2 _ _ _) := x2;
     }.
+    Global Instance Get_AF_charlie : Notation.DoubleColon t "charlie" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _ _) := x2;
+    }.
     Global Instance Get_django : Notation.Dot "django" := {
       Notation.dot '(Build_t _ _ _ x3 _ _) := x3;
+    }.
+    Global Instance Get_AF_django : Notation.DoubleColon t "django" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _ _) := x3;
     }.
     Global Instance Get_eve : Notation.Dot "eve" := {
       Notation.dot '(Build_t _ _ _ _ x4 _) := x4;
     }.
+    Global Instance Get_AF_eve : Notation.DoubleColon t "eve" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4 _) := x4;
+    }.
     Global Instance Get_frank : Notation.Dot "frank" := {
       Notation.dot '(Build_t _ _ _ _ _ x5) := x5;
+    }.
+    Global Instance Get_AF_frank : Notation.DoubleColon t "frank" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ x5) := x5;
     }.
   End DefaultAccounts.
 End DefaultAccounts.
@@ -2921,17 +3121,33 @@ Module CallParams.
     Global Instance Get_call_type : Notation.Dot "call_type" := {
       Notation.dot '(Build_t x0 _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_call_type : Notation.DoubleColon t "call_type" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+    }.
     Global Instance Get_call_flags : Notation.Dot "call_flags" := {
       Notation.dot '(Build_t _ x1 _ _ _) := x1;
+    }.
+    Global Instance Get_AF_call_flags : Notation.DoubleColon t "call_flags" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
     }.
     Global Instance Get__return_type : Notation.Dot "_return_type" := {
       Notation.dot '(Build_t _ _ x2 _ _) := x2;
     }.
+    Global Instance Get_AF__return_type
+      : Notation.DoubleColon t "_return_type" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+    }.
     Global Instance Get_exec_input : Notation.Dot "exec_input" := {
       Notation.dot '(Build_t _ _ _ x3 _) := x3;
     }.
+    Global Instance Get_AF_exec_input : Notation.DoubleColon t "exec_input" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+    }.
     Global Instance Get__phantom : Notation.Dot "_phantom" := {
       Notation.dot '(Build_t _ _ _ _ x4) := x4;
+    }.
+    Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
     }.
   End CallParams.
 End CallParams.
@@ -2969,12 +3185,22 @@ Module Call.
     Global Instance Get_callee : Notation.Dot "callee" := {
       Notation.dot '(Build_t x0 _ _) := x0;
     }.
+    Global Instance Get_AF_callee : Notation.DoubleColon t "callee" := {
+      Notation.double_colon '(Build_t x0 _ _) := x0;
+    }.
     Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
       Notation.dot '(Build_t _ x1 _) := x1;
+    }.
+    Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+      Notation.double_colon '(Build_t _ x1 _) := x1;
     }.
     Global Instance Get_transferred_value
       : Notation.Dot "transferred_value" := {
       Notation.dot '(Build_t _ _ x2) := x2;
+    }.
+    Global Instance Get_AF_transferred_value
+      : Notation.DoubleColon t "transferred_value" := {
+      Notation.double_colon '(Build_t _ _ x2) := x2;
     }.
   End Call.
 End Call.
@@ -2993,6 +3219,9 @@ Module DelegateCall.
     
     Global Instance Get_code_hash : Notation.Dot "code_hash" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End DelegateCall.
 End DelegateCall.
@@ -3018,17 +3247,33 @@ Module CallBuilder.
     Global Instance Get_call_type : Notation.Dot "call_type" := {
       Notation.dot '(Build_t x0 _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_call_type : Notation.DoubleColon t "call_type" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _) := x0;
+    }.
     Global Instance Get_call_flags : Notation.Dot "call_flags" := {
       Notation.dot '(Build_t _ x1 _ _ _) := x1;
+    }.
+    Global Instance Get_AF_call_flags : Notation.DoubleColon t "call_flags" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _) := x1;
     }.
     Global Instance Get_exec_input : Notation.Dot "exec_input" := {
       Notation.dot '(Build_t _ _ x2 _ _) := x2;
     }.
+    Global Instance Get_AF_exec_input : Notation.DoubleColon t "exec_input" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _) := x2;
+    }.
     Global Instance Get_return_type : Notation.Dot "return_type" := {
       Notation.dot '(Build_t _ _ _ x3 _) := x3;
     }.
+    Global Instance Get_AF_return_type
+      : Notation.DoubleColon t "return_type" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _) := x3;
+    }.
     Global Instance Get__phantom : Notation.Dot "_phantom" := {
       Notation.dot '(Build_t _ _ _ _ x4) := x4;
+    }.
+    Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4) := x4;
     }.
   End CallBuilder.
 End CallBuilder.
@@ -3052,6 +3297,9 @@ Module ReturnFlags.
   Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End ReturnFlags.
 Definition ReturnFlags : Set := ReturnFlags.t.
 
@@ -3068,14 +3316,28 @@ Module CallFlags.
   Global Instance Get_forward_input : Notation.Dot "forward_input" := {
     Notation.dot '(Build_t x0 _ _ _) := x0;
   }.
+  Global Instance Get_AF_forward_input
+    : Notation.DoubleColon t "forward_input" := {
+    Notation.double_colon '(Build_t x0 _ _ _) := x0;
+  }.
   Global Instance Get_clone_input : Notation.Dot "clone_input" := {
     Notation.dot '(Build_t _ x1 _ _) := x1;
+  }.
+  Global Instance Get_AF_clone_input : Notation.DoubleColon t "clone_input" := {
+    Notation.double_colon '(Build_t _ x1 _ _) := x1;
   }.
   Global Instance Get_tail_call : Notation.Dot "tail_call" := {
     Notation.dot '(Build_t _ _ x2 _) := x2;
   }.
+  Global Instance Get_AF_tail_call : Notation.DoubleColon t "tail_call" := {
+    Notation.double_colon '(Build_t _ _ x2 _) := x2;
+  }.
   Global Instance Get_allow_reentry : Notation.Dot "allow_reentry" := {
     Notation.dot '(Build_t _ _ _ x3) := x3;
+  }.
+  Global Instance Get_AF_allow_reentry
+    : Notation.DoubleColon t "allow_reentry" := {
+    Notation.double_colon '(Build_t _ _ _ x3) := x3;
   }.
 End CallFlags.
 Definition CallFlags : Set := CallFlags.t.
@@ -3894,23 +4156,47 @@ Module create_builder.
       Global Instance Get_code_hash : Notation.Dot "code_hash" := {
         Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+      }.
       Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
         Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+      }.
+      Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
       }.
       Global Instance Get_endowment : Notation.Dot "endowment" := {
         Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
       }.
+      Global Instance Get_AF_endowment : Notation.DoubleColon t "endowment" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+      }.
       Global Instance Get_exec_input : Notation.Dot "exec_input" := {
         Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+      }.
+      Global Instance Get_AF_exec_input
+        : Notation.DoubleColon t "exec_input" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
       }.
       Global Instance Get_salt_bytes : Notation.Dot "salt_bytes" := {
         Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
       }.
+      Global Instance Get_AF_salt_bytes
+        : Notation.DoubleColon t "salt_bytes" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+      }.
       Global Instance Get__return_type : Notation.Dot "_return_type" := {
         Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
       }.
+      Global Instance Get_AF__return_type
+        : Notation.DoubleColon t "_return_type" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+      }.
       Global Instance Get__phantom : Notation.Dot "_phantom" := {
         Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+      }.
+      Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
       }.
     End CreateParams.
   End CreateParams.
@@ -3945,23 +4231,46 @@ Module create_builder.
       Global Instance Get_code_hash : Notation.Dot "code_hash" := {
         Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
       }.
+      Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+        Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+      }.
       Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
         Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+      }.
+      Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+        Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
       }.
       Global Instance Get_endowment : Notation.Dot "endowment" := {
         Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
       }.
+      Global Instance Get_AF_endowment : Notation.DoubleColon t "endowment" := {
+        Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+      }.
       Global Instance Get_exec_input : Notation.Dot "exec_input" := {
         Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+      }.
+      Global Instance Get_AF_exec_input
+        : Notation.DoubleColon t "exec_input" := {
+        Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
       }.
       Global Instance Get_salt : Notation.Dot "salt" := {
         Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
       }.
+      Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+        Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+      }.
       Global Instance Get_return_type : Notation.Dot "return_type" := {
         Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
       }.
+      Global Instance Get_AF_return_type
+        : Notation.DoubleColon t "return_type" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+      }.
       Global Instance Get__phantom : Notation.Dot "_phantom" := {
         Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+      }.
+      Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+        Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
       }.
     End CreateBuilder.
   End CreateBuilder.
@@ -4060,23 +4369,45 @@ Module CreateParams.
     Global Instance Get_code_hash : Notation.Dot "code_hash" := {
       Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+    }.
     Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
       Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+    }.
+    Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
     }.
     Global Instance Get_endowment : Notation.Dot "endowment" := {
       Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
     }.
+    Global Instance Get_AF_endowment : Notation.DoubleColon t "endowment" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+    }.
     Global Instance Get_exec_input : Notation.Dot "exec_input" := {
       Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+    }.
+    Global Instance Get_AF_exec_input : Notation.DoubleColon t "exec_input" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
     }.
     Global Instance Get_salt_bytes : Notation.Dot "salt_bytes" := {
       Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
     }.
+    Global Instance Get_AF_salt_bytes : Notation.DoubleColon t "salt_bytes" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+    }.
     Global Instance Get__return_type : Notation.Dot "_return_type" := {
       Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
     }.
+    Global Instance Get_AF__return_type
+      : Notation.DoubleColon t "_return_type" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+    }.
     Global Instance Get__phantom : Notation.Dot "_phantom" := {
       Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+    }.
+    Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
     }.
   End CreateParams.
 End CreateParams.
@@ -4110,23 +4441,45 @@ Module CreateBuilder.
     Global Instance Get_code_hash : Notation.Dot "code_hash" := {
       Notation.dot '(Build_t x0 _ _ _ _ _ _) := x0;
     }.
+    Global Instance Get_AF_code_hash : Notation.DoubleColon t "code_hash" := {
+      Notation.double_colon '(Build_t x0 _ _ _ _ _ _) := x0;
+    }.
     Global Instance Get_gas_limit : Notation.Dot "gas_limit" := {
       Notation.dot '(Build_t _ x1 _ _ _ _ _) := x1;
+    }.
+    Global Instance Get_AF_gas_limit : Notation.DoubleColon t "gas_limit" := {
+      Notation.double_colon '(Build_t _ x1 _ _ _ _ _) := x1;
     }.
     Global Instance Get_endowment : Notation.Dot "endowment" := {
       Notation.dot '(Build_t _ _ x2 _ _ _ _) := x2;
     }.
+    Global Instance Get_AF_endowment : Notation.DoubleColon t "endowment" := {
+      Notation.double_colon '(Build_t _ _ x2 _ _ _ _) := x2;
+    }.
     Global Instance Get_exec_input : Notation.Dot "exec_input" := {
       Notation.dot '(Build_t _ _ _ x3 _ _ _) := x3;
+    }.
+    Global Instance Get_AF_exec_input : Notation.DoubleColon t "exec_input" := {
+      Notation.double_colon '(Build_t _ _ _ x3 _ _ _) := x3;
     }.
     Global Instance Get_salt : Notation.Dot "salt" := {
       Notation.dot '(Build_t _ _ _ _ x4 _ _) := x4;
     }.
+    Global Instance Get_AF_salt : Notation.DoubleColon t "salt" := {
+      Notation.double_colon '(Build_t _ _ _ _ x4 _ _) := x4;
+    }.
     Global Instance Get_return_type : Notation.Dot "return_type" := {
       Notation.dot '(Build_t _ _ _ _ _ x5 _) := x5;
     }.
+    Global Instance Get_AF_return_type
+      : Notation.DoubleColon t "return_type" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ x5 _) := x5;
+    }.
     Global Instance Get__phantom : Notation.Dot "_phantom" := {
       Notation.dot '(Build_t _ _ _ _ _ _ x6) := x6;
+    }.
+    Global Instance Get_AF__phantom : Notation.DoubleColon t "_phantom" := {
+      Notation.double_colon '(Build_t _ _ _ _ _ _ x6) := x6;
     }.
   End CreateBuilder.
 End CreateBuilder.
@@ -4160,8 +4513,14 @@ Module execution_input.
       Global Instance Get_selector : Notation.Dot "selector" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_selector : Notation.DoubleColon t "selector" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_args : Notation.Dot "args" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_args : Notation.DoubleColon t "args" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End ExecutionInput.
   End ExecutionInput.
@@ -4181,8 +4540,14 @@ Module execution_input.
       Global Instance Get_head : Notation.Dot "head" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_head : Notation.DoubleColon t "head" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_rest : Notation.Dot "rest" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_rest : Notation.DoubleColon t "rest" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End ArgumentList.
   End ArgumentList.
@@ -4200,6 +4565,9 @@ Module execution_input.
       
       Global Instance Get_arg : Notation.Dot "arg" := {
         Notation.dot '(Build_t x0) := x0;
+      }.
+      Global Instance Get_AF_arg : Notation.DoubleColon t "arg" := {
+        Notation.double_colon '(Build_t x0) := x0;
       }.
     End Argument.
   End Argument.
@@ -4234,8 +4602,14 @@ Module ExecutionInput.
     Global Instance Get_selector : Notation.Dot "selector" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_selector : Notation.DoubleColon t "selector" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_args : Notation.Dot "args" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_args : Notation.DoubleColon t "args" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End ExecutionInput.
 End ExecutionInput.
@@ -4254,8 +4628,14 @@ Module ArgumentList.
     Global Instance Get_head : Notation.Dot "head" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_head : Notation.DoubleColon t "head" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_rest : Notation.Dot "rest" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_rest : Notation.DoubleColon t "rest" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End ArgumentList.
 End ArgumentList.
@@ -4278,6 +4658,9 @@ Module Argument.
     
     Global Instance Get_arg : Notation.Dot "arg" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_arg : Notation.DoubleColon t "arg" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End Argument.
 End Argument.
@@ -4304,6 +4687,9 @@ Module selector.
     Global Instance Get_bytes : Notation.Dot "bytes" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End Selector.
   Definition Selector : Set := Selector.t.
 End selector.
@@ -4317,6 +4703,9 @@ Module Selector.
   
   Global Instance Get_bytes : Notation.Dot "bytes" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End Selector.
 Definition Selector : Set := Selector.t.
@@ -4348,8 +4737,14 @@ Module chain_extension.
       Global Instance Get_func_id : Notation.Dot "func_id" := {
         Notation.dot '(Build_t x0 _) := x0;
       }.
+      Global Instance Get_AF_func_id : Notation.DoubleColon t "func_id" := {
+        Notation.double_colon '(Build_t x0 _) := x0;
+      }.
       Global Instance Get_state : Notation.Dot "state" := {
         Notation.dot '(Build_t _ x1) := x1;
+      }.
+      Global Instance Get_AF_state : Notation.DoubleColon t "state" := {
+        Notation.double_colon '(Build_t _ x1) := x1;
       }.
     End ChainExtensionMethod.
   End ChainExtensionMethod.
@@ -4374,6 +4769,10 @@ Module chain_extension.
         
         Global Instance Get_error_code : Notation.Dot "error_code" := {
           Notation.dot '(Build_t x0) := x0;
+        }.
+        Global Instance Get_AF_error_code
+          : Notation.DoubleColon t "error_code" := {
+          Notation.double_colon '(Build_t x0) := x0;
         }.
       End HandleErrorCode.
     End HandleErrorCode.
@@ -4434,8 +4833,14 @@ Module ChainExtensionMethod.
     Global Instance Get_func_id : Notation.Dot "func_id" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_func_id : Notation.DoubleColon t "func_id" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_state : Notation.Dot "state" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_state : Notation.DoubleColon t "state" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End ChainExtensionMethod.
 End ChainExtensionMethod.
@@ -4462,6 +4867,10 @@ Module Wrap_state_1.
         Global Instance Get_error_code : Notation.Dot "error_code" := {
           Notation.dot '(Build_t x0) := x0;
         }.
+        Global Instance Get_AF_error_code
+          : Notation.DoubleColon t "error_code" := {
+          Notation.double_colon '(Build_t x0) := x0;
+        }.
       End HandleErrorCode.
     End HandleErrorCode.
     Definition HandleErrorCode (T : Set) : Set := HandleErrorCode.t (T := T).
@@ -4486,6 +4895,9 @@ Module HandleErrorCode.
     
     Global Instance Get_error_code : Notation.Dot "error_code" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_error_code : Notation.DoubleColon t "error_code" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End HandleErrorCode.
 End HandleErrorCode.
@@ -4558,6 +4970,9 @@ Module off_chain.
       Global Instance Get_bytes : Notation.Dot "bytes" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End CallData.
     Definition CallData : Set := CallData.t.
   End call_data.
@@ -4572,6 +4987,9 @@ Module off_chain.
       
       Global Instance Get_topics : Notation.Dot "topics" := {
         Notation.dot '(Build_t x0) := x0;
+      }.
+      Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+        Notation.double_colon '(Build_t x0) := x0;
       }.
     End TopicsBuilder.
     Definition TopicsBuilder : Set := TopicsBuilder.t.
@@ -4606,6 +5024,9 @@ Module call_data.
     Global Instance Get_bytes : Notation.Dot "bytes" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End CallData.
   Definition CallData : Set := CallData.t.
 End call_data.
@@ -4619,6 +5040,9 @@ Module CallData.
   
   Global Instance Get_bytes : Notation.Dot "bytes" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_bytes : Notation.DoubleColon t "bytes" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End CallData.
 Definition CallData : Set := CallData.t.
@@ -4634,6 +5058,9 @@ Module impls.
     Global Instance Get_topics : Notation.Dot "topics" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End TopicsBuilder.
   Definition TopicsBuilder : Set := TopicsBuilder.t.
 End impls.
@@ -4647,6 +5074,9 @@ Module TopicsBuilder.
   
   Global Instance Get_topics : Notation.Dot "topics" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_topics : Notation.DoubleColon t "topics" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End TopicsBuilder.
 Definition TopicsBuilder : Set := TopicsBuilder.t.
@@ -4689,11 +5119,7 @@ Module HashOutput.
 End HashOutput.
 
 Module CryptoHash.
-  Class Trait
-      (Self : Set)
-      `{ink_env.hash.HashOutput.Trait Self}
-      `{ink_env.hash.private.Sealed.Trait Self} :
-      Type := {
+  Class Trait (Self : Set) `{ink_env.hash.HashOutput.Trait Self} : Type := {
     hash `{H' : State.Trait}
       :
       (ref (Slice u8)) ->
@@ -4891,8 +5317,14 @@ Module PrefixedValue.
     Global Instance Get_prefix : Notation.Dot "prefix" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_prefix : Notation.DoubleColon t "prefix" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End PrefixedValue.
 End PrefixedValue.

--- a/CoqOfRust/ink/ink_storage.v
+++ b/CoqOfRust/ink/ink_storage.v
@@ -20,6 +20,9 @@ Module lazy.
         Global Instance Get__marker : Notation.Dot "_marker" := {
           Notation.dot '(Build_t x0) := x0;
         }.
+        Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+          Notation.double_colon '(Build_t x0) := x0;
+        }.
       End Mapping.
     End Mapping.
     Definition Mapping
@@ -42,6 +45,9 @@ Module lazy.
       
       Global Instance Get__marker : Notation.Dot "_marker" := {
         Notation.dot '(Build_t x0) := x0;
+      }.
+      Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
       }.
     End Lazy.
   End Lazy.
@@ -68,6 +74,9 @@ Module mapping.
       Global Instance Get__marker : Notation.Dot "_marker" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End Mapping.
   End Mapping.
   Definition Mapping
@@ -93,6 +102,9 @@ Module Mapping.
     Global Instance Get__marker : Notation.Dot "_marker" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End Mapping.
 End Mapping.
 Definition Mapping
@@ -114,6 +126,9 @@ Module Lazy.
     
     Global Instance Get__marker : Notation.Dot "_marker" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF__marker : Notation.DoubleColon t "_marker" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End Lazy.
 End Lazy.

--- a/CoqOfRust/ink/scale_info.v
+++ b/CoqOfRust/ink/scale_info.v
@@ -560,7 +560,7 @@ Module interner.
       (* Context {T : Set}. *)
       Global Instance I :
         core.cmp.PartialEq.Trait (UntrackedSymbol core.any.TypeId)
-        (Rhs := None).
+        (Rhs := UntrackedSymbol core.any.TypeId).
       Admitted.
     End Impl_PartialEq_for_UntrackedSymbol.
   End Impl_PartialEq_for_UntrackedSymbol.
@@ -579,7 +579,8 @@ Module interner.
     Section Impl_PartialOrd_for_UntrackedSymbol.
       (* Context {T : Set}. *)
       Global Instance I : core.cmp.PartialOrd.Trait
-        (UntrackedSymbol core.any.TypeId) None.
+        (UntrackedSymbol core.any.TypeId)
+        (Rhs := UntrackedSymbol core.any.TypeId).
       Admitted.
     End Impl_PartialOrd_for_UntrackedSymbol.
   End Impl_PartialOrd_for_UntrackedSymbol.
@@ -590,7 +591,7 @@ Module interner.
       (* Context {T : Set}. *)
       Global Instance I : core.cmp.PartialOrd.Trait
         (UntrackedSymbol core.any.TypeId)
-        (Some (UntrackedSymbol core.any.TypeId)).
+        (Rhs := UntrackedSymbol core.any.TypeId).
       Admitted.
     End Impl_PartialOrd_for_UntrackedSymbol'.
   End Impl_PartialOrd_for_UntrackedSymbol'.
@@ -651,18 +652,18 @@ Module form.
     Class Trait
         (Self : Set)
         {Type_ : Set}
-        `{core.cmp.PartialEq.Trait Type_ (Rhs := None)}
+        `{core.cmp.PartialEq.Trait Type_ (Rhs := Type_)}
         `{core.cmp.Eq.Trait Type_}
-        `{core.cmp.PartialOrd.Trait Type_ (Rhs := None)}
+        `{core.cmp.PartialOrd.Trait Type_ (Rhs := Type_)}
         `{core.cmp.Ord.Trait Type_}
         `{core.clone.Clone.Trait Type_}
         `{core.fmt.Debug.Trait Type_}
         `{scale_info.form.JsonSchemaMaybe.Trait Type_}
         {String : Set}
         `{core.convert.AsRef.Trait String (T := str)}
-        `{core.cmp.PartialEq.Trait String (Rhs := None)}
+        `{core.cmp.PartialEq.Trait String (Rhs := String)}
         `{core.cmp.Eq.Trait String}
-        `{core.cmp.PartialOrd.Trait String (Rhs := None)}
+        `{core.cmp.PartialOrd.Trait String (Rhs := String)}
         `{core.cmp.Ord.Trait String}
         `{core.clone.Clone.Trait String}
         `{core.fmt.Debug.Trait String}
@@ -707,7 +708,7 @@ Module form.
   (* manual implementation *)
   Module Impl_PartialEq_for_PortableForm.
     Global Instance I :
-      core.cmp.PartialEq.Trait PortableForm (Rhs := None) := {|
+      core.cmp.PartialEq.Trait PortableForm (Rhs := PortableForm) := {|
       core.cmp.PartialEq.eq `{H : State.Trait} _ _ := Pure (H := H) true;
     |}.
   End Impl_PartialEq_for_PortableForm.
@@ -720,7 +721,7 @@ Module form.
   (* manual implementation *)
   Module Impl_PartialOrd_for_PortableForm.
     Global Instance I :
-      core.cmp.PartialOrd.Trait PortableForm (Some PortableForm) := {|
+      core.cmp.PartialOrd.Trait PortableForm (Rhs := PortableForm) := {|
       core.cmp.PartialOrd.partial_cmp `{H : State.Trait} _ _
         := Pure (H := H) (option.Option.Some std.cmp.Ordering.Equal);
     |}.

--- a/CoqOfRust/ink/update_after_translation.py
+++ b/CoqOfRust/ink/update_after_translation.py
@@ -825,8 +825,7 @@ def update_erc20():
 
 Require CoqOfRust.ink.ink_storage.
 Require CoqOfRust.ink.ink_env.
-Require CoqOfRust.ink.ink.
-""",
+Require CoqOfRust.ink.ink.""",
         content,
     )
 
@@ -850,13 +849,6 @@ Require CoqOfRust.ink.ink.
       H0.(ink_storage_traits.storage.AutoStorableHint.Type_)). Admitted.
 """,
         content,
-    )
-
-    content = sub_exactly_n(
-        r"IS_RESULT := Pure ink.reflect.dispatch.ConstructorOutput.IS_RESULT.",
-        r"IS_RESULT `{State.Trait} := Pure ink.reflect.dispatch.ConstructorOutput.IS_RESULT.",
-        content,
-        2,
     )
 
     content = sub_exactly_once(
@@ -892,30 +884,6 @@ Require CoqOfRust.ink.ink.
     Defined.
     Global Hint Resolve I : core.""",
         content,
-    )
-
-    content = sub_exactly_n(
-        r"    Definition PAYABLE := Pure false.",
-        r"    Definition PAYABLE `{State.Trait} := Pure false.",
-        content,
-        7,
-    )
-
-    content = sub_exactly_n(
-        r"    Definition SELECTOR := Pure",
-        r"    Definition SELECTOR `{State.Trait} := Pure",
-        content,
-        7,
-    )
-
-    content = sub_exactly_once(
-        r'    Definition LABEL := Pure "new".',
-        r'    Definition LABEL `{State.Trait} := Pure "new".',
-        content,
-    )
-
-    content = sub_exactly_n(
-        r"CALLABLE := Pure", r"CALLABLE `{State.Trait} := Pure", content, 14
     )
 
     with open(file_name, "w") as f:

--- a/CoqOfRust/ink/update_after_translation.py
+++ b/CoqOfRust/ink/update_after_translation.py
@@ -566,6 +566,9 @@ Parameter recorded_events :
   Global Instance Get_engine : Notation.Dot "engine" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_engine : Notation.DoubleColon t "engine" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End EnvInstance.""",
         """Module EnvInstance.
   Unset Primitive Projections.
@@ -599,8 +602,14 @@ End private.""",
     Global Instance Get_backend : Notation.Dot "backend" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_backend : Notation.DoubleColon t "backend" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_state : Notation.Dot "state" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_state : Notation.DoubleColon t "state" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End TopicsBuilder.
 End TopicsBuilder.
@@ -816,51 +825,7 @@ def update_erc20():
 
 Require CoqOfRust.ink.ink_storage.
 Require CoqOfRust.ink.ink_env.
-(* @TODO Require CoqOfRust.ink.ink. *)
-
-(** @TODO [erc20] dependencies which are WIP *)
-
-Module ink.
-  Module codegen.
-    Module event.
-      Module topics.
-        Module EventTopics.
-          Parameter t : Set.
-        End EventTopics.
-        Module EventLenTopics.
-          Class Trait (Self : Set) : Type := {
-              LenTopics : Set;
-            }.
-        End EventLenTopics.
-        Definition EventTopics := EventTopics.t.
-      End topics.
-    End event.
-  End codegen.
-  Module reflect.
-    Module dispatch.
-      Module ConstructorOutput.
-        Parameter Error : Set.
-        Definition IS_RESULT : bool. Admitted.
-      End ConstructorOutput.
-
-      Module DispatchableConstructorInfo.
-        Class Trait (Self : Set) := {
-
-            Input : Set;
-            Storage : Set;
-            Output : Set;
-            Error : Set;
-            IS_RESULT `{H' : State.Trait} : M bool;
-            CALLABLE `{H' : State.Trait} : M (unit -> M Self);
-            PAYABLE `{H' : State.Trait} : M bool;
-            SELECTOR `{H' : State.Trait} : M (list Z);
-            LABEL `{H' : State.Trait} : M string;
-          }.
-      End DispatchableConstructorInfo.
-    End dispatch.
-  End reflect.
-End ink.
-
+Require CoqOfRust.ink.ink.
 """,
         content,
     )

--- a/CoqOfRust/ink/update_after_translation.py
+++ b/CoqOfRust/ink/update_after_translation.py
@@ -430,23 +430,29 @@ End TypedEnvBackend.""",
         "",
     )
     content = content.replace(
-        """Parameter build_create :
+        """
+Parameter build_create :
     forall
       `{H' : State.Trait}
       {ContractRef : Set}
       `{ink_env.contract.ContractEnv.Trait ContractRef},
     M (H := H')
         (ink_env.call.create_builder.CreateBuilder
-          ink_env.contract.ContractEnv.Env
+          (ink_env.contract.ContractEnv.Env (Self := ContractRef))
           ContractRef
-          (ink_env.call.common.Unset_ ink_env.types.Environment.Hash)
+          (ink_env.call.common.Unset_
+            (ink_env.types.Environment.Hash
+              (Self := ink_env.contract.ContractEnv.Env (Self := ContractRef))))
           (ink_env.call.common.Unset_ u64)
-          (ink_env.call.common.Unset_ ink_env.types.Environment.Balance)
+          (ink_env.call.common.Unset_
+            (ink_env.types.Environment.Balance
+              (Self := ink_env.contract.ContractEnv.Env (Self := ContractRef))))
           (ink_env.call.common.Unset_
             (ink_env.call.execution_input.ExecutionInput
               ink_env.call.execution_input.EmptyArgumentList))
           (ink_env.call.common.Unset_ ink_env.call.create_builder.state.Salt)
-          (ink_env.call.common.Unset_ (ink_env.call.common.ReturnType unit))).""",
+          (ink_env.call.common.Unset_ (ink_env.call.common.ReturnType unit))).
+""",
         "",
     )
     content = content.replace(
@@ -515,7 +521,8 @@ End OnInstance.""",
       `{H' : State.Trait}
       {T : Set}
       `{ink_env.types.Environment.Trait T}
-      `{core.convert.From.Trait ink_env.types.Environment.AccountId
+      `{core.convert.From.Trait
+            (ink_env.types.Environment.AccountId (Self := T))
           (T := list u8)},
     T::type["AccountId"] -> M (H := H') bool.""",
         "",
@@ -829,13 +836,13 @@ Require CoqOfRust.ink.ink.""",
         content,
     )
 
-    for field in ("total_supply", "balances", "allowances"):
-        content = sub_exactly_n(
-            f"{field} : ink_storage_traits.storage.AutoStorableHint.Type_",
-            f"{field} `{{ink_storage_traits.storage.AutoStorableHint.Trait}} : ink_storage_traits.storage.AutoStorableHint.Type_",
-            content,
-            2,
-        )
+    # for field in ("total_supply", "balances", "allowances"):
+    #     content = sub_exactly_n(
+    #         f"{field} : ink_storage_traits.storage.AutoStorableHint.Type_",
+    #         f"{field} `{{ink_storage_traits.storage.AutoStorableHint.Trait}} : ink_storage_traits.storage.AutoStorableHint.Type_",
+    #         content,
+    #         2,
+    #     )
 
     content = sub_exactly_once(
         r"""Module Impl_core_default_Default_for_erc20_erc20_Erc20.

--- a/CoqOfRust/num_traits.v
+++ b/CoqOfRust/num_traits.v
@@ -1005,21 +1005,21 @@ Module float.
     Global Instance Method_TAU `{H : State.Trait} `(Trait)
       : Notation.Dot "TAU" := {
       Notation.dot`{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))}
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)}
            :=
         (axiom : M (H := H) Self);
     }.
     Global Instance Method_LOG10_2 `{H : State.Trait} `(Trait)
       : Notation.Dot "LOG10_2" := {
       Notation.dot`{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
+          `{core.ops.arith.Div.Trait Self (Rhs := Self)}
            :=
         (axiom : M (H := H) Self);
     }.
     Global Instance Method_LOG2_10 `{H : State.Trait} `(Trait)
       : Notation.Dot "LOG2_10" := {
       Notation.dot`{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
+          `{core.ops.arith.Div.Trait Self (Rhs := Self)}
            :=
         (axiom : M (H := H) Self);
     }.
@@ -1558,21 +1558,21 @@ Module FloatConst.
   Global Instance Method_TAU `{H : State.Trait} `(Trait)
     : Notation.Dot "TAU" := {
     Notation.dot`{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))}
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)}
          :=
       (axiom : M (H := H) Self);
   }.
   Global Instance Method_LOG10_2 `{H : State.Trait} `(Trait)
     : Notation.Dot "LOG10_2" := {
     Notation.dot`{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
+        `{core.ops.arith.Div.Trait Self (Rhs := Self)}
          :=
       (axiom : M (H := H) Self);
   }.
   Global Instance Method_LOG2_10 `{H : State.Trait} `(Trait)
     : Notation.Dot "LOG2_10" := {
     Notation.dot`{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
+        `{core.ops.arith.Div.Trait Self (Rhs := Self)}
          :=
       (axiom : M (H := H) Self);
   }.
@@ -1583,7 +1583,7 @@ Module identities.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
         Set := {
       zero `{H : State.Trait} : (M (H := H) Self);
       is_zero `{H : State.Trait} : (ref Self) -> (M (H := H) bool);
@@ -1607,7 +1607,7 @@ Module identities.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
         Set := {
       one `{H : State.Trait} : (M (H := H) Self);
     }.
@@ -1622,7 +1622,7 @@ Module identities.
     }.
     Global Instance Method_is_one `{H : State.Trait} `(Trait)
       : Notation.Dot "is_one" := {
-      Notation.dot`{core.cmp.PartialEq.Trait Self (Rhs := None)} 
+      Notation.dot`{core.cmp.PartialEq.Trait Self (Rhs := Self)} 
           (self : ref Self) :=
         (axiom : M (H := H) bool);
     }.
@@ -1643,7 +1643,7 @@ Module Zero.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
       Set := {
     zero `{H : State.Trait} : (M (H := H) Self);
     is_zero `{H : State.Trait} : (ref Self) -> (M (H := H) bool);
@@ -1667,7 +1667,7 @@ Module One.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
       Set := {
     one `{H : State.Trait} : (M (H := H) Self);
   }.
@@ -2035,7 +2035,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
           Set := {
         checked_add
           `{H : State.Trait}
@@ -2053,7 +2053,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
           Set := {
         checked_sub
           `{H : State.Trait}
@@ -2071,7 +2071,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
           Set := {
         checked_mul
           `{H : State.Trait}
@@ -2089,7 +2089,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Div.Trait Self (Rhs := Self)} :
           Set := {
         checked_div
           `{H : State.Trait}
@@ -2107,7 +2107,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
           Set := {
         checked_rem
           `{H : State.Trait}
@@ -2178,8 +2178,8 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
-            `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Div.Trait Self (Rhs := Self)}
+            `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
           Set := {
         div_euclid
           `{H : State.Trait}
@@ -2294,7 +2294,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
           Set := {
         overflowing_add
           `{H : State.Trait}
@@ -2312,7 +2312,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
           Set := {
         overflowing_sub
           `{H : State.Trait}
@@ -2330,7 +2330,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
           Set := {
         overflowing_mul
           `{H : State.Trait}
@@ -2366,7 +2366,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
           Set := {
         saturating_add
           `{H : State.Trait}
@@ -2384,7 +2384,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
           Set := {
         saturating_sub
           `{H : State.Trait}
@@ -2402,7 +2402,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
           Set := {
         saturating_mul
           `{H : State.Trait}
@@ -2422,7 +2422,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
           Set := {
         wrapping_add
           `{H : State.Trait}
@@ -2440,7 +2440,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
           Set := {
         wrapping_sub
           `{H : State.Trait}
@@ -2458,7 +2458,7 @@ Module ops.
       Class Trait
           (Self : Set)
             `{core.marker.Sized.Trait Self}
-            `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+            `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
           Set := {
         wrapping_mul
           `{H : State.Trait}
@@ -2705,7 +2705,7 @@ Module checked.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
         Set := {
       checked_add
         `{H : State.Trait}
@@ -2723,7 +2723,7 @@ Module checked.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
         Set := {
       checked_sub
         `{H : State.Trait}
@@ -2741,7 +2741,7 @@ Module checked.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
         Set := {
       checked_mul
         `{H : State.Trait}
@@ -2759,7 +2759,7 @@ Module checked.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Div.Trait Self (Rhs := Self)} :
         Set := {
       checked_div
         `{H : State.Trait}
@@ -2777,7 +2777,7 @@ Module checked.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
         Set := {
       checked_rem
         `{H : State.Trait}
@@ -2846,7 +2846,7 @@ Module CheckedAdd.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
       Set := {
     checked_add
       `{H : State.Trait}
@@ -2864,7 +2864,7 @@ Module CheckedSub.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
       Set := {
     checked_sub
       `{H : State.Trait}
@@ -2882,7 +2882,7 @@ Module CheckedMul.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
       Set := {
     checked_mul
       `{H : State.Trait}
@@ -2900,7 +2900,7 @@ Module CheckedDiv.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Div.Trait Self (Rhs := Self)} :
       Set := {
     checked_div
       `{H : State.Trait}
@@ -2918,7 +2918,7 @@ Module CheckedRem.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
       Set := {
     checked_rem
       `{H : State.Trait}
@@ -2987,8 +2987,8 @@ Module euclid.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
-          `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Div.Trait Self (Rhs := Self)}
+          `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
         Set := {
       div_euclid
         `{H : State.Trait}
@@ -3039,8 +3039,8 @@ Module Euclid.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Div.Trait Self (Rhs := (Some Self))}
-        `{core.ops.arith.Rem.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Div.Trait Self (Rhs := Self)}
+        `{core.ops.arith.Rem.Trait Self (Rhs := Self)} :
       Set := {
     div_euclid
       `{H : State.Trait}
@@ -3211,7 +3211,7 @@ Module overflowing.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
         Set := {
       overflowing_add
         `{H : State.Trait}
@@ -3229,7 +3229,7 @@ Module overflowing.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
         Set := {
       overflowing_sub
         `{H : State.Trait}
@@ -3247,7 +3247,7 @@ Module overflowing.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
         Set := {
       overflowing_mul
         `{H : State.Trait}
@@ -3266,7 +3266,7 @@ Module OverflowingAdd.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
       Set := {
     overflowing_add
       `{H : State.Trait}
@@ -3284,7 +3284,7 @@ Module OverflowingSub.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
       Set := {
     overflowing_sub
       `{H : State.Trait}
@@ -3302,7 +3302,7 @@ Module OverflowingMul.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
       Set := {
     overflowing_mul
       `{H : State.Trait}
@@ -3337,7 +3337,7 @@ Module saturating.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
         Set := {
       saturating_add
         `{H : State.Trait}
@@ -3355,7 +3355,7 @@ Module saturating.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
         Set := {
       saturating_sub
         `{H : State.Trait}
@@ -3373,7 +3373,7 @@ Module saturating.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
         Set := {
       saturating_mul
         `{H : State.Trait}
@@ -3408,7 +3408,7 @@ Module SaturatingAdd.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
       Set := {
     saturating_add
       `{H : State.Trait}
@@ -3426,7 +3426,7 @@ Module SaturatingSub.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
       Set := {
     saturating_sub
       `{H : State.Trait}
@@ -3444,7 +3444,7 @@ Module SaturatingMul.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
       Set := {
     saturating_mul
       `{H : State.Trait}
@@ -3463,7 +3463,7 @@ Module wrapping.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
         Set := {
       wrapping_add
         `{H : State.Trait}
@@ -3481,7 +3481,7 @@ Module wrapping.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
         Set := {
       wrapping_sub
         `{H : State.Trait}
@@ -3499,7 +3499,7 @@ Module wrapping.
     Class Trait
         (Self : Set)
           `{core.marker.Sized.Trait Self}
-          `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+          `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
         Set := {
       wrapping_mul
         `{H : State.Trait}
@@ -3559,7 +3559,7 @@ Module WrappingAdd.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Add.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Add.Trait Self (Rhs := Self)} :
       Set := {
     wrapping_add
       `{H : State.Trait}
@@ -3577,7 +3577,7 @@ Module WrappingSub.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Sub.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Sub.Trait Self (Rhs := Self)} :
       Set := {
     wrapping_sub
       `{H : State.Trait}
@@ -3595,7 +3595,7 @@ Module WrappingMul.
   Class Trait
       (Self : Set)
         `{core.marker.Sized.Trait Self}
-        `{core.ops.arith.Mul.Trait Self (Rhs := (Some Self))} :
+        `{core.ops.arith.Mul.Trait Self (Rhs := Self)} :
       Set := {
     wrapping_mul
       `{H : State.Trait}
@@ -4231,7 +4231,7 @@ End Real.
 Module NumOps.
   Unset Primitive Projections.
   Class Trait
-      (Self : Set) {(* TODO *) Rhs (* TODO *) Output : option Set}
+      (Self : Set) {(* TODO *) Rhs : Set} {(* TODO *) Output : option Set}
         `{core.ops.arith.Add.Trait Self (Rhs := (Rhs (* @TODO *)))}
         `{core.ops.arith.Sub.Trait Self (Rhs := (Rhs (* @TODO *)))}
         `{core.ops.arith.Mul.Trait Self (Rhs := (Rhs (* @TODO *)))}
@@ -4246,10 +4246,10 @@ End NumOps.
 Module Num.
   Class Trait
       (Self : Set)
-        `{core.cmp.PartialEq.Trait Self (Rhs := None)}
+        `{core.cmp.PartialEq.Trait Self (Rhs := Self)}
         `{num_traits.identities.Zero.Trait Self}
         `{num_traits.identities.One.Trait Self}
-        `{num_traits.NumOps.Trait Self (Rhs := None) (Output := None)} :
+        `{num_traits.NumOps.Trait Self (Rhs := Self) (Output := None)} :
       Type := {
     FromStrRadixErr : Set;
     from_str_radix

--- a/coq_translation/axiomatized/examples/modules/struct_visibility.v
+++ b/coq_translation/axiomatized/examples/modules/struct_visibility.v
@@ -14,6 +14,9 @@ Module my.
       Global Instance Get_contents : Notation.Dot "contents" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End OpenBox.
   End OpenBox.
   Definition OpenBox (T : Set) : Set := OpenBox.t (T := T).
@@ -29,6 +32,9 @@ Module my.
       
       Global Instance Get_contents : Notation.Dot "contents" := {
         Notation.dot '(Build_t x0) := x0;
+      }.
+      Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+        Notation.double_colon '(Build_t x0) := x0;
       }.
     End ClosedBox.
   End ClosedBox.
@@ -47,6 +53,9 @@ Module OpenBox.
     Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End OpenBox.
 End OpenBox.
 Definition OpenBox (T : Set) : Set := OpenBox.t (T := T).
@@ -62,6 +71,9 @@ Module ClosedBox.
     
     Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End ClosedBox.
 End ClosedBox.

--- a/coq_translation/axiomatized/examples/subtle.v
+++ b/coq_translation/axiomatized/examples/subtle.v
@@ -87,8 +87,14 @@ Module CtOption.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_is_some : Notation.Dot "is_some" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_is_some : Notation.DoubleColon t "is_some" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End CtOption.
 End CtOption.

--- a/coq_translation/default/examples/conversion/converting_to_string.v
+++ b/coq_translation/default/examples/conversion/converting_to_string.v
@@ -11,6 +11,9 @@ Module Circle.
   Global Instance Get_radius : Notation.Dot "radius" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_radius : Notation.DoubleColon t "radius" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Circle.
 Definition Circle : Set := Circle.t.
 

--- a/coq_translation/default/examples/conversion/from.v
+++ b/coq_translation/default/examples/conversion/from.v
@@ -11,6 +11,9 @@ Module Number.
   Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Number.
 Definition Number : Set := Number.t.
 

--- a/coq_translation/default/examples/conversion/into.v
+++ b/coq_translation/default/examples/conversion/into.v
@@ -11,6 +11,9 @@ Module Number.
   Global Instance Get_value : Notation.Dot "value" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Number.
 Definition Number : Set := Number.t.
 

--- a/coq_translation/default/examples/conversion/try_from_and_try_into.v
+++ b/coq_translation/default/examples/conversion/try_from_and_try_into.v
@@ -61,7 +61,9 @@ Module Impl_core_cmp_PartialEq_for_try_from_and_try_into_EvenNumber.
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.

--- a/coq_translation/default/examples/custom_types/structures.v
+++ b/coq_translation/default/examples/custom_types/structures.v
@@ -12,8 +12,14 @@ Module Person.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_age : Notation.DoubleColon t "age" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Person.
 Definition Person : Set := Person.t.
@@ -90,8 +96,14 @@ Module Point.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Point.
 Definition Point : Set := Point.t.
@@ -107,8 +119,15 @@ Module Rectangle.
   Global Instance Get_top_left : Notation.Dot "top_left" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_top_left : Notation.DoubleColon t "top_left" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_bottom_right
+    : Notation.DoubleColon t "bottom_right" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.

--- a/coq_translation/default/examples/error_handling/unpacking_options_via_question_mark.v
+++ b/coq_translation/default/examples/error_handling/unpacking_options_via_question_mark.v
@@ -11,6 +11,9 @@ Module Person.
   Global Instance Get_job : Notation.Dot "job" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_job : Notation.DoubleColon t "job" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Person.
 Definition Person : Set := Person.t.
 
@@ -25,6 +28,10 @@ Module Job.
   
   Global Instance Get_phone_number : Notation.Dot "phone_number" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_phone_number
+    : Notation.DoubleColon t "phone_number" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End Job.
 Definition Job : Set := Job.t.
@@ -73,8 +80,14 @@ Module PhoneNumber.
   Global Instance Get_area_code : Notation.Dot "area_code" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_area_code : Notation.DoubleColon t "area_code" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_number : Notation.Dot "number" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_number : Notation.DoubleColon t "number" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End PhoneNumber.
 Definition PhoneNumber : Set := PhoneNumber.t.

--- a/coq_translation/default/examples/expressions/const_underscore_expression.v
+++ b/coq_translation/default/examples/expressions/const_underscore_expression.v
@@ -11,6 +11,9 @@ Module Foo.
   Global Instance Get_test : Notation.Dot "test" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_test : Notation.DoubleColon t "test" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Foo.
 Definition Foo : Set := Foo.t.
 
@@ -23,6 +26,9 @@ Module Bar.
   
   Global Instance Get_test : Notation.Dot "test" := {
     Notation.dot '(Build_t x0) := x0;
+  }.
+  Global Instance Get_AF_test : Notation.DoubleColon t "test" := {
+    Notation.double_colon '(Build_t x0) := x0;
   }.
 End Bar.
 Definition Bar : Set := Bar.t.

--- a/coq_translation/default/examples/flow_of_control/match_destructuring_structs.v
+++ b/coq_translation/default/examples/flow_of_control/match_destructuring_structs.v
@@ -12,8 +12,14 @@ Module Foo.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Foo.
 Definition Foo : Set := Foo.t.

--- a/coq_translation/default/examples/functions/associated_functions_and_methods.v
+++ b/coq_translation/default/examples/functions/associated_functions_and_methods.v
@@ -12,8 +12,14 @@ Module Point.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Point.
 Definition Point : Set := Point.t.
@@ -63,8 +69,14 @@ Module Rectangle.
   Global Instance Get_p1 : Notation.Dot "p1" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_p1 : Notation.DoubleColon t "p1" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_p2 : Notation.Dot "p2" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_p2 : Notation.DoubleColon t "p2" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.

--- a/coq_translation/default/examples/generics/generics_bounds.v
+++ b/coq_translation/default/examples/generics/generics_bounds.v
@@ -39,8 +39,14 @@ Module Rectangle.
   Global Instance Get_length : Notation.Dot "length" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_length : Notation.DoubleColon t "length" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_height : Notation.Dot "height" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_height : Notation.DoubleColon t "height" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.
@@ -91,8 +97,14 @@ Module Triangle.
   Global Instance Get_length : Notation.Dot "length" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_length : Notation.DoubleColon t "length" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_height : Notation.Dot "height" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_height : Notation.DoubleColon t "height" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Triangle.
 Definition Triangle : Set := Triangle.t.

--- a/coq_translation/default/examples/generics/generics_implementation.v
+++ b/coq_translation/default/examples/generics/generics_implementation.v
@@ -11,6 +11,9 @@ Module Val.
   Global Instance Get_val : Notation.Dot "val" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_val : Notation.DoubleColon t "val" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Val.
 Definition Val : Set := Val.t.
 
@@ -25,6 +28,9 @@ Module GenVal.
     
     Global Instance Get_gen_val : Notation.Dot "gen_val" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_gen_val : Notation.DoubleColon t "gen_val" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End GenVal.
 End GenVal.

--- a/coq_translation/default/examples/generics/generics_phantom_type.v
+++ b/coq_translation/default/examples/generics/generics_phantom_type.v
@@ -55,7 +55,10 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
       Notation.dot := eq;
     }.
     
-    Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+    Global Instance I
+      : core.cmp.PartialEq.Trait Self
+          (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+        := {
       core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
     }.
   End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
@@ -122,7 +125,10 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
       Notation.dot := eq;
     }.
     
-    Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+    Global Instance I
+      : core.cmp.PartialEq.Trait Self
+          (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+        := {
       core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
     }.
   End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.

--- a/coq_translation/default/examples/generics/generics_phantom_type.v
+++ b/coq_translation/default/examples/generics/generics_phantom_type.v
@@ -75,8 +75,14 @@ Module PhantomStruct.
     Global Instance Get_first : Notation.Dot "first" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_first : Notation.DoubleColon t "first" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_phantom : Notation.Dot "phantom" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_phantom : Notation.DoubleColon t "phantom" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End PhantomStruct.
 End PhantomStruct.

--- a/coq_translation/default/examples/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/coq_translation/default/examples/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -249,7 +249,10 @@ Module
       Notation.dot := add;
     }.
     
-    Global Instance I : core.ops.arith.Add.Trait Self (Rhs := None) := {
+    Global Instance I
+      : core.ops.arith.Add.Trait Self
+          (Rhs := core.ops.arith.Add.Default.Rhs Self)
+        := {
       core.ops.arith.Add.Output := Output;
       core.ops.arith.Add.add `{H' : State.Trait} := add;
     }.

--- a/coq_translation/default/examples/modules/struct_visibility.v
+++ b/coq_translation/default/examples/modules/struct_visibility.v
@@ -14,6 +14,9 @@ Module my.
       Global Instance Get_contents : Notation.Dot "contents" := {
         Notation.dot '(Build_t x0) := x0;
       }.
+      Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+        Notation.double_colon '(Build_t x0) := x0;
+      }.
     End OpenBox.
   End OpenBox.
   Definition OpenBox (T : Set) : Set := OpenBox.t (T := T).
@@ -29,6 +32,9 @@ Module my.
       
       Global Instance Get_contents : Notation.Dot "contents" := {
         Notation.dot '(Build_t x0) := x0;
+      }.
+      Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+        Notation.double_colon '(Build_t x0) := x0;
       }.
     End ClosedBox.
   End ClosedBox.
@@ -62,6 +68,9 @@ Module OpenBox.
     Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
     }.
+    Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+      Notation.double_colon '(Build_t x0) := x0;
+    }.
   End OpenBox.
 End OpenBox.
 Definition OpenBox (T : Set) : Set := OpenBox.t (T := T).
@@ -77,6 +86,9 @@ Module ClosedBox.
     
     Global Instance Get_contents : Notation.Dot "contents" := {
       Notation.dot '(Build_t x0) := x0;
+    }.
+    Global Instance Get_AF_contents : Notation.DoubleColon t "contents" := {
+      Notation.double_colon '(Build_t x0) := x0;
     }.
   End ClosedBox.
 End ClosedBox.

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_aliasing.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_aliasing.v
@@ -13,11 +13,20 @@ Module Point.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_z : Notation.Dot "z" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_z : Notation.DoubleColon t "z" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Point.
 Definition Point : Set := Point.t.

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_mutablity.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_mutablity.v
@@ -14,11 +14,20 @@ Module Book.
   Global Instance Get_author : Notation.Dot "author" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_author : Notation.DoubleColon t "author" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_title : Notation.Dot "title" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_title : Notation.DoubleColon t "title" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_year : Notation.Dot "year" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_year : Notation.DoubleColon t "year" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Book.
 Definition Book : Set := Book.t.

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
@@ -12,8 +12,14 @@ Module Point.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Point.
 Definition Point : Set := Point.t.

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_lifetimes_structs.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_lifetimes_structs.v
@@ -48,8 +48,14 @@ Module NamedBorrowed.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End NamedBorrowed.
 Definition NamedBorrowed : Set := NamedBorrowed.t.

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_lifetimes_traits.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_lifetimes_traits.v
@@ -11,6 +11,9 @@ Module Borrowed.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Borrowed.
 Definition Borrowed : Set := Borrowed.t.
 

--- a/coq_translation/default/examples/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
+++ b/coq_translation/default/examples/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
@@ -62,8 +62,14 @@ Module Person.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_age : Notation.DoubleColon t "age" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Person.
 Definition Person : Set := Person.t.

--- a/coq_translation/default/examples/std_library_types/box_stack_heap.v
+++ b/coq_translation/default/examples/std_library_types/box_stack_heap.v
@@ -13,8 +13,14 @@ Module Point.
   Global Instance Get_x : Notation.Dot "x" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_x : Notation.DoubleColon t "x" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_y : Notation.Dot "y" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_y : Notation.DoubleColon t "y" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Point.
 Definition Point : Set := Point.t.
@@ -95,8 +101,15 @@ Module Rectangle.
   Global Instance Get_top_left : Notation.Dot "top_left" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_top_left : Notation.DoubleColon t "top_left" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_bottom_right : Notation.Dot "bottom_right" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_bottom_right
+    : Notation.DoubleColon t "bottom_right" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Rectangle.
 Definition Rectangle : Set := Rectangle.t.

--- a/coq_translation/default/examples/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/coq_translation/default/examples/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -12,8 +12,14 @@ Module Account.
   Global Instance Get_username : Notation.Dot "username" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_username : Notation.DoubleColon t "username" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_password : Notation.Dot "password" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_password : Notation.DoubleColon t "password" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Account.
 Definition Account : Set := Account.t.
@@ -118,8 +124,14 @@ Module AccountInfo.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_email : Notation.Dot "email" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_email : Notation.DoubleColon t "email" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End AccountInfo.
 Definition AccountInfo : Set := AccountInfo.t.

--- a/coq_translation/default/examples/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/coq_translation/default/examples/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -52,7 +52,9 @@ Module
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.

--- a/coq_translation/default/examples/std_misc/foreign_function_interface.v
+++ b/coq_translation/default/examples/std_misc/foreign_function_interface.v
@@ -55,8 +55,14 @@ Module Complex.
   Global Instance Get_re : Notation.Dot "re" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_re : Notation.DoubleColon t "re" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_im : Notation.Dot "im" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_im : Notation.DoubleColon t "im" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Complex.
 Definition Complex : Set := Complex.t.

--- a/coq_translation/default/examples/subtle.v
+++ b/coq_translation/default/examples/subtle.v
@@ -1449,8 +1449,14 @@ Module CtOption.
     Global Instance Get_value : Notation.Dot "value" := {
       Notation.dot '(Build_t x0 _) := x0;
     }.
+    Global Instance Get_AF_value : Notation.DoubleColon t "value" := {
+      Notation.double_colon '(Build_t x0 _) := x0;
+    }.
     Global Instance Get_is_some : Notation.Dot "is_some" := {
       Notation.dot '(Build_t _ x1) := x1;
+    }.
+    Global Instance Get_AF_is_some : Notation.DoubleColon t "is_some" := {
+      Notation.double_colon '(Build_t _ x1) := x1;
     }.
   End CtOption.
 End CtOption.

--- a/coq_translation/default/examples/subtle.v
+++ b/coq_translation/default/examples/subtle.v
@@ -129,7 +129,10 @@ Module Impl_core_ops_bit_BitAnd_for_subtle_Choice.
     Notation.dot := bitand;
   }.
   
-  Global Instance I : core.ops.bit.BitAnd.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitAnd.Trait Self
+        (Rhs := core.ops.bit.BitAnd.Default.Rhs Self)
+      := {
     core.ops.bit.BitAnd.Output := Output;
     core.ops.bit.BitAnd.bitand `{H' : State.Trait} := bitand;
   }.
@@ -156,7 +159,10 @@ Module Impl_core_ops_bit_BitAndAssign_for_subtle_Choice.
     Notation.dot := bitand_assign;
   }.
   
-  Global Instance I : core.ops.bit.BitAndAssign.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitAndAssign.Trait Self
+        (Rhs := core.ops.bit.BitAndAssign.Default.Rhs Self)
+      := {
     core.ops.bit.BitAndAssign.bitand_assign `{H' : State.Trait}
       :=
       bitand_assign;
@@ -181,7 +187,9 @@ Module Impl_core_ops_bit_BitOr_for_subtle_Choice.
     Notation.dot := bitor;
   }.
   
-  Global Instance I : core.ops.bit.BitOr.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitOr.Trait Self (Rhs := core.ops.bit.BitOr.Default.Rhs Self)
+      := {
     core.ops.bit.BitOr.Output := Output;
     core.ops.bit.BitOr.bitor `{H' : State.Trait} := bitor;
   }.
@@ -208,7 +216,10 @@ Module Impl_core_ops_bit_BitOrAssign_for_subtle_Choice.
     Notation.dot := bitor_assign;
   }.
   
-  Global Instance I : core.ops.bit.BitOrAssign.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitOrAssign.Trait Self
+        (Rhs := core.ops.bit.BitOrAssign.Default.Rhs Self)
+      := {
     core.ops.bit.BitOrAssign.bitor_assign `{H' : State.Trait} := bitor_assign;
   }.
   Global Hint Resolve I : core.
@@ -231,7 +242,10 @@ Module Impl_core_ops_bit_BitXor_for_subtle_Choice.
     Notation.dot := bitxor;
   }.
   
-  Global Instance I : core.ops.bit.BitXor.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitXor.Trait Self
+        (Rhs := core.ops.bit.BitXor.Default.Rhs Self)
+      := {
     core.ops.bit.BitXor.Output := Output;
     core.ops.bit.BitXor.bitxor `{H' : State.Trait} := bitxor;
   }.
@@ -258,7 +272,10 @@ Module Impl_core_ops_bit_BitXorAssign_for_subtle_Choice.
     Notation.dot := bitxor_assign;
   }.
   
-  Global Instance I : core.ops.bit.BitXorAssign.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.ops.bit.BitXorAssign.Trait Self
+        (Rhs := core.ops.bit.BitXorAssign.Default.Rhs Self)
+      := {
     core.ops.bit.BitXorAssign.bitxor_assign `{H' : State.Trait}
       :=
       bitxor_assign;

--- a/coq_translation/default/examples/traits/derive.v
+++ b/coq_translation/default/examples/traits/derive.v
@@ -37,7 +37,9 @@ Module Impl_core_cmp_PartialEq_for_derive_Centimeters.
     Notation.dot := eq;
   }.
   
-  Global Instance I : core.cmp.PartialEq.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialEq.Trait Self (Rhs := core.cmp.PartialEq.Default.Rhs Self)
+      := {
     core.cmp.PartialEq.eq `{H' : State.Trait} := eq;
   }.
   Global Hint Resolve I : core.
@@ -58,7 +60,10 @@ Module Impl_core_cmp_PartialOrd_for_derive_Centimeters.
     Notation.dot := partial_cmp;
   }.
   
-  Global Instance I : core.cmp.PartialOrd.Trait Self (Rhs := None) := {
+  Global Instance I
+    : core.cmp.PartialOrd.Trait Self
+        (Rhs := core.cmp.PartialOrd.Default.Rhs Self)
+      := {
     core.cmp.PartialOrd.partial_cmp `{H' : State.Trait} := partial_cmp;
   }.
   Global Hint Resolve I : core.

--- a/coq_translation/default/examples/traits/disambiguating_overlapping_traits.v
+++ b/coq_translation/default/examples/traits/disambiguating_overlapping_traits.v
@@ -99,9 +99,11 @@ Definition main `{H' : State.Trait} : M (H := H') unit :=
         disambiguating_overlapping_traits.Form.age := 28;
       |} in
   let* username :=
-    disambiguating_overlapping_traits.UsernameWidget.get (addr_of form) in
+    (disambiguating_overlapping_traits.UsernameWidget.get
+        (Self := disambiguating_overlapping_traits.Form))
+      (addr_of form) in
   let* _ :=
-    let* α0 := "rustacean".["to_owned"] in
+    let* α0 := "rustacean".["to_string"] in
     match (addr_of α0, addr_of username) with
     | (left_val, right_val) =>
       let* α0 := left_val.["deref"] in
@@ -122,7 +124,10 @@ Definition main `{H' : State.Trait} : M (H := H') unit :=
       else
         Pure tt
     end in
-  let* age := disambiguating_overlapping_traits.AgeWidget.get (addr_of form) in
+  let* age :=
+    (disambiguating_overlapping_traits.AgeWidget.get
+        (Self := disambiguating_overlapping_traits.Form))
+      (addr_of form) in
   let* _ :=
     match (addr_of 28, addr_of age) with
     | (left_val, right_val) =>

--- a/coq_translation/default/examples/traits/disambiguating_overlapping_traits.v
+++ b/coq_translation/default/examples/traits/disambiguating_overlapping_traits.v
@@ -34,8 +34,14 @@ Module Form.
   Global Instance Get_username : Notation.Dot "username" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_username : Notation.DoubleColon t "username" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_age : Notation.Dot "age" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_age : Notation.DoubleColon t "age" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Form.
 Definition Form : Set := Form.t.

--- a/coq_translation/default/examples/traits/drop.v
+++ b/coq_translation/default/examples/traits/drop.v
@@ -11,6 +11,9 @@ Module Droppable.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t x0) := x0;
   }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t x0) := x0;
+  }.
 End Droppable.
 Definition Droppable : Set := Droppable.t.
 

--- a/coq_translation/default/examples/traits/hash.v
+++ b/coq_translation/default/examples/traits/hash.v
@@ -13,11 +13,20 @@ Module Person.
   Global Instance Get_id : Notation.Dot "id" := {
     Notation.dot '(Build_t x0 _ _) := x0;
   }.
+  Global Instance Get_AF_id : Notation.DoubleColon t "id" := {
+    Notation.double_colon '(Build_t x0 _ _) := x0;
+  }.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t _ x1 _) := x1;
   }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t _ x1 _) := x1;
+  }.
   Global Instance Get_phone : Notation.Dot "phone" := {
     Notation.dot '(Build_t _ _ x2) := x2;
+  }.
+  Global Instance Get_AF_phone : Notation.DoubleColon t "phone" := {
+    Notation.double_colon '(Build_t _ _ x2) := x2;
   }.
 End Person.
 Definition Person : Set := Person.t.

--- a/coq_translation/default/examples/traits/iterators.v
+++ b/coq_translation/default/examples/traits/iterators.v
@@ -12,8 +12,14 @@ Module Fibonacci.
   Global Instance Get_curr : Notation.Dot "curr" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_curr : Notation.DoubleColon t "curr" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_next : Notation.Dot "next" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_next : Notation.DoubleColon t "next" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Fibonacci.
 Definition Fibonacci : Set := Fibonacci.t.

--- a/coq_translation/default/examples/traits/operator_overloading.v
+++ b/coq_translation/default/examples/traits/operator_overloading.v
@@ -86,7 +86,7 @@ Module Impl_core_ops_arith_Add_for_operator_overloading_Foo.
   }.
   
   Global Instance I
-    : core.ops.arith.Add.Trait Self (Rhs := Some operator_overloading.Bar) := {
+    : core.ops.arith.Add.Trait Self (Rhs := operator_overloading.Bar) := {
     core.ops.arith.Add.Output := Output;
     core.ops.arith.Add.add `{H' : State.Trait} := add;
   }.
@@ -118,7 +118,7 @@ Module Impl_core_ops_arith_Add_for_operator_overloading_Bar.
   }.
   
   Global Instance I
-    : core.ops.arith.Add.Trait Self (Rhs := Some operator_overloading.Foo) := {
+    : core.ops.arith.Add.Trait Self (Rhs := operator_overloading.Foo) := {
     core.ops.arith.Add.Output := Output;
     core.ops.arith.Add.add `{H' : State.Trait} := add;
   }.

--- a/coq_translation/default/examples/traits/traits.v
+++ b/coq_translation/default/examples/traits/traits.v
@@ -12,8 +12,14 @@ Module Sheep.
   Global Instance Get_naked : Notation.Dot "naked" := {
     Notation.dot '(Build_t x0 _) := x0;
   }.
+  Global Instance Get_AF_naked : Notation.DoubleColon t "naked" := {
+    Notation.double_colon '(Build_t x0 _) := x0;
+  }.
   Global Instance Get_name : Notation.Dot "name" := {
     Notation.dot '(Build_t _ x1) := x1;
+  }.
+  Global Instance Get_AF_name : Notation.DoubleColon t "name" := {
+    Notation.double_colon '(Build_t _ x1) := x1;
   }.
 End Sheep.
 Definition Sheep : Set := Sheep.t.

--- a/examples/traits/disambiguating_overlapping_traits.rs
+++ b/examples/traits/disambiguating_overlapping_traits.rs
@@ -38,7 +38,7 @@ fn main() {
     // println!("{}", form.get());
 
     let username = <Form as UsernameWidget>::get(&form);
-    assert_eq!("rustacean".to_owned(), username);
+    assert_eq!(("rustacean".to_string()), username);
     let age = <Form as AgeWidget>::get(&form);
     assert_eq!(28, age);
 }

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -1851,41 +1851,65 @@ impl TopLevelItem {
                                     coq::TopLevel::new(&fields
                                         .iter()
                                         .enumerate()
-                                        .map(|(i, (name, _))| {
-                                            coq::TopLevelItem::Instance(coq::Instance::new(
-                                                false,
-                                                &format!("Get_{name}"),
-                                                &[],
-                                                coq::Expression::Variable {
-                                                    ident: Path::new(&["Notation", "Dot"]),
-                                                    no_implicit: false,
-                                                }
-                                                .apply(&coq::Expression::String(name.to_owned())),
-                                                &coq::Expression::Record {
-                                                    fields: vec![coq::Field::new(
-                                                        &Path::new(&["Notation", "dot"]),
-                                                        &[coq::ArgDecl::new(
-                                                            &coq::ArgDeclVar::Destructured {
-                                                                pattern: coq::Expression::just_name("Build_t")
-                                                                    .apply_many(
-                                                                        &fields
-                                                                            .iter()
-                                                                            .enumerate()
-                                                                            .map(|(j, _)| if i == j {
-                                                                                coq::Expression::just_name(&format!("x{j}"))
-                                                                            } else {
-                                                                                coq::Expression::Wild
-                                                                            })
-                                                                            .collect::<Vec<_>>()
-                                                                    ),
-                                                            },
-                                                            coq::ArgSpecKind::Explicit,
-                                                        )],
-                                                        &coq::Expression::just_name(&format!("x{i}")),
-                                                    )],
+                                        .flat_map(|(i, (name, _))| {
+                                            let projection_pattern = [coq::ArgDecl::new(
+                                                &coq::ArgDeclVar::Destructured {
+                                                    pattern: coq::Expression::just_name("Build_t")
+                                                        .apply_many(
+                                                            &fields
+                                                                .iter()
+                                                                .enumerate()
+                                                                .map(|(j, _)| if i == j {
+                                                                    coq::Expression::just_name(&format!("x{j}"))
+                                                                } else {
+                                                                    coq::Expression::Wild
+                                                                })
+                                                                .collect::<Vec<_>>()
+                                                        ),
                                                 },
-                                                vec![],
-                                            ))
+                                                coq::ArgSpecKind::Explicit,
+                                            )];
+                                            [
+                                                coq::TopLevelItem::Instance(coq::Instance::new(
+                                                    false,
+                                                    &format!("Get_{name}"),
+                                                    &[],
+                                                    coq::Expression::Variable {
+                                                        ident: Path::new(&["Notation", "Dot"]),
+                                                        no_implicit: false,
+                                                    }
+                                                    .apply(&coq::Expression::String(name.to_owned())),
+                                                    &coq::Expression::Record {
+                                                        fields: vec![coq::Field::new(
+                                                            &Path::new(&["Notation", "dot"]),
+                                                            &projection_pattern,
+                                                            &coq::Expression::just_name(&format!("x{i}")),
+                                                        )],
+                                                    },
+                                                    vec![],
+                                                )),
+                                                coq::TopLevelItem::Instance(coq::Instance::new(
+                                                    false,
+                                                    &format!("Get_AF_{name}"),
+                                                    &[],
+                                                    coq::Expression::Variable {
+                                                        ident: Path::new(&["Notation", "DoubleColon"]),
+                                                        no_implicit: false,
+                                                    }
+                                                    .apply_many(&[
+                                                        coq::Expression::just_name("t"),
+                                                        coq::Expression::String(name.to_owned())
+                                                    ]),
+                                                    &coq::Expression::Record {
+                                                        fields: vec![coq::Field::new(
+                                                            &Path::new(&["Notation", "double_colon"]),
+                                                            &projection_pattern,
+                                                            &coq::Expression::just_name(&format!("x{i}")),
+                                                        )],
+                                                    },
+                                                    vec![],
+                                                ))
+                                            ]
                                         })
                                         .collect::<Vec<_>>(),
                                     ),

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -1235,7 +1235,7 @@ impl FunDefinition {
                     None => {
                         let ret_ty_name = [&self.name, "_", "ret_ty"].concat();
                         let ret_opaque_ty = CoqType::Application {
-                            func: Box::new(Path::new(&["projT1"])),
+                            func: CoqType::var("projT1".to_string()),
                             args: vec![CoqType::var(ret_ty_name.clone())],
                         };
                         let opaque_return_tys_bounds =

--- a/lib/src/ty.rs
+++ b/lib/src/ty.rs
@@ -7,8 +7,9 @@ use rustc_hir::{BareFnTy, FnDecl, FnRetTy, GenericBound, ItemKind, OpaqueTyOrigi
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum CoqType {
     Var(Box<Path>),
+    VarWithSelfTy(Box<Path>, Box<CoqType>),
     Application {
-        func: Box<Path>,
+        func: Box<CoqType>,
         args: Vec<Box<CoqType>>,
     },
     Function {
@@ -35,9 +36,9 @@ impl CoqType {
     pub(crate) fn monad(ty: Box<CoqType>) -> Box<CoqType> {
         Box::new(CoqType::Application {
             // TODO: try to remove the explicit parameter
-            func: Box::new(Path::local(format!(
+            func: Box::new(CoqType::Var(Box::new(Path::local(format!(
                 "M (H := {LOCAL_STATE_TRAIT_INSTANCE})"
-            ))),
+            ))))),
             args: vec![ty],
         })
     }
@@ -50,6 +51,7 @@ pub(crate) fn mt_ty_unboxed(ty: CoqType) -> CoqType {
             args: args.into_iter().map(mt_ty).collect(),
         },
         CoqType::Var(..) => ty,
+        CoqType::VarWithSelfTy(path, self_ty) => CoqType::VarWithSelfTy(path, mt_ty(self_ty)),
         CoqType::Function { args, ret } => CoqType::Function {
             args: args.into_iter().map(mt_ty).collect(),
             ret: CoqType::monad(mt_ty(ret)),
@@ -69,7 +71,7 @@ pub(crate) fn mt_ty(ty: Box<CoqType>) -> Box<CoqType> {
 pub(crate) fn compile_type(env: &Env, ty: &Ty) -> Box<CoqType> {
     match &ty.kind {
         TyKind::Slice(ty) => {
-            let func = Box::new(Path::local("Slice".to_string()));
+            let func = Box::new(CoqType::Var(Box::new(Path::local("Slice".to_string()))));
             let args = vec![compile_type(env, ty)];
             Box::new(CoqType::Application { func, args })
         }
@@ -84,18 +86,23 @@ pub(crate) fn compile_type(env: &Env, ty: &Ty) -> Box<CoqType> {
             tys.iter().map(|ty| compile_type(env, ty)).collect(),
         )),
         TyKind::Path(qpath) => {
+            let self_ty = match qpath {
+                rustc_hir::QPath::Resolved(Some(self_ty), _) => Some(compile_type(env, self_ty)),
+                _ => None,
+            };
             let params = match qpath {
                 rustc_hir::QPath::Resolved(_, path) => compile_path_ty_params(env, path),
                 _ => vec![],
             };
             let qpath = Box::new(compile_qpath(env, qpath));
+            let func = Box::new(match self_ty {
+                Some(self_ty) => CoqType::VarWithSelfTy(qpath, self_ty),
+                None => CoqType::Var(qpath),
+            });
             if params.is_empty() {
-                Box::new(CoqType::Var(qpath))
+                func
             } else {
-                Box::new(CoqType::Application {
-                    func: qpath,
-                    args: params,
-                })
+                Box::new(CoqType::Application { func, args: params })
             }
         }
         TyKind::OpaqueDef(item_id, _, _) => {
@@ -222,11 +229,14 @@ impl CoqType {
                 ident: *path.clone(),
                 no_implicit: false,
             },
-            CoqType::Application { func, args } => coq::Expression::Variable {
-                ident: *func.clone(),
+            CoqType::VarWithSelfTy(path, self_ty) => coq::Expression::Variable {
+                ident: *path.clone(),
                 no_implicit: false,
             }
-            .apply_many(&args.iter().map(|arg| arg.to_coq()).collect::<Vec<_>>()),
+            .apply_arg(&Some("Self".to_string()), &self_ty.to_coq()),
+            CoqType::Application { func, args } => func
+                .to_coq()
+                .apply_many(&args.iter().map(|arg| arg.to_coq()).collect::<Vec<_>>()),
             CoqType::Function { args, ret } => ret
                 .to_coq()
                 .arrows_from(&args.iter().map(|arg| arg.to_coq()).collect::<Vec<_>>()),
@@ -265,10 +275,18 @@ impl CoqType {
     pub(crate) fn to_doc<'a>(&self, with_paren: bool) -> Doc<'a> {
         match self {
             CoqType::Var(path) => path.to_doc(),
+            CoqType::VarWithSelfTy(path, self_ty) => paren(
+                with_paren,
+                nest([
+                    path.to_doc(),
+                    line(),
+                    nest([text("(Self :="), line(), self_ty.to_doc(false), text(")")]),
+                ]),
+            ),
             CoqType::Application { func, args } => paren(
                 with_paren,
                 nest([
-                    func.to_doc(),
+                    func.to_doc(true),
                     line(),
                     intersperse(args.iter().map(|arg| arg.to_doc(true)), [line()]),
                 ]),
@@ -313,6 +331,9 @@ impl CoqType {
     pub(crate) fn to_name(&self) -> String {
         match self {
             CoqType::Var(path) => path.to_name(),
+            CoqType::VarWithSelfTy(path, self_ty) => {
+                format!("{}_{}", self_ty.to_name(), path.to_name())
+            }
             CoqType::Application { func, args } => {
                 let mut name = func.to_name();
                 for arg in args {
@@ -371,6 +392,7 @@ impl CoqType {
     pub(crate) fn has_opaque_types(&self) -> bool {
         match self {
             CoqType::Var(_) => false,
+            CoqType::VarWithSelfTy(_, self_ty) => self_ty.has_opaque_types(),
             CoqType::Application { args, .. } => args.iter().any(|ty| ty.has_opaque_types()),
             CoqType::Function { args, ret } => {
                 args.iter().any(|ty| ty.has_opaque_types()) && ret.has_opaque_types()
@@ -386,6 +408,7 @@ impl CoqType {
     pub(crate) fn opaque_types_bounds(&self) -> Vec<Vec<Path>> {
         match self {
             CoqType::Var(_) => vec![],
+            CoqType::VarWithSelfTy(_, self_ty) => self_ty.opaque_types_bounds(),
             CoqType::Application { args, .. } => args
                 .iter()
                 .flat_map(|ty| ty.opaque_types_bounds())
@@ -405,10 +428,11 @@ impl CoqType {
         }
     }
 
-    /// substitutes all occurences of OpaqueType with ty
+    /// substitutes all occurrences of OpaqueType with ty
     pub(crate) fn subst_opaque_types(&mut self, ty: &CoqType) {
         match self {
             CoqType::Var(_) => {}
+            CoqType::VarWithSelfTy(_, self_ty) => self_ty.subst_opaque_types(ty),
             CoqType::Application { args, .. } => args
                 .iter_mut()
                 .map(|arg_ty| arg_ty.subst_opaque_types(ty))


### PR DESCRIPTION
This pull-request:

* adds associated functions for record fields
* adds the type `SelfTy` from the notation `<SelfTy as Trait>::field` for values and types
* removes the optional types for trait parameters with default values. Instead, it relies on a default type value being implemented next to the trait definition in some `Module Default.` module. This helps the inference of type-classes in some instances.