### PR TITLE
Update README and write new install/build tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,41 +54,11 @@ The tool `coq-of-rust` translates Rust programs to the battle-tested formal veri
 
 ## Install
 
-From the root of this repository, install `coq-of-rust` with:
-
-```sh
-cargo install --path lib/
-```
-
-Then, in any Rust project, generate a `Crate.v` file with the Coq translation of the crate:
-
-```sh
-cargo coq-of-rust
-```
-
-## Details
-The translation works at the level of the [THIR](https://rustc-dev-guide.rust-lang.org/thir.html) intermediate representation of Rust.
-
-Translate the test files (but show the error/warning messages):
-
-```sh
-cargo run --bin coq-of-rust -- translate --path examples
-```
-
-Update the snapshots of the translations of the test files, including the error messages:
-
-```sh
-python run_tests.py
-```
-
-Compile the Coq files:
-
-```sh
-cd CoqOfRust
-make
-```
+See the [build tutorial](./docs/BUILD.md) for detailed instructions on building and installing `coq-of-rust`.
 
 ## Language features
+The translation works at the level of the [THIR](https://rustc-dev-guide.rust-lang.org/thir.html) intermediate representation of Rust.
+
 We support 80% of the Rust examples from the [Rust Book by Examples](https://doc.rust-lang.org/rust-by-example/). This includes:
 
 - basic control structures (like&nbsp;`if` and&nbsp;`match`)

--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ The development of `coq-of-rust` was mainly funded by the crypto-currency&nbsp;[
 
 ## Table of Contents
 
+- [Example](#example)
 - [Rationale](#rationale)
 - [Prerequisites](#prerequisites)
-- [Details](#details)
-- [Features](#features)
-- [Limitations](#limitations)
+- [Installation](#install)
+- [Features](#language-features)
+- [Contact](#contact)
 - [Alternative Projects](#alternative-projects)
 - [Contributing](#contributing)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The tool `coq-of-rust` translates Rust programs to the battle-tested formal veri
 ## Prerequisites
 
 - Rust
-- Coq (version 8.14 or newer)
+- Coq (see [coq-of-rust.opam](./CoqOfRust/coq-of-rust.opam))
 
 ## Install
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,93 @@
+# Installation and Build Tutorial
+
+## Rust
+
+### Cargo plugin
+
+In order to install `coq-of-rust` run the following command from the
+root of this repository:
+```sh
+cargo install --path lib/
+```
+
+This command would build and install the `coq-of-rust` library and
+the cargo plugin.
+
+Then, in any Rust project, generate a `Crate.v` file with the Coq
+translation of the crate using this command:
+```sh
+cargo coq-of-rust
+```
+
+Sometimes the execution of the above command might result with an
+error related to Rust library versions mismatch. In that case, copy
+the `rust-toolchain` config file (which can be found in the root of
+this repository) to the root of the Rust project you want to generate
+the translation of.
+
+### Standalone executable
+
+Additionally, it is also possible to build `coq-of-rust` as a
+standalone executable. This method has an advantage of supporting the
+translation of individual files, while the cargo plugin only supports
+the translation of the whole crates.
+
+For example, the following command would build `coq-of-rust` as a
+standalone executable an use it to translate one of the test examples:
+```sh
+cargo run --bin coq-of-rust -- translate --path examples/rust_book/hello_world/hello_world.rs
+```
+
+Note that the standalone executable and the cargo plugin versions of
+`coq-of-rust` support different sets of command line options. Run
+`coq-of-rust` with `--help` option to see what options are supported.
+
+Using `coq-of-rust` as a standalone executable is intended for testing
+purposes. We generally recommend to use the cargo plugin instead.
+
+### Tests
+
+The following command allows to regenerate the snapshots of the
+translations of the test files:
+```sh
+python run_tests.py
+```
+
+If `coq-of-rust` would fail to translate some of the test files, it
+would produce a file with an error instead.
+
+Check if some freshly generated translation results differ to those
+included in the repository:
+```sh
+git diff
+```
+
+## Coq
+
+In order to install dependencies and build the Coq part of the project
+run the following commands.
+
+Create a new opam switch:
+```sh
+opam switch create coq-of-rust ocaml.5.1.0
+```
+
+Add the repository with Coq packages:
+```sh
+opam repo add coq-released https://coq.inria.fr/opam/released
+```
+
+Go to the directory with Coq files:
+```sh
+cd CoqOfRust
+```
+
+Install the required dependencies:
+```sh
+opam install --deps-only .
+```
+
+Compile the Coq files:
+```sh
+make
+```


### PR DESCRIPTION
In `README.md` file `Install` and `Details` sections are merged into one and moved to a separate `docs/BUILD.md` file, which now contains more detailed building/installing tutorial.

In the new `BUILD.md` file I describe:
- How to build `coq-of-rust` as a cargo plugin
- How to fix the Rust stdlib version mismatch when using `coq-of-rust`
- Mention it is also possible to build it as a standalone executable
- And which method is preferable and why
- What `run_tests.py` file does
- How to install dependencies and build Coq part of the project

I also added a link to `.opam` config file in `README.md` in the `Prerequisites` section.
I also fixed a table of contents of the `README.md` to made sure it is up to date and that all links work.