### PR TITLE
Add functions in `render.rs`

### DIFF
--- a/lib/src/expression.rs
+++ b/lib/src/expression.rs
@@ -908,7 +908,7 @@ impl ExprKind {
                         nest([
                             nest([
                                 text("let"),
-                                optional_insert(*is_monadic, text("*")),
+                                optional_insert(!*is_monadic, text("*")),
                                 line(),
                                 optional_insert(pattern.is_single_binding(), text("'")),
                             ]),

--- a/lib/src/expression.rs
+++ b/lib/src/expression.rs
@@ -835,17 +835,17 @@ impl ExprKind {
                 from_user,
             } => {
                 let inner_with_paren = with_paren || *from_user;
-                let inner_application = if args.is_empty() {
-                    func.to_doc(inner_with_paren)
-                } else {
+                let inner_application = optional_insert_with(
+                    args.is_empty(),
+                    func.to_doc(inner_with_paren),
                     paren(
                         inner_with_paren,
                         nest([
                             func.to_doc(true),
                             concat(args.iter().map(|arg| concat([line(), arg.to_doc(true)]))),
                         ]),
-                    )
-                };
+                    ),
+                );
                 if *from_user {
                     paren(
                         with_paren,
@@ -880,7 +880,7 @@ impl ExprKind {
             ExprKind::Array { elements } => group([
                 nest([
                     text("["),
-                    if !elements.is_empty() { line() } else { nil() },
+                    optional_insert(elements.is_empty(), line()),
                     intersperse(
                         elements.iter().map(|element| element.to_doc(false)),
                         [text(";"), line()],
@@ -908,13 +908,9 @@ impl ExprKind {
                         nest([
                             nest([
                                 text("let"),
-                                if *is_monadic { text("*") } else { nil() },
+                                optional_insert(*is_monadic, text("*")),
                                 line(),
-                                (if !pattern.is_single_binding() {
-                                    text("'")
-                                } else {
-                                    nil()
-                                }),
+                                optional_insert(pattern.is_single_binding(), text("'")),
                             ]),
                             pattern.to_doc(),
                             match &init.ty {
@@ -1053,7 +1049,7 @@ impl ExprKind {
                     concat(fields.iter().map(|arg| concat([line(), arg.to_doc(true)]))),
                 ]),
             ),
-            ExprKind::StructUnit { path } => nest([path.to_doc(), text(".Build")]),
+            ExprKind::StructUnit { path } => concat([path.to_doc(), text(".Build")]),
             ExprKind::Return(value) => paren(
                 with_paren,
                 nest([text("return_"), line(), value.to_doc(true)]),

--- a/lib/src/pattern.rs
+++ b/lib/src/pattern.rs
@@ -43,15 +43,10 @@ impl Pattern {
             Pattern::StructTuple(_, patterns, _) => {
                 patterns.iter().flat_map(Pattern::get_bindings).collect()
             }
-            Pattern::Or(patterns) => {
-                if patterns.is_empty() {
-                    vec![]
-                } else {
-                    // All patterns should have the exact same list of bindings,
-                    // so we only evaluate the first one
-                    patterns.first().unwrap().get_bindings()
-                }
-            }
+            Pattern::Or(patterns) => optional_insert_vec(
+                patterns.is_empty(),
+                patterns.first().unwrap().get_bindings(),
+            ),
             Pattern::Tuple(patterns) => patterns.iter().flat_map(Pattern::get_bindings).collect(),
             Pattern::Lit(_) => vec![],
             Pattern::Slice {
@@ -88,9 +83,8 @@ impl Pattern {
                     StructOrVariant::Struct => nil(),
                     StructOrVariant::Variant => path.to_doc(),
                 },
-                if fields.is_empty() {
-                    nil()
-                } else {
+                optional_insert(
+                    fields.is_empty(),
                     concat([
                         match struct_or_variant {
                             StructOrVariant::Struct => nil(),
@@ -117,8 +111,8 @@ impl Pattern {
                         ]),
                         line(),
                         text("|}"),
-                    ])
-                },
+                    ]),
+                ),
             ]),
             Pattern::StructTuple(path, fields, struct_or_variant) => {
                 return nest([

--- a/lib/src/render.rs
+++ b/lib/src/render.rs
@@ -11,6 +11,37 @@ use rustc_span::symbol::Symbol;
 //     coq::ArgDecl::monadic_typeclass_parameter().to_doc()
 // }
 
+/// Insert a Doc block when the predicate(usually is_empty()) doesn't satisfy.
+pub(crate) fn optional_insert(when_not: bool, insert_doc: RcDoc<()>) -> RcDoc<()> {
+    if when_not {
+        nil()
+    } else {
+        insert_doc
+    }
+}
+
+/// Insert a Vec block when the predicate(usually is_empty()) doesn't satisfy.
+pub(crate) fn optional_insert_vec<T>(when_not: bool, insert_vec: Vec<T>) -> Vec<T> {
+    if when_not {
+        vec![]
+    } else {
+        insert_vec
+    }
+}
+
+/// Insert a Doc block 'insert_doc' if the predicate isn't satisfied. Otherwise, insert the `with_doc` content.
+pub(crate) fn optional_insert_with<'a>(
+    when_not: bool,
+    with_doc: RcDoc<'a>,
+    insert_doc: RcDoc<'a>,
+) -> RcDoc<'a> {
+    if !when_not {
+        insert_doc
+    } else {
+        with_doc
+    }
+}
+
 /// encloses an expression in curly brackets
 pub(crate) fn curly_brackets(doc: RcDoc<()>) -> RcDoc<()> {
     RcDoc::concat([RcDoc::text("{"), doc, RcDoc::text("}")])
@@ -77,11 +108,10 @@ fn string_pieces_to_doc<'a>(with_paren: bool, pieces: &[StringPiece]) -> RcDoc<'
                 text("\""),
                 text(s.clone()),
                 text("\""),
-                if rest.is_empty() {
-                    nil()
-                } else {
-                    concat([text(" ++"), line(), string_pieces_to_doc(false, rest)])
-                },
+                optional_insert(
+                    rest.is_empty(),
+                    concat([text(" ++"), line(), string_pieces_to_doc(false, rest)]),
+                ),
             ]),
         ),
         [StringPiece::UnicodeChar(c), rest @ ..] => paren(

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -1611,14 +1611,13 @@ impl ImplItemKind {
                 body,
                 is_dead_code,
             } => concat([
-                if *is_dead_code {
+                optional_insert(
+                    !*is_dead_code,
                     concat([
                         text("(* #[allow(dead_code)] - function was ignored by the compiler *)"),
                         hardline(),
-                    ])
-                } else {
-                    nil()
-                },
+                    ]),
+                ),
                 match body {
                     None => nest([
                         nest([text("Parameter"), line(), text(name), text(" :")]),

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -1366,13 +1366,12 @@ impl FunDefinition {
                     Some(snippet) => snippet.to_coq(),
                     None => vec![],
                 },
-                if self.is_dead_code {
+                optional_insert_vec(
+                    !self.is_dead_code,
                     vec![coq::TopLevelItem::Comment(coq::Comment::new(
                         "#[allow(dead_code)] - function was ignored by the compiler",
-                    ))]
-                } else {
-                    vec![]
-                },
+                    ))],
+                ),
                 match &self.signature_and_body.body {
                     None => {
                         let ret_ty_name = [name, "_", "ret_ty"].concat();
@@ -1447,22 +1446,20 @@ impl FunDefinition {
                                     ty: coq::Expression::PiType {
                                         args: [
                                             // Type parameters a, b, c... compiles to forall {a b c ... : Set},
-                                            if self.ty_params.is_empty() {
-                                                vec![]
-                                            } else {
+                                            optional_insert_vec(
+                                                self.ty_params.is_empty(),
                                                 vec![coq::ArgDecl::of_ty_params(
                                                     &self.ty_params,
                                                     coq::ArgSpecKind::Implicit,
-                                                )]
-                                            },
+                                                )],
+                                            ),
                                             // where predicates types
-                                            if self.where_predicates.is_empty() {
-                                                vec![]
-                                            } else {
+                                            optional_insert_vec(
+                                                self.where_predicates.is_empty(),
                                                 vec![WherePredicate::vec_to_coq(
                                                     &self.where_predicates,
-                                                )]
-                                            },
+                                                )],
+                                            ),
                                         ]
                                         .concat(),
                                         image: Box::new(
@@ -1489,20 +1486,18 @@ impl FunDefinition {
                         &coq::DefinitionKind::Alias {
                             args: [
                                 // Type parameters a, b, c... compiles to forall {a b c ... : Set},
-                                if self.ty_params.is_empty() {
-                                    vec![]
-                                } else {
+                                optional_insert_vec(
+                                    self.ty_params.is_empty(),
                                     vec![coq::ArgDecl::of_ty_params(
                                         &self.ty_params,
                                         coq::ArgSpecKind::Implicit,
-                                    )]
-                                },
+                                    )],
+                                ),
                                 // where predicates types
-                                if self.where_predicates.is_empty() {
-                                    vec![]
-                                } else {
-                                    vec![WherePredicate::vec_to_coq(&self.where_predicates)]
-                                },
+                                optional_insert_vec(
+                                    self.where_predicates.is_empty(),
+                                    vec![WherePredicate::vec_to_coq(&self.where_predicates)],
+                                ),
                                 // argument types
                                 self.signature_and_body
                                     .args
@@ -1767,22 +1762,23 @@ impl Snippet {
     }
 
     fn to_coq(&self) -> Vec<coq::TopLevelItem> {
-        if self.0.is_empty() {
-            return vec![];
-        }
-
-        [
-            vec![coq::TopLevelItem::Code(text("(*"))],
-            self.0
-                .iter()
-                // We do this replace to avoid messing up with the Coq comments
-                .map(|line| {
-                    coq::TopLevelItem::Code(text(line.replace("(*", "( *").replace("*)", "* )")))
-                })
-                .collect(),
-            vec![coq::TopLevelItem::Code(text("*)"))],
-        ]
-        .concat()
+        optional_insert_vec(
+            self.0.is_empty(),
+            [
+                vec![coq::TopLevelItem::Code(text("(*"))],
+                self.0
+                    .iter()
+                    // We do this replace to avoid messing up with the Coq comments
+                    .map(|line| {
+                        coq::TopLevelItem::Code(text(
+                            line.replace("(*", "( *").replace("*)", "* )"),
+                        ))
+                    })
+                    .collect(),
+                vec![coq::TopLevelItem::Code(text("*)"))],
+            ]
+            .concat(),
+        )
     }
 }
 
@@ -1828,13 +1824,12 @@ impl TopLevelItem {
                     .count();
                 coq::TopLevel::new(
                     &[
-                        if *is_dead_code {
+                        optional_insert_vec(
+                            !*is_dead_code,
                             vec![coq::TopLevelItem::Comment(coq::Comment::new(
                                 "#[allow(dead_code)] - module was ignored by the compiler",
-                            ))]
-                        } else {
-                            vec![]
-                        },
+                            ))],
+                        ),
                         vec![coq::TopLevelItem::Module(coq::Module::new_with_repeat(
                             name,
                             false,
@@ -1887,9 +1882,9 @@ impl TopLevelItem {
                                                 line(),
                                                 text("{"),
                                             ]),
-                                            if fields.is_empty() {
-                                                text(" ")
-                                            } else {
+                                            optional_insert_with(
+                                                fields.is_empty(),
+                                                text(" "),
                                                 concat([
                                                     nest([
                                                         hardline(),
@@ -1908,8 +1903,8 @@ impl TopLevelItem {
                                                         ),
                                                     ]),
                                                     hardline(),
-                                                ])
-                                            },
+                                                ]),
+                                            ),
                                             text("}."),
                                         ])),
                                     ]),
@@ -2146,22 +2141,20 @@ impl TopLevelItem {
                             } => vec![coq::ClassFieldDef::new(
                                 &Some(name.to_owned()),
                                 &[
-                                    if ty_params.is_empty() {
-                                        vec![]
-                                    } else {
+                                    optional_insert_vec(
+                                        ty_params.is_empty(),
                                         vec![coq::ArgDecl::new(
                                             &coq::ArgDeclVar::Simple {
                                                 idents: ty_params.to_owned(),
                                                 ty: Some(coq::Expression::Set),
                                             },
                                             coq::ArgSpecKind::Implicit,
-                                        )]
-                                    },
-                                    if where_predicates.is_empty() {
-                                        vec![]
-                                    } else {
-                                        vec![WherePredicate::vec_to_coq(where_predicates)]
-                                    },
+                                        )],
+                                    ),
+                                    optional_insert_vec(
+                                        where_predicates.is_empty(),
+                                        vec![WherePredicate::vec_to_coq(where_predicates)],
+                                    ),
                                 ]
                                 .concat(),
                                 &ty.to_coq(),
@@ -2257,16 +2250,15 @@ impl TopLevelItem {
                             generic_tys,
                             false,
                             &coq::TopLevel::new(&[
-                                if predicates.is_empty() {
-                                    vec![]
-                                } else {
-                                    vec![
-                                        coq::TopLevelItem::Context(coq::Context::new(
-                                            &[WherePredicate::vec_to_coq(predicates)]
-                                        )),
-                                        coq::TopLevelItem::Line,
-                                    ]
-                                },
+                              optional_insert_vec(
+                                predicates.is_empty(),
+                                vec![
+                                    coq::TopLevelItem::Context(coq::Context::new(
+                                        &[WherePredicate::vec_to_coq(predicates)]
+                                    )),
+                                    coq::TopLevelItem::Line,
+                                ]
+                              ),
                                 vec![coq::TopLevelItem::Definition(
                                     coq::Definition::new(
                                         "Self",
@@ -2339,16 +2331,14 @@ impl TopLevelItem {
                                                         Some(ImplItemKind::Definition { definition, ..}) => {
                                                             let FunDefinition {ty_params, where_predicates, ..} = &**definition;
                                                             vec![
-                                                                if ty_params.is_empty() {
-                                                                    vec![]
-                                                                } else {
-                                                                    vec![coq::ArgDecl::of_ty_params(ty_params, coq::ArgSpecKind::Implicit)]
-                                                                },
-                                                                if where_predicates.is_empty() {
-                                                                    vec![]
-                                                                } else {
-                                                                    vec![WherePredicate::vec_to_coq(where_predicates)]
-                                                                },
+                                                              optional_insert_vec(
+                                                                ty_params.is_empty(),
+                                                                vec![coq::ArgDecl::of_ty_params(ty_params, coq::ArgSpecKind::Implicit)]
+                                                              ),
+                                                              optional_insert_vec(
+                                                                where_predicates.is_empty(),
+                                                                vec![WherePredicate::vec_to_coq(where_predicates)]
+                                                              )
                                                             ].concat()
                                                         }
                                                         _ => vec![],
@@ -2470,13 +2460,12 @@ impl TypeStructStruct {
             .collect::<Vec<_>>();
         coq::TopLevel::new(
             &[
-                if *is_dead_code {
+                optional_insert_vec(
+                    !*is_dead_code,
                     vec![coq::TopLevelItem::Comment(coq::Comment::new(
                         "#[allow(dead_code)] - struct was ignored by the compiler",
-                    ))]
-                } else {
-                    vec![]
-                },
+                    ))],
+                ),
                 vec![coq::TopLevelItem::Module(coq::Module::new(
                     name,
                     true,
@@ -2488,13 +2477,12 @@ impl TypeStructStruct {
                                 .collect::<Vec<_>>(),
                             true,
                             &coq::TopLevel::concat(&[
-                                coq::TopLevel::new(&if predicates.is_empty() {
-                                    vec![]
-                                } else {
+                                coq::TopLevel::new(&optional_insert_vec(
+                                    predicates.is_empty(),
                                     vec![coq::TopLevelItem::Context(coq::Context::new(&[
                                         WherePredicate::vec_to_coq(predicates),
-                                    ]))]
-                                }),
+                                    ]))],
+                                )),
                                 //   coq::TopLevel::new(&if trait_objects_traits.is_empty() {
                                 //       vec![]
                                 //   } else {
@@ -2618,11 +2606,10 @@ impl TypeStructStruct {
                                         })
                                         .collect::<Vec<_>>(),
                                 ))]),
-                                coq::TopLevel::new(&if fields.is_empty() {
-                                    vec![]
-                                } else {
-                                    vec![coq::TopLevelItem::Line]
-                                }),
+                                coq::TopLevel::new(&optional_insert_vec(
+                                    fields.is_empty(),
+                                    vec![coq::TopLevelItem::Line],
+                                )),
                                 coq::TopLevel::new(
                                     &fields
                                         .iter()
@@ -2692,15 +2679,14 @@ impl TypeStructStruct {
                                 ),
                             ]),
                         ),
-                        coq::TopLevel::new(&if params_with_default.is_empty() {
-                            vec![]
-                        } else {
+                        coq::TopLevel::new(&optional_insert_vec(
+                            params_with_default.is_empty(),
                             vec![coq::TopLevelItem::Module(coq::Module::new(
                                 "Default",
                                 false,
                                 coq::TopLevel::new(&params_with_default),
-                            ))]
-                        }),
+                            ))],
+                        )),
                     ]),
                 ))],
             ]


### PR DESCRIPTION
Add `optional_insert` functions into `render.rs` to reduce complexities for generating coq code
Note that this is more like a proposal about functions in `render.rs` and see how the general code would become