### PR TITLE
Minor updates of the user tutorial

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,7 +7,7 @@ use clap::{Parser, Subcommand};
 
 #[derive(Args)]
 struct Translate {
-    /// Sets a path to rust project
+    /// Sets a path to rust file
     #[arg(short, long, value_name = "PATH", value_parser = is_valid_path)]
     path: PathBuf,
     /// Axiomatize the definitions

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -12,13 +12,13 @@ of those versions of `coq-of-rust`.
 ## Table of Contents
 
 - [Cargo plugin](#cargo-plugin)
-  - [Inteface](#interface-0)
   - [Example](#example-0)
   - [Tips](#tips-0)
+  - [Inteface](#interface-0)
 - [Standalone executable](#standalone-executable)
-  - [Inteface](#interface-1)
   - [Example](#example-1)
   - [Tips](#tips-1)
+  - [Inteface](#interface-1)
 
 ## Cargo plugin
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -90,7 +90,7 @@ Options:
 Usage: `coq-of-rust translate [OPTIONS] --path <PATH>`
 
 Options:
-- `-p`, `--path <PATH>`           Sets a path to rust project
+- `-p`, `--path <PATH>`           Sets a path to rust file
 - `--axiomatize`                  Axiomatize the definitions
 - `--axiomatize-public`           Axiomatize the definitions with everything as public
 - `--generate-reorder`            Generate the "reorder" section of the configuration file

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -84,3 +84,16 @@ Options:
 - `-d`, `--debug...` Turn debugging information on
 - `-h`, `--help`     Print help
 - `-V`, `--version`  Print version
+
+#### Translate subcommand
+
+Usage: `coq-of-rust translate [OPTIONS] --path <PATH>`
+
+Options:
+- `-p`, `--path <PATH>`           Sets a path to rust project
+- `--axiomatize`                  Axiomatize the definitions
+- `--axiomatize-public`           Axiomatize the definitions with everything as public
+- `--generate-reorder`            Generate the "reorder" section of the configuration file
+- `--output-path <output_path>`   Output path where to place the translation `[default: coq_translation]`
+- `--configuration-file <config>` Configuration file path `[default: coq-of-rust-config.json]`
+- `-h`, `--help`                  Print help


### PR DESCRIPTION
### Minor updates of the user tutorial:

- fix order of items in the table of contents
- add list of options supported by translate subcommand in standalone executable mode of `coq-of-rust` (it turns out those options are shown when running `coq-of-rust translate --help` rather than just `coq-of-rust --help`)
- change description of `--path` option: it is a path to a Rust file rather than Rust project (trying to run standalone executable version of `coq-of-rust` with a path to Rust project directory results with an error `couldn't read ... Is a directory`)