### PR TITLE
Reduce more contract errors

### DIFF
--- a/contracts/source/erc1155.rs
+++ b/contracts/source/erc1155.rs
@@ -1,0 +1,609 @@
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+use ink::{
+    prelude::vec::Vec,
+    primitives::AccountId,
+};
+
+// This is the return value that we expect if a smart contract supports receiving ERC-1155
+// tokens.
+//
+// It is calculated with
+// `bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"))`, and
+// corresponds to 0xf23a6e61.
+#[cfg_attr(test, allow(dead_code))]
+const ON_ERC_1155_RECEIVED_SELECTOR: [u8; 4] = [0xF2, 0x3A, 0x6E, 0x61];
+
+// This is the return value that we expect if a smart contract supports batch receiving
+// ERC-1155 tokens.
+//
+// It is calculated with
+// `bytes4(keccak256("onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)"
+// ))`, and corresponds to 0xbc197c81.
+const _ON_ERC_1155_BATCH_RECEIVED_SELECTOR: [u8; 4] = [0xBC, 0x19, 0x7C, 0x81];
+
+/// A type representing the unique IDs of tokens managed by this contract.
+pub type TokenId = u128;
+
+type Balance = <ink::env::DefaultEnvironment as ink::env::Environment>::Balance;
+
+// The ERC-1155 error types.
+#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum Error {
+    /// This token ID has not yet been created by the contract.
+    UnexistentToken,
+    /// The caller tried to sending tokens to the zero-address (`0x00`).
+    ZeroAddressTransfer,
+    /// The caller is not approved to transfer tokens on behalf of the account.
+    NotApproved,
+    /// The account does not have enough funds to complete the transfer.
+    InsufficientBalance,
+    /// An account does not need to approve themselves to transfer tokens.
+    SelfApproval,
+    /// The number of tokens being transferred does not match the specified number of
+    /// transfers.
+    BatchTransferMismatch,
+}
+
+// The ERC-1155 result types.
+pub type Result<T> = core::result::Result<T, Error>;
+
+/// Evaluate `$x:expr` and if not true return `Err($y:expr)`.
+///
+/// Used as `ensure!(expression_to_ensure, expression_to_return_on_false)`.
+macro_rules! ensure {
+    ( $condition:expr, $error:expr $(,)? ) => {{
+        if !$condition {
+            return ::core::result::Result::Err(::core::convert::Into::into($error))
+        }
+    }};
+}
+
+/// The interface for an ERC-1155 compliant contract.
+///
+/// The interface is defined here: <https://eips.ethereum.org/EIPS/eip-1155>.
+///
+/// The goal of ERC-1155 is to allow a single contract to manage a variety of assets.
+/// These assets can be fungible, non-fungible, or a combination.
+///
+/// By tracking multiple assets the ERC-1155 standard is able to support batch transfers,
+/// which make it easy to transfer a mix of multiple tokens at once.
+#[ink::trait_definition]
+pub trait Erc1155 {
+    /// Transfer a `value` amount of `token_id` tokens to the `to` account from the `from`
+    /// account.
+    ///
+    /// Note that the call does not have to originate from the `from` account, and may
+    /// originate from any account which is approved to transfer `from`'s tokens.
+    #[ink(message)]
+    fn safe_transfer_from(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        token_id: TokenId,
+        value: Balance,
+        data: Vec<u8>,
+    ) -> Result<()>;
+
+    /// Perform a batch transfer of `token_ids` to the `to` account from the `from`
+    /// account.
+    ///
+    /// The number of `values` specified to be transferred must match the number of
+    /// `token_ids`, otherwise this call will revert.
+    ///
+    /// Note that the call does not have to originate from the `from` account, and may
+    /// originate from any account which is approved to transfer `from`'s tokens.
+    #[ink(message)]
+    fn safe_batch_transfer_from(
+        &mut self,
+        from: AccountId,
+        to: AccountId,
+        token_ids: Vec<TokenId>,
+        values: Vec<Balance>,
+        data: Vec<u8>,
+    ) -> Result<()>;
+
+    /// Query the balance of a specific token for the provided account.
+    #[ink(message)]
+    fn balance_of(&self, owner: AccountId, token_id: TokenId) -> Balance;
+
+    /// Query the balances for a set of tokens for a set of accounts.
+    ///
+    /// E.g use this call if you want to query what Alice and Bob's balances are for
+    /// Tokens ID 1 and ID 2.
+    ///
+    /// This will return all the balances for a given owner before moving on to the next
+    /// owner. In the example above this means that the return value should look like:
+    ///
+    /// [Alice Balance of Token ID 1, Alice Balance of Token ID 2, Bob Balance of Token ID
+    /// 1, Bob Balance of Token ID 2]
+    #[ink(message)]
+    fn balance_of_batch(
+        &self,
+        owners: Vec<AccountId>,
+        token_ids: Vec<TokenId>,
+    ) -> Vec<Balance>;
+
+    /// Enable or disable a third party, known as an `operator`, to control all tokens on
+    /// behalf of the caller.
+    #[ink(message)]
+    fn set_approval_for_all(&mut self, operator: AccountId, approved: bool)
+        -> Result<()>;
+
+    /// Query if the given `operator` is allowed to control all of `owner`'s tokens.
+    #[ink(message)]
+    fn is_approved_for_all(&self, owner: AccountId, operator: AccountId) -> bool;
+}
+
+/// The interface for an ERC-1155 Token Receiver contract.
+///
+/// The interface is defined here: <https://eips.ethereum.org/EIPS/eip-1155>.
+///
+/// Smart contracts which want to accept token transfers must implement this interface. By
+/// default if a contract does not support this interface any transactions originating
+/// from an ERC-1155 compliant contract which attempt to transfer tokens directly to the
+/// contract's address must be reverted.
+#[ink::trait_definition]
+pub trait Erc1155TokenReceiver {
+    /// Handle the receipt of a single ERC-1155 token.
+    ///
+    /// This should be called by a compliant ERC-1155 contract if the intended recipient
+    /// is a smart contract.
+    ///
+    /// If the smart contract implementing this interface accepts token transfers then it
+    /// must return `ON_ERC_1155_RECEIVED_SELECTOR` from this function. To reject a
+    /// transfer it must revert.
+    ///
+    /// Any callers must revert if they receive anything other than
+    /// `ON_ERC_1155_RECEIVED_SELECTOR` as a return value.
+    #[ink(message, selector = 0xF23A6E61)]
+    fn on_received(
+        &mut self,
+        operator: AccountId,
+        from: AccountId,
+        token_id: TokenId,
+        value: Balance,
+        data: Vec<u8>,
+    ) -> Vec<u8>;
+
+    /// Handle the receipt of multiple ERC-1155 tokens.
+    ///
+    /// This should be called by a compliant ERC-1155 contract if the intended recipient
+    /// is a smart contract.
+    ///
+    /// If the smart contract implementing this interface accepts token transfers then it
+    /// must return `BATCH_ON_ERC_1155_RECEIVED_SELECTOR` from this function. To
+    /// reject a transfer it must revert.
+    ///
+    /// Any callers must revert if they receive anything other than
+    /// `BATCH_ON_ERC_1155_RECEIVED_SELECTOR` as a return value.
+    #[ink(message, selector = 0xBC197C81)]
+    fn on_batch_received(
+        &mut self,
+        operator: AccountId,
+        from: AccountId,
+        token_ids: Vec<TokenId>,
+        values: Vec<Balance>,
+        data: Vec<u8>,
+    ) -> Vec<u8>;
+}
+
+#[ink::contract]
+mod erc1155 {
+    use super::*;
+
+    use ink::storage::Mapping;
+
+    type Owner = AccountId;
+    type Operator = AccountId;
+
+    /// Indicate that a token transfer has occured.
+    ///
+    /// This must be emitted even if a zero value transfer occurs.
+    #[ink(event)]
+    pub struct TransferSingle {
+        #[ink(topic)]
+        operator: Option<AccountId>,
+        #[ink(topic)]
+        from: Option<AccountId>,
+        #[ink(topic)]
+        to: Option<AccountId>,
+        token_id: TokenId,
+        value: Balance,
+    }
+
+    /// Indicate that an approval event has happened.
+    #[ink(event)]
+    pub struct ApprovalForAll {
+        #[ink(topic)]
+        owner: AccountId,
+        #[ink(topic)]
+        operator: AccountId,
+        approved: bool,
+    }
+
+    /// Indicate that a token's URI has been updated.
+    #[ink(event)]
+    pub struct Uri {
+        value: ink::prelude::string::String,
+        #[ink(topic)]
+        token_id: TokenId,
+    }
+
+    /// An ERC-1155 contract.
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct Contract {
+        /// Tracks the balances of accounts across the different tokens that they might
+        /// be holding.
+        balances: Mapping<(AccountId, TokenId), Balance>,
+        /// Which accounts (called operators) have been approved to spend funds on behalf
+        /// of an owner.
+        approvals: Mapping<(Owner, Operator), ()>,
+        /// A unique identifier for the tokens which have been minted (and are therefore
+        /// supported) by this contract.
+        token_id_nonce: TokenId,
+    }
+
+    impl Contract {
+        /// Initialize a default instance of this ERC-1155 implementation.
+        #[ink(constructor)]
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        /// Create the initial supply for a token.
+        ///
+        /// The initial supply will be provided to the caller (a.k.a the minter), and the
+        /// `token_id` will be assigned by the smart contract.
+        ///
+        /// Note that as implemented anyone can create tokens. If you were to instantiate
+        /// this contract in a production environment you'd probably want to lock down
+        /// the addresses that are allowed to create tokens.
+        #[ink(message)]
+        pub fn create(&mut self, value: Balance) -> TokenId {
+            let caller = self.env().caller();
+
+            // Given that TokenId is a `u128` the likelihood of this overflowing is pretty
+            // slim.
+            self.token_id_nonce += 1;
+            self.balances.insert((caller, self.token_id_nonce), &value);
+
+            // Emit transfer event but with mint semantics
+            self.env().emit_event(TransferSingle {
+                operator: Some(caller),
+                from: None,
+                to: if value == 0 { None } else { Some(caller) },
+                token_id: self.token_id_nonce,
+                value,
+            });
+
+            self.token_id_nonce
+        }
+
+        /// Mint a `value` amount of `token_id` tokens.
+        ///
+        /// It is assumed that the token has already been `create`-ed. The newly minted
+        /// supply will be assigned to the caller (a.k.a the minter).
+        ///
+        /// Note that as implemented anyone can mint tokens. If you were to instantiate
+        /// this contract in a production environment you'd probably want to lock down
+        /// the addresses that are allowed to mint tokens.
+        #[ink(message)]
+        pub fn mint(&mut self, token_id: TokenId, value: Balance) -> Result<()> {
+            ensure!(token_id <= self.token_id_nonce, Error::UnexistentToken);
+
+            let caller = self.env().caller();
+            self.balances.insert((caller, token_id), &value);
+
+            // Emit transfer event but with mint semantics
+            self.env().emit_event(TransferSingle {
+                operator: Some(caller),
+                from: None,
+                to: Some(caller),
+                token_id,
+                value,
+            });
+
+            Ok(())
+        }
+
+        // Helper function for performing single token transfers.
+        //
+        // Should not be used directly since it's missing certain checks which are
+        // important to the ERC-1155 standard (it is expected that the caller has
+        // already performed these).
+        //
+        // # Panics
+        //
+        // If `from` does not hold any `token_id` tokens.
+        fn perform_transfer(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            token_id: TokenId,
+            value: Balance,
+        ) {
+            let mut sender_balance = self
+                .balances
+                .get((from, token_id))
+                .expect("Caller should have ensured that `from` holds `token_id`.");
+            sender_balance -= value;
+            self.balances.insert((from, token_id), &sender_balance);
+
+            let mut recipient_balance = self.balances.get((to, token_id)).unwrap_or(0);
+            recipient_balance += value;
+            self.balances.insert((to, token_id), &recipient_balance);
+
+            let caller = self.env().caller();
+            self.env().emit_event(TransferSingle {
+                operator: Some(caller),
+                from: Some(from),
+                to: Some(to),
+                token_id,
+                value,
+            });
+        }
+
+        // Check if the address at `to` is a smart contract which accepts ERC-1155 token
+        // transfers.
+        //
+        // If they're a smart contract which **doesn't** accept tokens transfers this call
+        // will revert. Otherwise we risk locking user funds at in that contract
+        // with no chance of recovery.
+        #[cfg_attr(test, allow(unused_variables))]
+        fn transfer_acceptance_check(
+            &mut self,
+            caller: AccountId,
+            from: AccountId,
+            to: AccountId,
+            token_id: TokenId,
+            value: Balance,
+            data: Vec<u8>,
+        ) {
+            // This is disabled during tests due to the use of `invoke_contract()` not
+            // being supported (tests end up panicking).
+            #[cfg(not(test))]
+            {
+                use ink::env::call::{
+                    build_call,
+                    ExecutionInput,
+                    Selector,
+                };
+
+                // If our recipient is a smart contract we need to see if they accept or
+                // reject this transfer. If they reject it we need to revert the call.
+                let result = build_call::<Environment>()
+                    .call(to)
+                    .gas_limit(5000)
+                    .exec_input(
+                        ExecutionInput::new(Selector::new(ON_ERC_1155_RECEIVED_SELECTOR))
+                            .push_arg(caller)
+                            .push_arg(from)
+                            .push_arg(token_id)
+                            .push_arg(value)
+                            .push_arg(data),
+                    )
+                    .returns::<Vec<u8>>()
+                    .params()
+                    .try_invoke();
+
+                match result {
+                    Ok(v) => {
+                        ink::env::debug_println!(
+                            "Received return value \"{:?}\" from contract {:?}",
+                            v.clone().expect(
+                                "Call should be valid, don't expect a `LangError`."
+                            ),
+                            from
+                        );
+                        assert_eq!(
+                            v.clone().expect("Call should be valid, don't expect a `LangError`."),
+                            &ON_ERC_1155_RECEIVED_SELECTOR[..],
+                            "The recipient contract at {to:?} does not accept token transfers.\n
+                            Expected: {ON_ERC_1155_RECEIVED_SELECTOR:?}, Got {v:?}"
+                        )
+                    }
+                    Err(e) => {
+                        match e {
+                            ink::env::Error::CodeNotFound
+                            | ink::env::Error::NotCallable => {
+                                // Our recipient wasn't a smart contract, so there's
+                                // nothing more for
+                                // us to do
+                                ink::env::debug_println!("Recipient at {:?} from is not a smart contract ({:?})", from, e);
+                            }
+                            _ => {
+                                // We got some sort of error from the call to our
+                                // recipient smart
+                                // contract, and as such we must revert this call
+                                panic!(
+                                    "Got error \"{e:?}\" while trying to call {from:?}"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    impl super::Erc1155 for Contract {
+        #[ink(message)]
+        fn safe_transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            token_id: TokenId,
+            value: Balance,
+            data: Vec<u8>,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            if caller != from {
+                ensure!(self.is_approved_for_all(from, caller), Error::NotApproved);
+            }
+
+            ensure!(to != zero_address(), Error::ZeroAddressTransfer);
+
+            let balance = self.balance_of(from, token_id);
+            ensure!(balance >= value, Error::InsufficientBalance);
+
+            self.perform_transfer(from, to, token_id, value);
+            self.transfer_acceptance_check(caller, from, to, token_id, value, data);
+
+            Ok(())
+        }
+
+        #[ink(message)]
+        fn safe_batch_transfer_from(
+            &mut self,
+            from: AccountId,
+            to: AccountId,
+            token_ids: Vec<TokenId>,
+            values: Vec<Balance>,
+            data: Vec<u8>,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            if caller != from {
+                ensure!(self.is_approved_for_all(from, caller), Error::NotApproved);
+            }
+
+            ensure!(to != zero_address(), Error::ZeroAddressTransfer);
+            ensure!(!token_ids.is_empty(), Error::BatchTransferMismatch);
+            ensure!(
+                token_ids.len() == values.len(),
+                Error::BatchTransferMismatch,
+            );
+
+            let transfers = token_ids.iter().zip(values.iter());
+            for (&id, &v) in transfers.clone() {
+                let balance = self.balance_of(from, id);
+                ensure!(balance >= v, Error::InsufficientBalance);
+            }
+
+            for (&id, &v) in transfers {
+                self.perform_transfer(from, to, id, v);
+            }
+
+            // Can use the any token ID/value here, we really just care about knowing if
+            // `to` is a smart contract which accepts transfers
+            self.transfer_acceptance_check(
+                caller,
+                from,
+                to,
+                token_ids[0],
+                values[0],
+                data,
+            );
+
+            Ok(())
+        }
+
+        #[ink(message)]
+        fn balance_of(&self, owner: AccountId, token_id: TokenId) -> Balance {
+            self.balances.get((owner, token_id)).unwrap_or(0)
+        }
+
+        #[ink(message)]
+        fn balance_of_batch(
+            &self,
+            owners: Vec<AccountId>,
+            token_ids: Vec<TokenId>,
+        ) -> Vec<Balance> {
+            let mut output = Vec::new();
+            for o in &owners {
+                for t in &token_ids {
+                    let amount = self.balance_of(*o, *t);
+                    output.push(amount);
+                }
+            }
+            output
+        }
+
+        #[ink(message)]
+        fn set_approval_for_all(
+            &mut self,
+            operator: AccountId,
+            approved: bool,
+        ) -> Result<()> {
+            let caller = self.env().caller();
+            ensure!(operator != caller, Error::SelfApproval);
+
+            if approved {
+                self.approvals.insert((&caller, &operator), &());
+            } else {
+                self.approvals.remove((&caller, &operator));
+            }
+
+            self.env().emit_event(ApprovalForAll {
+                owner: caller,
+                operator,
+                approved,
+            });
+
+            Ok(())
+        }
+
+        #[ink(message)]
+        fn is_approved_for_all(&self, owner: AccountId, operator: AccountId) -> bool {
+            self.approvals.contains((&owner, &operator))
+        }
+    }
+
+    impl super::Erc1155TokenReceiver for Contract {
+        #[ink(message, selector = 0xF23A6E61)]
+        fn on_received(
+            &mut self,
+            _operator: AccountId,
+            _from: AccountId,
+            _token_id: TokenId,
+            _value: Balance,
+            _data: Vec<u8>,
+        ) -> Vec<u8> {
+            // The ERC-1155 standard dictates that if a contract does not accept token
+            // transfers directly to the contract, then the contract must
+            // revert.
+            //
+            // This prevents a user from unintentionally transferring tokens to a smart
+            // contract and getting their funds stuck without any sort of
+            // recovery mechanism.
+            //
+            // Note that the choice of whether or not to accept tokens is implementation
+            // specific, and we've decided to not accept them in this
+            // implementation.
+            unimplemented!("This smart contract does not accept token transfer.")
+        }
+
+        #[ink(message, selector = 0xBC197C81)]
+        fn on_batch_received(
+            &mut self,
+            _operator: AccountId,
+            _from: AccountId,
+            _token_ids: Vec<TokenId>,
+            _values: Vec<Balance>,
+            _data: Vec<u8>,
+        ) -> Vec<u8> {
+            // The ERC-1155 standard dictates that if a contract does not accept token
+            // transfers directly to the contract, then the contract must
+            // revert.
+            //
+            // This prevents a user from unintentionally transferring tokens to a smart
+            // contract and getting their funds stuck without any sort of
+            // recovery mechanism.
+            //
+            // Note that the choice of whether or not to accept tokens is implementation
+            // specific, and we've decided to not accept them in this
+            // implementation.
+            unimplemented!("This smart contract does not accept batch token transfers.")
+        }
+    }
+
+    /// Helper for referencing the zero address (`0x00`). Note that in practice this
+    /// address should not be treated in any special way (such as a default
+    /// placeholder) since it has a known private key.
+    fn zero_address() -> AccountId {
+        [0u8; 32].into()
+    }
+
+  }

--- a/contracts/source/flipper.rs
+++ b/contracts/source/flipper.rs
@@ -1,0 +1,25 @@
+#[ink::contract]
+pub mod flipper {
+    // #[ink(storage)]
+    pub struct Flipper {
+        value: bool,
+    }
+
+    impl Flipper {
+        pub fn new(init_value: bool) -> Self {
+            Self { value: init_value }
+        }
+
+        pub fn new_default() -> Self {
+            Self::new(Default::default())
+        }
+
+        pub fn flip(&mut self) {
+            self.value = !self.value;
+        }
+
+        pub fn get(&self) -> bool {
+            self.value
+        }
+    }
+}

--- a/contracts/source/multisig.rs
+++ b/contracts/source/multisig.rs
@@ -61,9 +61,6 @@ pub use self::multisig::{
     Transaction,
 };
 
-#[macro_use]
-extern crate scale;
-
 #[ink::contract]
 mod multisig {
     use ink::{

--- a/contracts/source/multisig.rs
+++ b/contracts/source/multisig.rs
@@ -1,0 +1,735 @@
+//! # Multisig Wallet
+//!
+//! This implements a plain multi owner wallet.
+//!
+//! ## Warning
+//!
+//! This contract is an *example*. It is neither audited nor endorsed for production use.
+//! Do **not** rely on it to keep anything of value secure.
+//!
+//! ## Overview
+//!
+//! Each instantiation of this contract has a set of `owners` and a `requirement` of
+//! how many of them need to agree on a `Transaction` for it to be able to be executed.
+//! Every owner can submit a transaction and when enough of the other owners confirm
+//! it will be able to be executed. The following invariant is enforced by the contract:
+//!
+//! ```ignore
+//! 0 < requirement && requirement <= owners && owners <= MAX_OWNERS
+//! ```
+//!
+//! ## Error Handling
+//!
+//! With the exception of `execute_transaction` no error conditions are signalled
+//! through return types. Any error or invariant violation triggers a panic and therefore
+//! rolls back the transaction.
+//!
+//! ## Interface
+//!
+//! The interface is modelled after the popular Gnosis multisig wallet. However, there
+//! are subtle variations from the interface. For example the `confirm_transaction`
+//! will never trigger the execution of a `Transaction` even if the threshold is reached.
+//! A call of `execute_transaction` is always required. This can be called by anyone.
+//!
+//! All the messages that are declared as only callable by the wallet must go through
+//! the usual submit, confirm, execute cycle as any other transaction that should be
+//! called by the wallet. For example, to add an owner you would submit a transaction
+//! that calls the wallets own `add_owner` message through `submit_transaction`.
+//!
+//! ### Owner Management
+//!
+//! The messages `add_owner`, `remove_owner`, and `replace_owner` can be used to manage
+//! the owner set after instantiation.
+//!
+//! ### Changing the Requirement
+//!
+//! `change_requirement` can be used to tighten or relax the `requirement` of how many
+//! owner signatures are needed to execute a `Transaction`.
+//!
+//! ### Transaction Management
+//!
+//! `submit_transaction`, `cancel_transaction`, `confirm_transaction`,
+//! `revoke_confirmation` and `execute_transaction` are the bread and butter messages
+//! of this contract. Use them to dispatch arbitrary messages to other contracts
+//! with the wallet as a sender.
+
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+
+pub use self::multisig::{
+    ConfirmationStatus,
+    Multisig,
+    Transaction,
+};
+
+#[macro_use]
+extern crate scale;
+
+#[ink::contract]
+mod multisig {
+    use ink::{
+        env::{
+            call::{
+                build_call,
+                ExecutionInput,
+            },
+            CallFlags,
+        },
+        prelude::vec::Vec,
+        storage::Mapping,
+    };
+    use scale::Output;
+
+    /// Tune this to your liking but be wary that allowing too many owners will not
+    /// perform well.
+    const MAX_OWNERS: u32 = 50;
+
+    type TransactionId = u32;
+    const WRONG_TRANSACTION_ID: &str =
+        "The user specified an invalid transaction id. Abort.";
+
+    /// A wrapper that allows us to encode a blob of bytes.
+    ///
+    /// We use this to pass the set of untyped (bytes) parameters to the `CallBuilder`.
+    struct CallInput<'a>(&'a [u8]);
+
+    impl<'a> scale::Encode for CallInput<'a> {
+        fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+            dest.write(self.0);
+        }
+    }
+
+    /// Indicates whether a transaction is already confirmed or needs further
+    /// confirmations.
+    #[derive(Clone, Copy, scale::Decode, scale::Encode)]
+    #[cfg_attr(
+        feature = "std",
+        derive(scale_info::TypeInfo, ink::storage::traits::StorageLayout)
+    )]
+    pub enum ConfirmationStatus {
+        /// The transaction is already confirmed.
+        Confirmed,
+        /// Indicates how many confirmations are remaining.
+        ConfirmationsNeeded(u32),
+    }
+
+    /// A Transaction is what every `owner` can submit for confirmation by other owners.
+    /// If enough owners agree it will be executed by the contract.
+    #[derive(scale::Decode, scale::Encode)]
+    #[cfg_attr(
+        feature = "std",
+        derive(
+            Debug,
+            PartialEq,
+            Eq,
+            scale_info::TypeInfo,
+            ink::storage::traits::StorageLayout
+        )
+    )]
+    // // NOTE: Added temporarily
+    // use crate::storage::AccountId;
+
+    pub struct Transaction {
+        /// The `AccountId` of the contract that is called in this transaction.
+        pub callee: AccountId,
+        /// The selector bytes that identifies the function of the callee that should be
+        /// called.
+        pub selector: [u8; 4],
+        /// The SCALE encoded parameters that are passed to the called function.
+        pub input: Vec<u8>,
+        /// The amount of chain balance that is transferred to the callee.
+        pub transferred_value: Balance,
+        /// Gas limit for the execution of the call.
+        pub gas_limit: u64,
+        /// If set to true the transaction will be allowed to re-enter the multisig
+        /// contract. Re-entrancy can lead to vulnerabilities. Use at your own
+        /// risk.
+        pub allow_reentry: bool,
+    }
+
+    /// Errors that can occur upon calling this contract.
+    #[derive(Copy, Clone, Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+    #[cfg_attr(feature = "std", derive(::scale_info::TypeInfo))]
+    pub enum Error {
+        /// Returned if the call failed.
+        TransactionFailed,
+    }
+
+    /// This is a book keeping struct that stores a list of all transaction ids and
+    /// also the next id to use. We need it for cleaning up the storage.
+    #[derive(Default, scale::Decode, scale::Encode)]
+    #[cfg_attr(
+        feature = "std",
+        derive(
+            Debug,
+            PartialEq,
+            Eq,
+            scale_info::TypeInfo,
+            ink::storage::traits::StorageLayout
+        )
+    )]
+    pub struct Transactions {
+        /// Just store all transaction ids packed.
+        transactions: Vec<TransactionId>,
+        /// We just increment this whenever a new transaction is created.
+        /// We never decrement or defragment. For now, the contract becomes defunct
+        /// when the ids are exhausted.
+        next_id: TransactionId,
+    }
+
+    /// Emitted when an owner confirms a transaction.
+    #[ink(event)]
+    pub struct Confirmation {
+        /// The transaction that was confirmed.
+        #[ink(topic)]
+        transaction: TransactionId,
+        /// The owner that sent the confirmation.
+        #[ink(topic)]
+        from: AccountId,
+        /// The confirmation status after this confirmation was applied.
+        #[ink(topic)]
+        status: ConfirmationStatus,
+    }
+
+    /// Emitted when an owner revoked a confirmation.
+    #[ink(event)]
+    pub struct Revocation {
+        /// The transaction that was revoked.
+        #[ink(topic)]
+        transaction: TransactionId,
+        /// The owner that sent the revocation.
+        #[ink(topic)]
+        from: AccountId,
+    }
+
+    /// Emitted when an owner submits a transaction.
+    #[ink(event)]
+    pub struct Submission {
+        /// The transaction that was submitted.
+        #[ink(topic)]
+        transaction: TransactionId,
+    }
+
+    /// Emitted when a transaction was canceled.
+    #[ink(event)]
+    pub struct Cancellation {
+        /// The transaction that was canceled.
+        #[ink(topic)]
+        transaction: TransactionId,
+    }
+
+    /// Emitted when a transaction was executed.
+    #[ink(event)]
+    pub struct Execution {
+        /// The transaction that was executed.
+        #[ink(topic)]
+        transaction: TransactionId,
+        /// Indicates whether the transaction executed successfully. If so the `Ok` value
+        /// holds the output in bytes. The Option is `None` when the transaction
+        /// was executed through `invoke_transaction` rather than
+        /// `evaluate_transaction`.
+        #[ink(topic)]
+        result: Result<Option<Vec<u8>>, Error>,
+    }
+
+    /// Emitted when an owner is added to the wallet.
+    #[ink(event)]
+    pub struct OwnerAddition {
+        /// The owner that was added.
+        #[ink(topic)]
+        owner: AccountId,
+    }
+
+    /// Emitted when an owner is removed from the wallet.
+    #[ink(event)]
+    pub struct OwnerRemoval {
+        /// The owner that was removed.
+        #[ink(topic)]
+        owner: AccountId,
+    }
+
+    /// Emitted when the requirement changed.
+    #[ink(event)]
+    pub struct RequirementChange {
+        /// The new requirement value.
+        new_requirement: u32,
+    }
+
+    #[ink(storage)]
+    #[derive(Default)]
+    pub struct Multisig {
+        /// Every entry in this map represents the confirmation of an owner for a
+        /// transaction. This is effectively a set rather than a map.
+        confirmations: Mapping<(TransactionId, AccountId), ()>,
+        /// The amount of confirmations for every transaction. This is a redundant
+        /// information and is kept in order to prevent iterating through the
+        /// confirmation set to check if a transaction is confirmed.
+        confirmation_count: Mapping<TransactionId, u32>,
+        /// Map the transaction id to its not-executed transaction.
+        transactions: Mapping<TransactionId, Transaction>,
+        /// We need to hold a list of all transactions so that we can clean up storage
+        /// when an owner is removed.
+        transaction_list: Transactions,
+        /// The list is a vector because iterating over it is necessary when cleaning
+        /// up the confirmation set.
+        owners: Vec<AccountId>,
+        /// Redundant information to speed up the check whether a caller is an owner.
+        is_owner: Mapping<AccountId, ()>,
+        /// Minimum number of owners that have to confirm a transaction to be executed.
+        requirement: u32,
+    }
+
+    impl Multisig {
+        /// The only constructor of the contract.
+        ///
+        /// A list of owners must be supplied and a number of how many of them must
+        /// confirm a transaction. Duplicate owners are silently dropped.
+        ///
+        /// # Panics
+        ///
+        /// If `requirement` violates our invariant.
+        #[ink(constructor)]
+        pub fn new(requirement: u32, mut owners: Vec<AccountId>) -> Self {
+            let mut contract = Multisig::default();
+            owners.sort_unstable();
+            owners.dedup();
+            ensure_requirement_is_valid(owners.len() as u32, requirement);
+
+            for owner in &owners {
+                contract.is_owner.insert(owner, &());
+            }
+
+            contract.owners = owners;
+            contract.transaction_list = Default::default();
+            contract.requirement = requirement;
+            contract
+        }
+
+        /// Add a new owner to the contract.
+        ///
+        /// Only callable by the wallet itself.
+        ///
+        /// # Panics
+        ///
+        /// If the owner already exists.
+        ///
+        /// # Examples
+        ///
+        /// Since this message must be send by the wallet itself it has to be build as a
+        /// `Transaction` and dispatched through `submit_transaction` and
+        /// `invoke_transaction`:
+        /// ```should_panic
+        /// use ink::{
+        ///     env::{
+        ///         call::{
+        ///             utils::ArgumentList,
+        ///             Call,
+        ///             CallParams,
+        ///             ExecutionInput,
+        ///             Selector,
+        ///         },
+        ///         DefaultEnvironment as Env,
+        ///         Environment,
+        ///     },
+        ///     selector_bytes,
+        /// };
+        /// use multisig::{
+        ///     ConfirmationStatus,
+        ///     Transaction,
+        /// };
+        /// use scale::Encode;
+        ///
+        /// type AccountId = <Env as Environment>::AccountId;
+        ///
+        /// // address of an existing `Multisig` contract
+        /// let wallet_id: AccountId = [7u8; 32].into();
+        ///
+        /// // first create the transaction that adds `alice` through `add_owner`
+        /// let alice: AccountId = [1u8; 32].into();
+        /// let add_owner_args = ArgumentList::empty().push_arg(&alice);
+        ///
+        /// let transaction_candidate = Transaction {
+        ///     callee: wallet_id,
+        ///     selector: selector_bytes!("add_owner"),
+        ///     input: add_owner_args.encode(),
+        ///     transferred_value: 0,
+        ///     gas_limit: 0,
+        ///     allow_reentry: true,
+        /// };
+        ///
+        /// // Submit the transaction for confirmation
+        /// //
+        /// // Note that the selector bytes of the `submit_transaction` method
+        /// // are `[86, 244, 13, 223]`.
+        /// let (id, _status) = ink::env::call::build_call::<Env>()
+        ///     .call_type(Call::new(wallet_id))
+        ///     .gas_limit(0)
+        ///     .exec_input(
+        ///         ExecutionInput::new(Selector::new([86, 244, 13, 223]))
+        ///             .push_arg(&transaction_candidate),
+        ///     )
+        ///     .returns::<(u32, ConfirmationStatus)>()
+        ///     .invoke();
+        ///
+        /// // Wait until all owners have confirmed and then execute the tx.
+        /// //
+        /// // Note that the selector bytes of the `invoke_transaction` method
+        /// // are `[185, 50, 225, 236]`.
+        /// ink::env::call::build_call::<Env>()
+        ///     .call_type(Call::new(wallet_id))
+        ///     .gas_limit(0)
+        ///     .exec_input(ExecutionInput::new(Selector::new([185, 50, 225, 236])).push_arg(&id))
+        ///     .returns::<()>()
+        ///     .invoke();
+        /// ```
+        #[ink(message)]
+        pub fn add_owner(&mut self, new_owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_no_owner(&new_owner);
+            ensure_requirement_is_valid(self.owners.len() as u32 + 1, self.requirement);
+            self.is_owner.insert(new_owner, &());
+            self.owners.push(new_owner);
+            self.env().emit_event(OwnerAddition { owner: new_owner });
+        }
+
+        /// Remove an owner from the contract.
+        ///
+        /// Only callable by the wallet itself. If by doing this the amount of owners
+        /// would be smaller than the requirement it is adjusted to be exactly the
+        /// number of owners.
+        ///
+        /// # Panics
+        ///
+        /// If `owner` is no owner of the wallet.
+        #[ink(message)]
+        pub fn remove_owner(&mut self, owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_owner(&owner);
+            let len = self.owners.len() as u32 - 1;
+            let requirement = u32::min(len, self.requirement);
+            ensure_requirement_is_valid(len, requirement);
+            let owner_index = self.owner_index(&owner) as usize;
+            self.owners.swap_remove(owner_index);
+            self.is_owner.remove(owner);
+            self.requirement = requirement;
+            self.clean_owner_confirmations(&owner);
+            self.env().emit_event(OwnerRemoval { owner });
+        }
+
+        /// Replace an owner from the contract with a new one.
+        ///
+        /// Only callable by the wallet itself.
+        ///
+        /// # Panics
+        ///
+        /// If `old_owner` is no owner or if `new_owner` already is one.
+        #[ink(message)]
+        pub fn replace_owner(&mut self, old_owner: AccountId, new_owner: AccountId) {
+            self.ensure_from_wallet();
+            self.ensure_owner(&old_owner);
+            self.ensure_no_owner(&new_owner);
+            let owner_index = self.owner_index(&old_owner);
+            self.owners[owner_index as usize] = new_owner;
+            self.is_owner.remove(old_owner);
+            self.is_owner.insert(new_owner, &());
+            self.clean_owner_confirmations(&old_owner);
+            self.env().emit_event(OwnerRemoval { owner: old_owner });
+            self.env().emit_event(OwnerAddition { owner: new_owner });
+        }
+
+        /// Change the requirement to a new value.
+        ///
+        /// Only callable by the wallet itself.
+        ///
+        /// # Panics
+        ///
+        /// If the `new_requirement` violates our invariant.
+        #[ink(message)]
+        pub fn change_requirement(&mut self, new_requirement: u32) {
+            self.ensure_from_wallet();
+            ensure_requirement_is_valid(self.owners.len() as u32, new_requirement);
+            self.requirement = new_requirement;
+            self.env().emit_event(RequirementChange { new_requirement });
+        }
+
+        /// Add a new transaction candidate to the contract.
+        ///
+        /// This also confirms the transaction for the caller. This can be called by any
+        /// owner.
+        #[ink(message)]
+        pub fn submit_transaction(
+            &mut self,
+            transaction: Transaction,
+        ) -> (TransactionId, ConfirmationStatus) {
+            self.ensure_caller_is_owner();
+            let trans_id = self.transaction_list.next_id;
+            self.transaction_list.next_id =
+                trans_id.checked_add(1).expect("Transaction ids exhausted.");
+            self.transactions.insert(trans_id, &transaction);
+            self.transaction_list.transactions.push(trans_id);
+            self.env().emit_event(Submission {
+                transaction: trans_id,
+            });
+            (
+                trans_id,
+                self.confirm_by_caller(self.env().caller(), trans_id),
+            )
+        }
+
+        /// Remove a transaction from the contract.
+        /// Only callable by the wallet itself.
+        ///
+        /// # Panics
+        ///
+        /// If `trans_id` is no valid transaction id.
+        #[ink(message)]
+        pub fn cancel_transaction(&mut self, trans_id: TransactionId) {
+            self.ensure_from_wallet();
+            if self.take_transaction(trans_id).is_some() {
+                self.env().emit_event(Cancellation {
+                    transaction: trans_id,
+                });
+            }
+        }
+
+        /// Confirm a transaction for the sender that was submitted by any owner.
+        ///
+        /// This can be called by any owner.
+        ///
+        /// # Panics
+        ///
+        /// If `trans_id` is no valid transaction id.
+        #[ink(message)]
+        pub fn confirm_transaction(
+            &mut self,
+            trans_id: TransactionId,
+        ) -> ConfirmationStatus {
+            self.ensure_caller_is_owner();
+            self.ensure_transaction_exists(trans_id);
+            self.confirm_by_caller(self.env().caller(), trans_id)
+        }
+
+        /// Revoke the senders confirmation.
+        ///
+        /// This can be called by any owner.
+        ///
+        /// # Panics
+        ///
+        /// If `trans_id` is no valid transaction id.
+        #[ink(message)]
+        pub fn revoke_confirmation(&mut self, trans_id: TransactionId) {
+            self.ensure_caller_is_owner();
+            let caller = self.env().caller();
+            if self.confirmations.contains((trans_id, caller)) {
+                self.confirmations.remove((trans_id, caller));
+                let mut confirmation_count = self
+                    .confirmation_count
+                    .get(trans_id)
+                    .expect(
+                    "There is a entry in `self.confirmations`. Hence a count must exit.",
+                );
+                // Will not underflow as there is at least one confirmation
+                confirmation_count -= 1;
+                self.confirmation_count
+                    .insert(trans_id, &confirmation_count);
+                self.env().emit_event(Revocation {
+                    transaction: trans_id,
+                    from: caller,
+                });
+            }
+        }
+
+        /// Invoke a confirmed execution without getting its output.
+        ///
+        /// If the transaction which is invoked transfers value, this value has
+        /// to be sent as payment with this call. The method will fail otherwise,
+        /// and the transaction would then be reverted.
+        ///
+        /// Its return value indicates whether the called transaction was successful.
+        /// This can be called by anyone.
+        #[ink(message, payable)]
+        pub fn invoke_transaction(
+            &mut self,
+            trans_id: TransactionId,
+        ) -> Result<(), Error> {
+            self.ensure_confirmed(trans_id);
+            let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
+            assert!(self.env().transferred_value() == t.transferred_value);
+            let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
+                .call(t.callee)
+                .gas_limit(t.gas_limit)
+                .transferred_value(t.transferred_value)
+                .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
+                .exec_input(
+                    ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
+                )
+                .returns::<()>()
+                .try_invoke();
+
+            let result = match result {
+                Ok(Ok(_)) => Ok(()),
+                _ => Err(Error::TransactionFailed),
+            };
+
+            self.env().emit_event(Execution {
+                transaction: trans_id,
+                result: result.map(|_| None),
+            });
+            result
+        }
+
+        /// Evaluate a confirmed execution and return its output as bytes.
+        ///
+        /// Its return value indicates whether the called transaction was successful and
+        /// contains its output when successful.
+        /// This can be called by anyone.
+        #[ink(message, payable)]
+        pub fn eval_transaction(
+            &mut self,
+            trans_id: TransactionId,
+        ) -> Result<Vec<u8>, Error> {
+            self.ensure_confirmed(trans_id);
+            let t = self.take_transaction(trans_id).expect(WRONG_TRANSACTION_ID);
+            let result = build_call::<<Self as ::ink::env::ContractEnv>::Env>()
+                .call(t.callee)
+                .gas_limit(t.gas_limit)
+                .transferred_value(t.transferred_value)
+                .call_flags(CallFlags::default().set_allow_reentry(t.allow_reentry))
+                .exec_input(
+                    ExecutionInput::new(t.selector.into()).push_arg(CallInput(&t.input)),
+                )
+                .returns::<Vec<u8>>()
+                .try_invoke();
+
+            let result = match result {
+                Ok(Ok(v)) => Ok(v),
+                _ => Err(Error::TransactionFailed),
+            };
+
+            self.env().emit_event(Execution {
+                transaction: trans_id,
+                result: result.clone().map(Some),
+            });
+            result
+        }
+
+        /// Set the `transaction` as confirmed by `confirmer`.
+        /// Idempotent operation regarding an already confirmed `transaction`
+        /// by `confirmer`.
+        fn confirm_by_caller(
+            &mut self,
+            confirmer: AccountId,
+            transaction: TransactionId,
+        ) -> ConfirmationStatus {
+            let mut count = self.confirmation_count.get(transaction).unwrap_or(0);
+            let key = (transaction, confirmer);
+            let new_confirmation = !self.confirmations.contains(key);
+            if new_confirmation {
+                count += 1;
+                self.confirmations.insert(key, &());
+                self.confirmation_count.insert(transaction, &count);
+            }
+            let status = {
+                if count >= self.requirement {
+                    ConfirmationStatus::Confirmed
+                } else {
+                    ConfirmationStatus::ConfirmationsNeeded(self.requirement - count)
+                }
+            };
+            if new_confirmation {
+                self.env().emit_event(Confirmation {
+                    transaction,
+                    from: confirmer,
+                    status,
+                });
+            }
+            status
+        }
+
+        /// Get the index of `owner` in `self.owners`.
+        /// Panics if `owner` is not found in `self.owners`.
+        fn owner_index(&self, owner: &AccountId) -> u32 {
+            self.owners.iter().position(|x| *x == *owner).expect(
+                "This is only called after it was already verified that the id is
+                 actually an owner.",
+            ) as u32
+        }
+
+        /// Remove the transaction identified by `trans_id` from `self.transactions`.
+        /// Also removes all confirmation state associated with it.
+        fn take_transaction(&mut self, trans_id: TransactionId) -> Option<Transaction> {
+            let transaction = self.transactions.get(trans_id);
+            if transaction.is_some() {
+                self.transactions.remove(trans_id);
+                let pos = self
+                    .transaction_list
+                    .transactions
+                    .iter()
+                    .position(|t| t == &trans_id)
+                    .expect("The transaction exists hence it must also be in the list.");
+                self.transaction_list.transactions.swap_remove(pos);
+                for owner in self.owners.iter() {
+                    self.confirmations.remove((trans_id, *owner));
+                }
+                self.confirmation_count.remove(trans_id);
+            }
+            transaction
+        }
+
+        /// Remove all confirmation state associated with `owner`.
+        /// Also adjusts the `self.confirmation_count` variable.
+        fn clean_owner_confirmations(&mut self, owner: &AccountId) {
+            for trans_id in &self.transaction_list.transactions {
+                let key = (*trans_id, *owner);
+                if self.confirmations.contains(key) {
+                    self.confirmations.remove(key);
+                    let mut count = self.confirmation_count.get(trans_id).unwrap_or(0);
+                    count -= 1;
+                    self.confirmation_count.insert(trans_id, &count);
+                }
+            }
+        }
+
+        /// Panic if transaction `trans_id` is not confirmed by at least
+        /// `self.requirement` owners.
+        fn ensure_confirmed(&self, trans_id: TransactionId) {
+            assert!(
+                self.confirmation_count
+                    .get(trans_id)
+                    .expect(WRONG_TRANSACTION_ID)
+                    >= self.requirement
+            );
+        }
+
+        /// Panic if the transaction `trans_id` does not exit.
+        fn ensure_transaction_exists(&self, trans_id: TransactionId) {
+            self.transactions.get(trans_id).expect(WRONG_TRANSACTION_ID);
+        }
+
+        /// Panic if the sender is no owner of the wallet.
+        fn ensure_caller_is_owner(&self) {
+            self.ensure_owner(&self.env().caller());
+        }
+
+        /// Panic if the sender is not this wallet.
+        fn ensure_from_wallet(&self) {
+            assert_eq!(self.env().caller(), self.env().account_id());
+        }
+
+        /// Panic if `owner` is not an owner,
+        fn ensure_owner(&self, owner: &AccountId) {
+            assert!(self.is_owner.contains(owner));
+        }
+
+        /// Panic if `owner` is an owner.
+        fn ensure_no_owner(&self, owner: &AccountId) {
+            assert!(!self.is_owner.contains(owner));
+        }
+    }
+
+    /// Panic if the number of `owners` under a `requirement` violates our
+    /// requirement invariant.
+    fn ensure_requirement_is_valid(owners: u32, requirement: u32) {
+        assert!(0 < requirement && requirement <= owners && owners <= MAX_OWNERS);
+    }
+
+}

--- a/contracts/source/multisig.rs
+++ b/contracts/source/multisig.rs
@@ -89,11 +89,12 @@ mod multisig {
     /// We use this to pass the set of untyped (bytes) parameters to the `CallBuilder`.
     struct CallInput<'a>(&'a [u8]);
 
-    impl<'a> scale::Encode for CallInput<'a> {
-        fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
-            dest.write(self.0);
-        }
-    }
+    // NOTE: temporarily removed
+    // impl<'a> scale::Encode for CallInput<'a> {
+    //     fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+    //         dest.write(self.0);
+    //     }
+    // }
 
     /// Indicates whether a transaction is already confirmed or needs further
     /// confirmations.
@@ -122,9 +123,8 @@ mod multisig {
             ink::storage::traits::StorageLayout
         )
     )]
-    // // NOTE: Added temporarily
-    // use crate::storage::AccountId;
 
+    #[derive(Default)]
     pub struct Transaction {
         /// The `AccountId` of the contract that is called in this transaction.
         pub callee: AccountId,

--- a/contracts/source_to_generated.py
+++ b/contracts/source_to_generated.py
@@ -98,6 +98,12 @@ for filename in os.listdir(source_dir):
               'use crate::storage::{'
             )
 
+            # For storage::call errors
+            content = content.replace(
+              'ink::env::call',
+              'storage::call'
+            )
+
             content = content.replace(
               'prelude::',
               ''

--- a/contracts/source_to_generated.py
+++ b/contracts/source_to_generated.py
@@ -56,6 +56,7 @@ for filename in os.listdir(source_dir):
         with open(target_file, 'r+') as f:
             content = f.read()
 
+            # General headers
             first_line = '#![cfg_attr(not(feature = "std"), no_std, no_main)]'
             content = content.replace(
                 first_line,
@@ -69,16 +70,21 @@ for filename in os.listdir(source_dir):
             )
 
             content = content.replace(
-                'mod erc20 {\n    use ink::storage::Mapping;',
-                'mod erc20 {\n    use crate::storage::*;',
+              'mod erc20 {\n    use ink::storage::Mapping;',
+              'mod erc20 {\n    use crate::storage::*;',
             )
 
             content = content.replace(
-                'mod erc721 {\n    use ink::storage::Mapping;',
-                'mod erc721 {\n    use crate::storage::*;',
+              'mod erc721 {\n    use ink::storage::Mapping;',
+              'mod erc721 {\n    use crate::storage::*;',
+            )
+
+            content = content.replace(
+              'mod erc1155 {\n    use super::*;',
+              'mod erc1155 {\n    use super::*;\n    use super::Error;'
             )
             
-            multisig_raw = """    use ink::{
+            multisig_header = """    use ink::{
         env::{
             call::{
                 build_call,
@@ -90,7 +96,7 @@ for filename in os.listdir(source_dir):
         storage::Mapping,
     };
     use scale::Output;"""
-            content = re.sub(multisig_raw, 'use super::*;', content)
+            content = re.sub(multisig_header, '    use super::*;\n    use crate::storage::call::ExecutionInput;', content)
 
             # for erc1155
             content = content.replace(
@@ -111,6 +117,11 @@ for filename in os.listdir(source_dir):
             content = content.replace(
               'ink::env::Error',
               'crate::storage::Error'
+            )
+
+            content = content.replace(
+              '::ink::env::ContractEnv',
+              'ContractEnv'
             )
 
             content = content.replace(
@@ -171,14 +182,25 @@ for filename in os.listdir(source_dir):
             )
 
             content = content.replace(
-              'prelude::',
-              ''
+              'prelude::vec::Vec',
+              'vec::Vec'
             )
 
-            content = content.replace(
-              'primitives::',
-              ''
-            )
+            # content = content.replace(
+            #   'prelude::',
+            #   ''
+            # )
+
+            # content = content.replace(
+            #   'primitives::',
+            #   ''
+            # )
+
+            imports_to_delete = [
+              'use crate::storage::{\n    vec::Vec,\n    primitives::AccountId,\n};\n'
+            ]
+            for imports in imports_to_delete:
+                content = content.replace(imports, '')
 
             macros_to_comment = [
                 '#[ink::contract]',

--- a/contracts/template/Cargo.toml
+++ b/contracts/template/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [workspace]
+
+[dependencies]
+scale = { path = "lib/scale" }

--- a/contracts/template/Cargo.toml
+++ b/contracts/template/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 scale = { path = "lib/scale" }
+derive_more = { version = "0.99", default-features = false, features = ["from", "display"] }

--- a/contracts/template/lib/scale/Cargo.toml
+++ b/contracts/template/lib/scale/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "scale"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = "0.15"
+quote = "0.6"
+
+[lib]
+proc-macro = true

--- a/contracts/template/lib/scale/src/lib.rs
+++ b/contracts/template/lib/scale/src/lib.rs
@@ -1,0 +1,30 @@
+#[macro_use]
+extern crate quote;
+#[macro_use]
+extern crate syn;
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::DeriveInput;
+
+// #[proc_macro]
+// pub trait Encode {}
+
+// #[proc_macro]
+// pub trait Decode {}
+
+// NOTE: this is a mere stub for #[derive(Encode)]'s implementation to eliminate errors.
+#[proc_macro_derive(Encode)]
+pub fn encode_macro_derive(input: TokenStream) -> TokenStream { 
+  let input = parse_macro_input!(input as DeriveInput);
+  let expanded = quote!{};
+  proc_macro::TokenStream::from(expanded)
+}
+
+#[proc_macro_derive(Decode)]
+pub fn decode_macro_derive(input: TokenStream) -> TokenStream { 
+  let input = parse_macro_input!(input as DeriveInput);
+  let expanded = quote!{};
+  proc_macro::TokenStream::from(expanded)
+}

--- a/contracts/template/lib/scale/src/lib.rs
+++ b/contracts/template/lib/scale/src/lib.rs
@@ -8,12 +8,6 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
-// #[proc_macro]
-// pub trait Encode {}
-
-// #[proc_macro]
-// pub trait Decode {}
-
 // NOTE: this is a mere stub for #[derive(Encode)]'s implementation to eliminate errors.
 #[proc_macro_derive(Encode)]
 pub fn encode_macro_derive(input: TokenStream) -> TokenStream { 

--- a/contracts/template/src/storage.rs
+++ b/contracts/template/src/storage.rs
@@ -9,7 +9,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::Arc;
 
-#[derive(Default, Eq, PartialEq, Clone, Copy)]
+#[derive(Default, Eq, PartialEq, Clone, Copy, Debug)]
 pub struct AccountId([u8; 32]);
 
 impl From<[u8; 32]> for AccountId {
@@ -21,6 +21,8 @@ impl From<[u8; 32]> for AccountId {
 pub type Balance = u128;
 
 pub trait Encode {}
+
+pub trait Decode {}
 
 impl<T> Encode for T {}
 
@@ -162,6 +164,7 @@ impl<
         R0: EncodeLike<R1>,
         R1: Encode,
     >
+ 
     EncodeLike<(
         A1,
         B1,
@@ -741,4 +744,147 @@ macro_rules! impl_storage {
             }
         }
     };
+}
+
+// scale::Encode
+impl std::fmt::Debug for dyn Encode {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+      write!(f, "{}", "Encode")
+  }
+}
+
+// scale::Decode
+impl std::fmt::Debug for dyn Decode {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+      write!(f, "{}", "Decode")
+  }
+}
+
+// ink::prelude::string
+pub mod string {
+  pub struct String {}
+}
+
+// ink::env::vec
+pub mod vec {
+  pub struct Vec<T> {
+    _marker: core::marker::PhantomData<T>,
+  }
+}
+
+// pub struct Args {}
+// pub struct Call<E: Environment> {
+//   // dest : MultiAddress<E::AccountId, ()>,
+//   // value : E::Balance,
+//   // gas_limit : Weight,
+//   // storage_deposit_limit : Option<E::Balance>,
+//   // data : Vec<u8>,
+// }
+
+// pub struct EmptyArgumentList {}
+// pub struct ReturnType<T>(PhantomData<fn() -> T>);
+// pub struct Unset<T>(PhantomData<fn() -> T>);
+
+// // ink::env::call
+// pub mod call {
+//   // pub fn build_call<E>() -> CallBuilder<
+//   //     E,
+//   //     Unset<Call<E>>,
+//   //     Unset<ExecutionInput<EmptyArgumentList>>,
+//   //     Unset<ReturnType<()>>,
+//   // >
+//   // where
+//   //     E: Environment,
+//   // {
+//   //     CallBuilder {
+//   //         call_type: Default::default(),
+//   //         call_flags: Default::default(),
+//   //         exec_input: Default::default(),
+//   //         return_type: Default::default(),
+//   //         _phantom: Default::default(),
+//   //     }
+//   // }
+//   use crate::storage::Environment;
+//   use crate::storage::Unset;
+//   use crate::storage::EmptyArgumentList;
+//   use crate::storage::ReturnType;
+//   use crate::storage::Call;
+
+//   pub struct Selector {
+//     bytes: [u8; 4],
+//   }
+//   pub struct ExecutionInput<Args> {
+//     selector: Selector,
+//     args: Args,
+//   }
+
+//   pub fn build_call<E>() -> CallBuilder<
+//     E,
+//     Unset<Call<E>>,
+//     Unset<ExecutionInput<EmptyArgumentList>>,
+//     Unset<ReturnType<()>>,
+//   >
+//   where
+//     E: Environment
+//   { unimplemented!() }
+// }
+
+// ink::env::DefaultEnvironment
+pub enum DefaultEnvironment {}
+
+// ink::env::Environment
+pub trait Environment {
+  type AccountId;
+  type Balance;
+  type Hash;
+  type Timestamp;
+  type BlockNumber;
+  type ChainExtension;
+
+  const MAX_EVENT_TOPICS: usize;
+}
+
+pub struct Hash {}
+pub struct Timestamp {}
+pub struct BlockNumber {}
+pub enum NoChainExtension {}
+
+impl Environment for DefaultEnvironment {
+  const MAX_EVENT_TOPICS: usize = 4;
+
+  type AccountId = AccountId;
+  type Balance = Balance;
+  type Hash = Hash;
+  type Timestamp = Timestamp;
+  type BlockNumber = BlockNumber;
+  type ChainExtension = NoChainExtension;
+}
+
+pub struct OffChainError {}
+
+pub struct ScaleError {} // parity_scale_codec::Error
+
+// ink::env::Error
+pub enum Error {
+  Decode(ScaleError),
+  OffChain(OffChainError),
+  CalleeTrapped,
+  CalleeReverted,
+  KeyNotFound,
+  _BelowSubsistenceThreshold,
+  TransferFailed,
+  _EndowmentTooLow,
+  CodeNotFound,
+  NotCallable,
+  Unknown,
+  LoggingDisabled,
+  CallRuntimeFailed,
+  EcdsaRecoveryFailed,
+}
+
+// ink::env::debug_println
+#[macro_export]
+macro_rules! debug_println {
+  () => { unimplemented!() };
+  ($($arg:tt)*) => { unimplemented!() };
 }

--- a/contracts/template/src/storage.rs
+++ b/contracts/template/src/storage.rs
@@ -767,67 +767,67 @@ pub mod string {
 
 // ink::env::vec
 pub mod vec {
-  pub struct Vec<T> {
-    _marker: core::marker::PhantomData<T>,
-  }
+  pub type Vec<T> = std::vec::Vec<T>;
 }
 
-// pub struct Args {}
-// pub struct Call<E: Environment> {
-//   // dest : MultiAddress<E::AccountId, ()>,
-//   // value : E::Balance,
-//   // gas_limit : Weight,
-//   // storage_deposit_limit : Option<E::Balance>,
-//   // data : Vec<u8>,
-// }
+pub struct Args {}
+pub struct Call<E: Environment> {
+  // dest : MultiAddress<E::AccountId, ()>,
+  // value : E::Balance,
+  // gas_limit : Weight,
+  // storage_deposit_limit : Option<E::Balance>,
+  // data : Vec<u8>,
+  _marker : core::marker::PhantomData<E>
+}
 
-// pub struct EmptyArgumentList {}
-// pub struct ReturnType<T>(PhantomData<fn() -> T>);
-// pub struct Unset<T>(PhantomData<fn() -> T>);
+pub struct EmptyArgumentList {}
+pub struct ReturnType<T>(PhantomData<fn() -> T>);
+pub struct Unset<T>(PhantomData<fn() -> T>);
 
-// // ink::env::call
-// pub mod call {
-//   // pub fn build_call<E>() -> CallBuilder<
-//   //     E,
-//   //     Unset<Call<E>>,
-//   //     Unset<ExecutionInput<EmptyArgumentList>>,
-//   //     Unset<ReturnType<()>>,
-//   // >
-//   // where
-//   //     E: Environment,
-//   // {
-//   //     CallBuilder {
-//   //         call_type: Default::default(),
-//   //         call_flags: Default::default(),
-//   //         exec_input: Default::default(),
-//   //         return_type: Default::default(),
-//   //         _phantom: Default::default(),
-//   //     }
-//   // }
-//   use crate::storage::Environment;
-//   use crate::storage::Unset;
-//   use crate::storage::EmptyArgumentList;
-//   use crate::storage::ReturnType;
-//   use crate::storage::Call;
+// ink::env::call
+pub mod call {
+  use super::*;
+  // pub fn build_call<E>() -> CallBuilder<
+  //     E,
+  //     Unset<Call<E>>,
+  //     Unset<ExecutionInput<EmptyArgumentList>>,
+  //     Unset<ReturnType<()>>,
+  // >
+  // where
+  //     E: Environment,
+  // {
+  //     CallBuilder {
+  //         call_type: Default::default(),
+  //         call_flags: Default::default(),
+  //         exec_input: Default::default(),
+  //         return_type: Default::default(),
+  //         _phantom: Default::default(),
+  //     }
+  // }
+  // use crate::storage::Environment;
+  // use crate::storage::Unset;
+  // use crate::storage::EmptyArgumentList;
+  // use crate::storage::ReturnType;
+  // use crate::storage::Call;
 
-//   pub struct Selector {
-//     bytes: [u8; 4],
-//   }
-//   pub struct ExecutionInput<Args> {
-//     selector: Selector,
-//     args: Args,
-//   }
+  pub struct Selector {
+    bytes: [u8; 4],
+  }
+  pub struct ExecutionInput<Args> {
+    selector: Selector,
+    args: Args,
+  }
 
-//   pub fn build_call<E>() -> CallBuilder<
-//     E,
-//     Unset<Call<E>>,
-//     Unset<ExecutionInput<EmptyArgumentList>>,
-//     Unset<ReturnType<()>>,
-//   >
-//   where
-//     E: Environment
-//   { unimplemented!() }
-// }
+  // pub fn build_call<E>() -> CallBuilder<
+  //   E,
+  //   Unset<Call<E>>,
+  //   Unset<ExecutionInput<EmptyArgumentList>>,
+  //   Unset<ReturnType<()>>,
+  // >
+  // where
+  //   E: Environment
+  // { unimplemented!() }
+}
 
 // ink::env::DefaultEnvironment
 pub enum DefaultEnvironment {}
@@ -860,11 +860,14 @@ impl Environment for DefaultEnvironment {
   type ChainExtension = NoChainExtension;
 }
 
+#[derive(Debug)]
 pub struct OffChainError {}
 
+#[derive(Debug)]
 pub struct ScaleError {} // parity_scale_codec::Error
 
 // ink::env::Error
+#[derive(Debug)]
 pub enum Error {
   Decode(ScaleError),
   OffChain(OffChainError),
@@ -880,6 +883,13 @@ pub enum Error {
   LoggingDisabled,
   CallRuntimeFailed,
   EcdsaRecoveryFailed,
+  // Unchecked
+  ZeroAddressTransfer,
+  BatchTransferMismatch,
+  InsufficientBalance,
+  SelfApproval,
+  UnexistentToken,
+  NotApproved
 }
 
 // ink::env::debug_println

--- a/contracts/template/src/storage.rs
+++ b/contracts/template/src/storage.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 extern crate derive_more;
 use derive_more::From;
 
-#[derive(Default, Eq, PartialEq, Clone, Copy, Debug)]
+#[derive(Default, Eq, PartialEq, Clone, Copy, Debug, Ord, PartialOrd)]
 pub struct AccountId([u8; 32]);
 
 impl From<[u8; 32]> for AccountId {
@@ -791,16 +791,25 @@ pub struct Call<E: Environment> {
   _marker : core::marker::PhantomData<E>
 }
 
-pub struct EmptyArgumentList {}
+pub struct EmptyArgumentList;
 pub struct ReturnType<T>(PhantomData<fn() -> T>);
 pub struct Unset<T>(PhantomData<fn() -> T>);
 pub struct CallType;
 pub struct RetType;
+
+#[derive(Default)]
 pub struct CallFlags {
   forward_input: bool,
   clone_input: bool,
   tail_call: bool,
   allow_reentry: bool,
+}
+
+impl CallFlags {
+  pub const fn set_allow_reentry(mut self, allow_reentry: bool) -> Self {
+    self.allow_reentry = allow_reentry;
+    self
+  }
 }
 
 // ink::env::call
@@ -819,6 +828,7 @@ pub mod call {
       _phantom: PhantomData<fn() -> E>,
   }
 
+  #[derive(From)]
   pub struct Selector {
     bytes: [u8; 4],
   }
@@ -888,9 +898,9 @@ pub trait ContractEnv {
   type Env: crate::Environment;
 }
 
-pub struct Hash {}
-pub struct Timestamp {}
-pub struct BlockNumber {}
+pub struct Hash;
+pub struct Timestamp;
+pub struct BlockNumber;
 pub enum NoChainExtension {}
 
 impl Environment for DefaultEnvironment {


### PR DESCRIPTION
# Note
Currently `erc1155` and `multisig` has only a few bugs left. While `multisig` still misses some varied functions to be implemented, `erc1155` and `multisig` both meets a major issue that is blocking them from being able to pass.

## Implement `build_call`

`build_call` seems to be a function to initiate executing a contract, so it involves a lot of dependency. In `erc1155` the errors comes from vacancy for implementing `push_arg` which is a dependency on `build_call` and `build_call` itself. Implementing them would go deep into the libraries.

## Implemnt the apis in `ink::env`
For `multisig`, another kind of problems can be summarized into implementing the functions given in the api. The missing of these api functions resulted in the failure for `multisig` to compile.