### PR TITLE
Fix path in config for reorder example

### DIFF
--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -55,7 +55,6 @@ examples/default/examples/rust_book/functions/functions_closures_input_functions
 examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define_and_use.v
 examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define.v
 examples/default/examples/rust_book/functions/functions_closures.v
-examples/default/examples/rust_book/functions/functions_order.v
 examples/default/examples/rust_book/generics/generics_associated_types_solution.v
 examples/default/examples/rust_book/generics/generics_functions.v
 examples/default/examples/rust_book/generics/generics_implementation.v

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_order.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_order.v
@@ -28,6 +28,16 @@ Section Impl_functions_order_SomeType_t.
   Definition Self : Set := functions_order.SomeType.t.
   
   (*
+      fn meth2(self) {}
+  *)
+  Parameter meth2 : Self -> M unit.
+  
+  Global Instance AssociatedFunction_meth2 :
+    Notations.DoubleColon Self "meth2" := {
+    Notations.double_colon := meth2;
+  }.
+  
+  (*
       pub fn meth1(self) {
           self.meth2();
       }
@@ -38,26 +48,8 @@ Section Impl_functions_order_SomeType_t.
     Notations.DoubleColon Self "meth1" := {
     Notations.double_colon := meth1;
   }.
-  
-  (*
-      fn meth2(self) {}
-  *)
-  Parameter meth2 : Self -> M unit.
-  
-  Global Instance AssociatedFunction_meth2 :
-    Notations.DoubleColon Self "meth2" := {
-    Notations.double_colon := meth2;
-  }.
 End Impl_functions_order_SomeType_t.
 End Impl_functions_order_SomeType_t.
-
-(*
-fn depends_on_trait_impl(u: u32, b: bool) {
-    OtherType(b).some_trait_foo();
-    SomeType(u).some_trait_foo();
-}
-*)
-Parameter depends_on_trait_impl : u32.t -> bool.t -> M unit.
 
 Module  SomeTrait.
 Section SomeTrait.
@@ -74,6 +66,16 @@ Section Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
   Definition Self : Set := functions_order.SomeType.t.
   
   (*
+      fn some_trait_bar(&self) {}
+  *)
+  Parameter some_trait_bar : (ref Self) -> M unit.
+  
+  Global Instance AssociatedFunction_some_trait_bar :
+    Notations.DoubleColon Self "some_trait_bar" := {
+    Notations.double_colon := some_trait_bar;
+  }.
+  
+  (*
       fn some_trait_foo(&self) {
           self.some_trait_bar()
       }
@@ -85,19 +87,9 @@ Section Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
     Notations.double_colon := some_trait_foo;
   }.
   
-  (*
-      fn some_trait_bar(&self) {}
-  *)
-  Parameter some_trait_bar : (ref Self) -> M unit.
-  
-  Global Instance AssociatedFunction_some_trait_bar :
-    Notations.DoubleColon Self "some_trait_bar" := {
-    Notations.double_colon := some_trait_bar;
-  }.
-  
   Global Instance ℐ : functions_order.SomeTrait.Trait Self := {
-    functions_order.SomeTrait.some_trait_foo := some_trait_foo;
     functions_order.SomeTrait.some_trait_bar := some_trait_bar;
+    functions_order.SomeTrait.some_trait_foo := some_trait_foo;
   }.
 End Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
@@ -133,7 +125,20 @@ Section Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 
+(*
+fn depends_on_trait_impl(u: u32, b: bool) {
+    OtherType(b).some_trait_foo();
+    SomeType(u).some_trait_foo();
+}
+*)
+Parameter depends_on_trait_impl : u32.t -> bool.t -> M unit.
+
 Module inner_mod.
+  (*
+      fn tar() {}
+  *)
+  Parameter tar : M unit.
+  
   (*
       pub fn bar() {
           // functions_order::inner_mod::bar
@@ -142,23 +147,18 @@ Module inner_mod.
   *)
   Parameter bar : M unit.
   
-  (*
-      fn tar() {}
-  *)
-  Parameter tar : M unit.
-  
   Module nested_mod.
+    (*
+            fn tack() {}
+    *)
+    Parameter tack : M unit.
+    
     (*
             pub fn tick() {
                 tack();
             }
     *)
     Parameter tick : M unit.
-    
-    (*
-            fn tack() {}
-    *)
-    Parameter tack : M unit.
   End nested_mod.
 End inner_mod.
 
@@ -177,16 +177,16 @@ Parameter tar : M unit.
 
 Module nested_mod.
   (*
+          fn tack() {}
+  *)
+  Parameter tack : M unit.
+  
+  (*
           pub fn tick() {
               tack();
           }
   *)
   Parameter tick : M unit.
-  
-  (*
-          fn tack() {}
-  *)
-  Parameter tack : M unit.
 End nested_mod.
 
 (*
@@ -202,6 +202,11 @@ Parameter tick : M unit.
 Parameter tack : M unit.
 
 (*
+fn foo() {}
+*)
+Parameter foo : M unit.
+
+(*
 fn main() {
     // functions_order::main
     foo();
@@ -211,8 +216,3 @@ fn main() {
 *)
 (* #[allow(dead_code)] - function was ignored by the compiler *)
 Parameter main : M unit.
-
-(*
-fn foo() {}
-*)
-Parameter foo : M unit.

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_order.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_order.v
@@ -28,6 +28,18 @@ Section Impl_functions_order_SomeType_t.
   Definition Self : Set := functions_order.SomeType.t.
   
   (*
+      fn meth2(self) {}
+  *)
+  Definition meth2 (self : Self) : M unit :=
+    let* self := M.alloc self in
+    M.pure tt.
+  
+  Global Instance AssociatedFunction_meth2 :
+    Notations.DoubleColon Self "meth2" := {
+    Notations.double_colon := meth2;
+  }.
+  
+  (*
       pub fn meth1(self) {
           self.meth2();
       }
@@ -45,54 +57,8 @@ Section Impl_functions_order_SomeType_t.
     Notations.DoubleColon Self "meth1" := {
     Notations.double_colon := meth1;
   }.
-  
-  (*
-      fn meth2(self) {}
-  *)
-  Definition meth2 (self : Self) : M unit :=
-    let* self := M.alloc self in
-    M.pure tt.
-  
-  Global Instance AssociatedFunction_meth2 :
-    Notations.DoubleColon Self "meth2" := {
-    Notations.double_colon := meth2;
-  }.
 End Impl_functions_order_SomeType_t.
 End Impl_functions_order_SomeType_t.
-
-(*
-fn depends_on_trait_impl(u: u32, b: bool) {
-    OtherType(b).some_trait_foo();
-    SomeType(u).some_trait_foo();
-}
-*)
-Definition depends_on_trait_impl (u : u32.t) (b : bool.t) : M unit :=
-  let* u := M.alloc u in
-  let* b := M.alloc b in
-  let* _ : M.Val unit :=
-    let* α0 : (ref functions_order.OtherType.t) -> M unit :=
-      ltac:(M.get_method (fun ℐ =>
-        functions_order.SomeTrait.some_trait_foo
-          (Self := functions_order.OtherType.t)
-          (Trait := ℐ))) in
-    let* α1 : bool.t := M.read b in
-    let* α2 : M.Val functions_order.OtherType.t :=
-      M.alloc (functions_order.OtherType.Build_t α1) in
-    let* α3 : unit := M.call (α0 (borrow α2)) in
-    M.alloc α3 in
-  let* _ : M.Val unit :=
-    let* α0 : (ref functions_order.SomeType.t) -> M unit :=
-      ltac:(M.get_method (fun ℐ =>
-        functions_order.SomeTrait.some_trait_foo
-          (Self := functions_order.SomeType.t)
-          (Trait := ℐ))) in
-    let* α1 : u32.t := M.read u in
-    let* α2 : M.Val functions_order.SomeType.t :=
-      M.alloc (functions_order.SomeType.Build_t α1) in
-    let* α3 : unit := M.call (α0 (borrow α2)) in
-    M.alloc α3 in
-  let* α0 : M.Val unit := M.alloc tt in
-  M.read α0.
 
 Module  SomeTrait.
 Section SomeTrait.
@@ -109,6 +75,18 @@ Section Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
   Definition Self : Set := functions_order.SomeType.t.
   
   (*
+      fn some_trait_bar(&self) {}
+  *)
+  Definition some_trait_bar (self : ref Self) : M unit :=
+    let* self := M.alloc self in
+    M.pure tt.
+  
+  Global Instance AssociatedFunction_some_trait_bar :
+    Notations.DoubleColon Self "some_trait_bar" := {
+    Notations.double_colon := some_trait_bar;
+  }.
+  
+  (*
       fn some_trait_foo(&self) {
           self.some_trait_bar()
       }
@@ -123,21 +101,9 @@ Section Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
     Notations.double_colon := some_trait_foo;
   }.
   
-  (*
-      fn some_trait_bar(&self) {}
-  *)
-  Definition some_trait_bar (self : ref Self) : M unit :=
-    let* self := M.alloc self in
-    M.pure tt.
-  
-  Global Instance AssociatedFunction_some_trait_bar :
-    Notations.DoubleColon Self "some_trait_bar" := {
-    Notations.double_colon := some_trait_bar;
-  }.
-  
   Global Instance ℐ : functions_order.SomeTrait.Trait Self := {
-    functions_order.SomeTrait.some_trait_foo := some_trait_foo;
     functions_order.SomeTrait.some_trait_bar := some_trait_bar;
+    functions_order.SomeTrait.some_trait_foo := some_trait_foo;
   }.
 End Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_SomeType_t.
@@ -177,7 +143,46 @@ Section Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 End Impl_functions_order_SomeTrait_for_functions_order_OtherType_t.
 
+(*
+fn depends_on_trait_impl(u: u32, b: bool) {
+    OtherType(b).some_trait_foo();
+    SomeType(u).some_trait_foo();
+}
+*)
+Definition depends_on_trait_impl (u : u32.t) (b : bool.t) : M unit :=
+  let* u := M.alloc u in
+  let* b := M.alloc b in
+  let* _ : M.Val unit :=
+    let* α0 : (ref functions_order.OtherType.t) -> M unit :=
+      ltac:(M.get_method (fun ℐ =>
+        functions_order.SomeTrait.some_trait_foo
+          (Self := functions_order.OtherType.t)
+          (Trait := ℐ))) in
+    let* α1 : bool.t := M.read b in
+    let* α2 : M.Val functions_order.OtherType.t :=
+      M.alloc (functions_order.OtherType.Build_t α1) in
+    let* α3 : unit := M.call (α0 (borrow α2)) in
+    M.alloc α3 in
+  let* _ : M.Val unit :=
+    let* α0 : (ref functions_order.SomeType.t) -> M unit :=
+      ltac:(M.get_method (fun ℐ =>
+        functions_order.SomeTrait.some_trait_foo
+          (Self := functions_order.SomeType.t)
+          (Trait := ℐ))) in
+    let* α1 : u32.t := M.read u in
+    let* α2 : M.Val functions_order.SomeType.t :=
+      M.alloc (functions_order.SomeType.Build_t α1) in
+    let* α3 : unit := M.call (α0 (borrow α2)) in
+    M.alloc α3 in
+  let* α0 : M.Val unit := M.alloc tt in
+  M.read α0.
+
 Module inner_mod.
+  (*
+      fn tar() {}
+  *)
+  Definition tar : M unit := M.pure tt.
+  
   (*
       pub fn bar() {
           // functions_order::inner_mod::bar
@@ -191,12 +196,12 @@ Module inner_mod.
     let* α0 : M.Val unit := M.alloc tt in
     M.read α0.
   
-  (*
-      fn tar() {}
-  *)
-  Definition tar : M unit := M.pure tt.
-  
   Module nested_mod.
+    (*
+            fn tack() {}
+    *)
+    Definition tack : M unit := M.pure tt.
+    
     (*
             pub fn tick() {
                 tack();
@@ -208,11 +213,6 @@ Module inner_mod.
         M.alloc α0 in
       let* α0 : M.Val unit := M.alloc tt in
       M.read α0.
-    
-    (*
-            fn tack() {}
-    *)
-    Definition tack : M unit := M.pure tt.
   End nested_mod.
 End inner_mod.
 
@@ -236,6 +236,11 @@ Definition tar : M unit := M.pure tt.
 
 Module nested_mod.
   (*
+          fn tack() {}
+  *)
+  Definition tack : M unit := M.pure tt.
+  
+  (*
           pub fn tick() {
               tack();
           }
@@ -246,11 +251,6 @@ Module nested_mod.
       M.alloc α0 in
     let* α0 : M.Val unit := M.alloc tt in
     M.read α0.
-  
-  (*
-          fn tack() {}
-  *)
-  Definition tack : M unit := M.pure tt.
 End nested_mod.
 
 (*
@@ -269,6 +269,11 @@ Definition tick : M unit :=
         fn tack() {}
 *)
 Definition tack : M unit := M.pure tt.
+
+(*
+fn foo() {}
+*)
+Definition foo : M unit := M.pure tt.
 
 (*
 fn main() {
@@ -294,8 +299,3 @@ Definition main : M unit :=
     M.alloc α0 in
   let* α0 : M.Val unit := M.alloc tt in
   M.read α0.
-
-(*
-fn foo() {}
-*)
-Definition foo : M unit := M.pure tt.

--- a/coq-of-rust-config.json
+++ b/coq-of-rust-config.json
@@ -4,7 +4,7 @@
   "impl_ignore_axioms": [
   ],
   "reorder": {
-    "examples/functions/functions_order.rs": {
+    "examples/rust_book/functions/functions_order.rs": {
       "top_level": {
       	"depends_on_trait_impl": { "move": "down", "after": "Impl_SomeTrait_for_OtherType" },
         "foo": { "move": "up", "before": "main" }


### PR DESCRIPTION
- Fix the path to `functions_order.rs` example in `coq-of-rust-config.json`
- Update the snapshots of the translation of this file
- Remove this example from blacklist as it compiles now