### PR TITLE
Add opam package configuration file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
             source "$HOME/.cargo/env"
             cargo --version
             sudo ln -s `which python3` /usr/bin/python
-            opam install -y coq-hammer
+            opam install -y --deps-only CoqOfRust/coq-of-rust.opam
           endGroup
           startGroup "Build"
             sudo chown -R $(whoami) .

--- a/CoqOfRust/coq-of-rust.opam
+++ b/CoqOfRust/coq-of-rust.opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+name: "coq-of-rust"
+version: "0.1"
+synopsis: "Coq of Rust"
+description: """
+Formal verification for Rust by translation to the proof system Coq
+"""
+maintainer: "Guillaume Claret <dev@clarus.me>"
+authors: [
+  "Guillaume Claret <dev@clarus.me>"
+]
+license: "AGPL-3.0"
+homepage: "https://formal.land/docs/coq-of-rust/introduction"
+bug-reports: "https://github.com/formal-land/coq-of-rust/issues"
+dev-repo: "git+https://github.com/formal-land/coq-of-rust.git"
+depends: [
+  "ocaml" {>= "4.08"}
+  "coq" {>= "8.18"}
+  "coq-hammer" {>= "1.3.2+8.18"}
+]
+build: [
+  ["./configure.sh"]
+  [make]
+]

--- a/CoqOfRust/coq-of-rust.opam
+++ b/CoqOfRust/coq-of-rust.opam
@@ -7,7 +7,7 @@ Formal verification for Rust by translation to the proof system Coq
 """
 maintainer: "Guillaume Claret <dev@clarus.me>"
 authors: [
-  "Guillaume Claret <dev@clarus.me>"
+  "Formal Land <contact@formal.land>"
 ]
 license: "AGPL-3.0"
 homepage: "https://formal.land/docs/coq-of-rust/introduction"

--- a/CoqOfRust/coq-of-rust.opam
+++ b/CoqOfRust/coq-of-rust.opam
@@ -15,8 +15,8 @@ bug-reports: "https://github.com/formal-land/coq-of-rust/issues"
 dev-repo: "git+https://github.com/formal-land/coq-of-rust.git"
 depends: [
   "ocaml" {>= "4.08"}
-  "coq" {>= "8.18"}
-  "coq-hammer" {>= "1.3.2+8.18"}
+  "coq" {>= "8.17.1" & < "8.18"}
+  "coq-hammer" {>= "1.3.2+8.17" & < "1.3.2+8.18"}
 ]
 build: [
   ["./configure.sh"]


### PR DESCRIPTION
Simple opam configuration file
Dependencies can be installed with:
```
opam install --deps-only .
```
Also use this configuration file to install dependencies in CI