### PR TITLE
Remove trait constraints

### DIFF
--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -37,7 +37,10 @@ examples/axiomatized/examples/rust_book/traits/traits_parms.v
 examples/axiomatized/examples/rust_book/traits/traits.v
 examples/axiomatized/examples/subtle.v
 examples/axiomatized/examples/test0.v
+examples/axiomatized/examples/ink_contracts/payment_channel.v
+examples/default/examples/ink_contracts/payment_channel.v
 examples/default/examples/ink_contracts/Proofs/erc20.v
+examples/default/examples/rust_book/generics/generics_associated_types_problem.v
 examples/default/examples/rust_book/custom_types/enums_testcase_linked_list.v
 examples/default/examples/rust_book/error_handling/pulling_results_out_of_options_with_stop_error_processing.v
 examples/default/examples/rust_book/error_handling/wrapping_errors.v

--- a/CoqOfRust/core/hash.v
+++ b/CoqOfRust/core/hash.v
@@ -94,10 +94,10 @@ pub trait Hash {
 Module Hash.
   Module Required.
     Class Trait (Self : Set) : Set := {
-      hash {H : Set} {H0 : Hasher.Trait H} : ref Self -> mut_ref H -> M unit;
+      hash {H : Set} : ref Self -> mut_ref H -> M unit;
       hash_slice :
         Datatypes.option (
-          forall (H : Set) (H0 : Hasher.Trait H),
+          forall (H : Set),
           ref (slice Self) -> mut_ref H -> M unit
         );
     }.
@@ -105,22 +105,21 @@ Module Hash.
 
   Module Provided.
     Parameter hash_slice :
-      forall {Self : Set} {H0 : Required.Trait Self},
-      forall {H : Set} {H0 : Hasher.Trait H},
+      forall {Self : Set} {H : Set},
       ref (slice Self) -> mut_ref H -> M unit.
   End Provided.
 
   Class Trait (Self : Set) : Set := {
-    hash {H : Set} {H0 : Hasher.Trait H} : ref Self -> mut_ref H -> M unit;
-    hash_slice {H : Set} {H0 : Hasher.Trait H} :
+    hash {H : Set} : ref Self -> mut_ref H -> M unit;
+    hash_slice {H : Set} :
       ref (slice Self) -> mut_ref H -> M unit;
   }.
 
   Global Instance From_Required {Self : Set}
       {H0 : Required.Trait Self} :
       Trait Self := {
-    hash {H : Set} {H0 : Hasher.Trait H} := Required.hash (H := H);
-    hash_slice {H : Set} {H0 : Hasher.Trait H} := Provided.hash_slice (H := H);
+    hash {H : Set} := Required.hash (H := H);
+    hash_slice {H : Set} := Provided.hash_slice (H := H);
   }.
 End Hash.
 
@@ -145,8 +144,6 @@ Module BuilHasher.
       Hasher := Hasher;
       build_hasher : ref Self -> Hasher;
       hash_one (T : Set) 
-        `{Hash.Trait T}
-        `{Hasher.Trait Hasher}
         : ref Self -> T -> u64.t;
   }.
 End BuilHasher.

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/payment_channel.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/payment_channel.v
@@ -428,12 +428,12 @@ where
 }
 *)
 Parameter hash_encoded :
-    forall {H T : Set} {ℋ_0 : payment_channel.CryptoHash.Trait H},
+    forall {H T : Set},
     (ref T) ->
       (mut_ref
         (payment_channel.HashOutput.Type_
           (Self := H)
-          (Trait := ℋ_0.(CryptoHash.ℒ_0))))
+          (Trait := ltac:(refine _))))
       ->
       M unit.
 

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_as_input_parameters.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_as_input_parameters.v
@@ -12,9 +12,7 @@ where
     f();
 }
 *)
-Parameter apply :
-    forall {F : Set} {ℋ_0 : core.ops.function.FnOnce.Trait F (Args := unit)},
-    F -> M unit.
+Parameter apply : forall {F : Set}, F -> M unit.
 
 (*
 fn apply_to_3<F>(f: F) -> i32
@@ -25,9 +23,7 @@ where
     f(3)
 }
 *)
-Parameter apply_to_3 :
-    forall {F : Set} {ℋ_0 : core.ops.function.Fn.Trait F (Args := i32.t)},
-    F -> M i32.t.
+Parameter apply_to_3 : forall {F : Set}, F -> M i32.t.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_input_functions.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_input_functions.v
@@ -6,9 +6,7 @@ fn call_me<F: Fn()>(f: F) {
     f();
 }
 *)
-Parameter call_me :
-    forall {F : Set} {ℋ_0 : core.ops.function.Fn.Trait F (Args := unit)},
-    F -> M unit.
+Parameter call_me : forall {F : Set}, F -> M unit.
 
 (*
 fn function() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_type_anonymity_define.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_type_anonymity_define.v
@@ -23,6 +23,4 @@ Parameter main : M unit.
         f();
     }
 *)
-Parameter apply :
-    forall {F : Set} {ℋ_0 : core.ops.function.FnOnce.Trait F (Args := unit)},
-    F -> M unit.
+Parameter apply : forall {F : Set}, F -> M unit.

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_type_anonymity_define_and_use.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/functions/functions_closures_type_anonymity_define_and_use.v
@@ -9,9 +9,7 @@ where
     f();
 }
 *)
-Parameter apply :
-    forall {F : Set} {ℋ_0 : core.ops.function.Fn.Trait F (Args := unit)},
-    F -> M unit.
+Parameter apply : forall {F : Set}, F -> M unit.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_associated_types_problem.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_associated_types_problem.v
@@ -85,12 +85,7 @@ where
     container.last() - container.first()
 }
 *)
-Parameter difference :
-    forall
-      {A B C : Set}
-      {ℋ_0 :
-        generics_associated_types_problem.Contains.Trait C (A := A) (B := B)},
-    (ref C) -> M i32.t.
+Parameter difference : forall {A B C : Set}, (ref C) -> M i32.t.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_associated_types_solution.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_associated_types_solution.v
@@ -113,22 +113,14 @@ fn difference<C: Contains>(container: &C) -> i32 {
     container.last() - container.first()
 }
 *)
-Parameter difference :
-    forall
-      {C : Set}
-      {ℋ_0 : generics_associated_types_solution.Contains.Trait C},
-    (ref C) -> M i32.t.
+Parameter difference : forall {C : Set}, (ref C) -> M i32.t.
 
 (*
 fn get_a<C: Contains>(container: &C) -> C::A {
     container.a()
 }
 *)
-Parameter get_a :
-    forall
-      {C : Set}
-      {ℋ_0 : generics_associated_types_solution.Contains.Trait C},
-    (ref C) -> M C::type["A"].t.
+Parameter get_a : forall {C : Set}, (ref C) -> M C::type["A"].t.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_bounds.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_bounds.v
@@ -86,18 +86,14 @@ fn print_debug<T: Debug>(t: &T) {
     println!("{:?}", t);
 }
 *)
-Parameter print_debug :
-    forall {T : Set} {ℋ_0 : core.fmt.Debug.Trait T},
-    (ref T) -> M unit.
+Parameter print_debug : forall {T : Set}, (ref T) -> M unit.
 
 (*
 fn area<T: HasArea>(t: &T) -> f64 {
     t.area()
 }
 *)
-Parameter area :
-    forall {T : Set} {ℋ_0 : generics_bounds.HasArea.Trait T},
-    (ref T) -> M f64.t.
+Parameter area : forall {T : Set}, (ref T) -> M f64.t.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_bounds_test_case_empty_bounds.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_bounds_test_case_empty_bounds.v
@@ -61,20 +61,14 @@ fn red<T: Red>(_: &T) -> &'static str {
     "red"
 }
 *)
-Parameter red :
-    forall {T : Set} {ℋ_0 : generics_bounds_test_case_empty_bounds.Red.Trait T},
-    (ref T) -> M (ref str.t).
+Parameter red : forall {T : Set}, (ref T) -> M (ref str.t).
 
 (*
 fn blue<T: Blue>(_: &T) -> &'static str {
     "blue"
 }
 *)
-Parameter blue :
-    forall
-      {T : Set}
-      {ℋ_0 : generics_bounds_test_case_empty_bounds.Blue.Trait T},
-    (ref T) -> M (ref str.t).
+Parameter blue : forall {T : Set}, (ref T) -> M (ref str.t).
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_multiple_bounds.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_multiple_bounds.v
@@ -7,12 +7,7 @@ fn compare_prints<T: Debug + Display>(t: &T) {
     println!("Display: `{}`", t);
 }
 *)
-Parameter compare_prints :
-    forall
-      {T : Set}
-      {ℋ_0 : core.fmt.Debug.Trait T}
-      {ℋ_1 : core.fmt.Display.Trait T},
-    (ref T) -> M unit.
+Parameter compare_prints : forall {T : Set}, (ref T) -> M unit.
 
 (*
 fn compare_types<T: Debug, U: Debug>(t: &T, u: &U) {
@@ -20,12 +15,7 @@ fn compare_types<T: Debug, U: Debug>(t: &T, u: &U) {
     println!("u: `{:?}`", u);
 }
 *)
-Parameter compare_types :
-    forall
-      {T U : Set}
-      {ℋ_0 : core.fmt.Debug.Trait T}
-      {ℋ_1 : core.fmt.Debug.Trait U},
-    (ref T) -> (ref U) -> M unit.
+Parameter compare_types : forall {T U : Set}, (ref T) -> (ref U) -> M unit.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -46,7 +46,7 @@ where
     println!("`print`: t is {:?}", t);
 }
 *)
-Parameter print : forall {T : Set} {ℋ_0 : core.fmt.Debug.Trait T}, T -> M unit.
+Parameter print : forall {T : Set}, T -> M unit.
 
 (*
 fn print_ref<'a, T>(t: &'a T)
@@ -56,9 +56,7 @@ where
     println!("`print_ref`: t is {:?}", t);
 }
 *)
-Parameter print_ref :
-    forall {T : Set} {ℋ_0 : core.fmt.Debug.Trait T},
-    (ref T) -> M unit.
+Parameter print_ref : forall {T : Set}, (ref T) -> M unit.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -90,20 +90,15 @@ Section Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account_t
   (*
   Hash
   *)
-  Parameter hash :
-      forall {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H},
-      (ref Self) -> (mut_ref __H) -> M unit.
+  Parameter hash : forall {__H : Set}, (ref Self) -> (mut_ref __H) -> M unit.
   
-  Global Instance AssociatedFunction_hash
-      {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H} :
+  Global Instance AssociatedFunction_hash {__H : Set} :
     Notations.DoubleColon Self "hash" := {
     Notations.double_colon := hash (__H := __H);
   }.
   
   Global Instance ℐ : core.hash.Hash.Required.Trait Self := {
-    core.hash.Hash.hash {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H} :=
-      hash (__H := __H);
+    core.hash.Hash.hash {__H : Set} := hash (__H := __H);
     core.hash.Hash.hash_slice := Datatypes.None;
   }.
 End Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account_t.

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
@@ -11,7 +11,7 @@ where
 }
 *)
 Parameter read_lines :
-    forall {P : Set} {ℋ_0 : core.convert.AsRef.Trait P (T := std.path.Path.t)},
+    forall {P : Set},
     P ->
       M
         ltac:(std.io.error.Result

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/traits/hash.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/traits/hash.v
@@ -25,20 +25,15 @@ Section Impl_core_hash_Hash_for_hash_Person_t.
   (*
   Hash
   *)
-  Parameter hash :
-      forall {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H},
-      (ref Self) -> (mut_ref __H) -> M unit.
+  Parameter hash : forall {__H : Set}, (ref Self) -> (mut_ref __H) -> M unit.
   
-  Global Instance AssociatedFunction_hash
-      {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H} :
+  Global Instance AssociatedFunction_hash {__H : Set} :
     Notations.DoubleColon Self "hash" := {
     Notations.double_colon := hash (__H := __H);
   }.
   
   Global Instance ℐ : core.hash.Hash.Required.Trait Self := {
-    core.hash.Hash.hash {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H} :=
-      hash (__H := __H);
+    core.hash.Hash.hash {__H : Set} := hash (__H := __H);
     core.hash.Hash.hash_slice := Datatypes.None;
   }.
 End Impl_core_hash_Hash_for_hash_Person_t.
@@ -51,9 +46,7 @@ fn calculate_hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 *)
-Parameter calculate_hash :
-    forall {T : Set} {ℋ_0 : core.hash.Hash.Trait T},
-    (ref T) -> M u64.t.
+Parameter calculate_hash : forall {T : Set}, (ref T) -> M u64.t.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/traits/supertraits.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/traits/supertraits.v
@@ -52,7 +52,7 @@ fn comp_sci_student_greeting(student: &dyn CompSciStudent) -> String {
 }
 *)
 Parameter comp_sci_student_greeting :
-    forall {DynT : Set} {ℋ_0 : supertraits.CompSciStudent.Trait.Trait DynT},
+    forall {DynT : Set},
     (ref DynT) -> M alloc.string.String.t.
 
 (*

--- a/CoqOfRust/examples/axiomatized/examples/subtle.v
+++ b/CoqOfRust/examples/axiomatized/examples/subtle.v
@@ -1436,12 +1436,9 @@ Section Impl_subtle_CtOption_t_T.
           T::conditional_select(&def, &self.value, self.is_some)
       }
   *)
-  Parameter unwrap_or :
-      forall {ℋ_0 : subtle.ConditionallySelectable.Trait T},
-      Self -> T -> M T.
+  Parameter unwrap_or : Self -> T -> M T.
   
-  Global Instance AssociatedFunction_unwrap_or
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T} :
+  Global Instance AssociatedFunction_unwrap_or :
     Notations.DoubleColon Self "unwrap_or" := {
     Notations.double_colon := unwrap_or;
   }.
@@ -1455,17 +1452,9 @@ Section Impl_subtle_CtOption_t_T.
           T::conditional_select(&f(), &self.value, self.is_some)
       }
   *)
-  Parameter unwrap_or_else :
-      forall
-        {F : Set}
-        {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-        {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)},
-      Self -> F -> M T.
+  Parameter unwrap_or_else : forall {F : Set}, Self -> F -> M T.
   
-  Global Instance AssociatedFunction_unwrap_or_else
-      {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)} :
+  Global Instance AssociatedFunction_unwrap_or_else {F : Set} :
     Notations.DoubleColon Self "unwrap_or_else" := {
     Notations.double_colon := unwrap_or_else (F := F);
   }.
@@ -1510,19 +1499,9 @@ Section Impl_subtle_CtOption_t_T.
           )
       }
   *)
-  Parameter map :
-      forall
-        {U F : Set}
-        {ℋ_0 : core.default.Default.Trait T}
-        {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-        {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)},
-      Self -> F -> M (subtle.CtOption.t U).
+  Parameter map : forall {U F : Set}, Self -> F -> M (subtle.CtOption.t U).
   
-  Global Instance AssociatedFunction_map
-      {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)} :
+  Global Instance AssociatedFunction_map {U F : Set} :
     Notations.DoubleColon Self "map" := {
     Notations.double_colon := map (U := U) (F := F);
   }.
@@ -1543,19 +1522,9 @@ Section Impl_subtle_CtOption_t_T.
           tmp
       }
   *)
-  Parameter and_then :
-      forall
-        {U F : Set}
-        {ℋ_0 : core.default.Default.Trait T}
-        {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-        {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)},
-      Self -> F -> M (subtle.CtOption.t U).
+  Parameter and_then : forall {U F : Set}, Self -> F -> M (subtle.CtOption.t U).
   
-  Global Instance AssociatedFunction_and_then
-      {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)} :
+  Global Instance AssociatedFunction_and_then {U F : Set} :
     Notations.DoubleColon Self "and_then" := {
     Notations.double_colon := and_then (U := U) (F := F);
   }.
@@ -1572,17 +1541,9 @@ Section Impl_subtle_CtOption_t_T.
           Self::conditional_select(&self, &f, is_none)
       }
   *)
-  Parameter or_else :
-      forall
-        {F : Set}
-        {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-        {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)},
-      Self -> F -> M (subtle.CtOption.t T).
+  Parameter or_else : forall {F : Set}, Self -> F -> M (subtle.CtOption.t T).
   
-  Global Instance AssociatedFunction_or_else
-      {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)} :
+  Global Instance AssociatedFunction_or_else {F : Set} :
     Notations.DoubleColon Self "or_else" := {
     Notations.double_colon := or_else (F := F);
   }.

--- a/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
@@ -523,7 +523,6 @@ where
 *)
 Definition hash_encoded
     {H T : Set}
-    {ℋ_0 : payment_channel.CryptoHash.Trait H}
     (input : ref T)
     (output
       :

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_as_input_parameters.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_as_input_parameters.v
@@ -12,11 +12,7 @@ where
     f();
 }
 *)
-Definition apply
-    {F : Set}
-    {ℋ_0 : core.ops.function.FnOnce.Trait F (Args := unit)}
-    (f : F)
-    : M unit :=
+Definition apply {F : Set} (f : F) : M unit :=
   let* f := M.alloc f in
   let* _ : M.Val unit :=
     let* α0 : F -> unit -> M _ :=
@@ -40,11 +36,7 @@ where
     f(3)
 }
 *)
-Definition apply_to_3
-    {F : Set}
-    {ℋ_0 : core.ops.function.Fn.Trait F (Args := i32.t)}
-    (f : F)
-    : M i32.t :=
+Definition apply_to_3 {F : Set} (f : F) : M i32.t :=
   let* f := M.alloc f in
   let* α0 : (ref F) -> i32.t -> M _ :=
     ltac:(M.get_method (fun ℐ =>

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_input_functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_input_functions.v
@@ -6,11 +6,7 @@ fn call_me<F: Fn()>(f: F) {
     f();
 }
 *)
-Definition call_me
-    {F : Set}
-    {ℋ_0 : core.ops.function.Fn.Trait F (Args := unit)}
-    (f : F)
-    : M unit :=
+Definition call_me {F : Set} (f : F) : M unit :=
   let* f := M.alloc f in
   let* _ : M.Val unit :=
     let* α0 : (ref F) -> unit -> M _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define.v
@@ -23,11 +23,7 @@ Definition main : M unit := M.pure tt.
         f();
     }
 *)
-Definition apply
-    {F : Set}
-    {ℋ_0 : core.ops.function.FnOnce.Trait F (Args := unit)}
-    (f : F)
-    : M unit :=
+Definition apply {F : Set} (f : F) : M unit :=
   let* f := M.alloc f in
   let* _ : M.Val unit :=
     let* α0 : F -> unit -> M _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define_and_use.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_type_anonymity_define_and_use.v
@@ -9,11 +9,7 @@ where
     f();
 }
 *)
-Definition apply
-    {F : Set}
-    {ℋ_0 : core.ops.function.Fn.Trait F (Args := unit)}
-    (f : F)
-    : M unit :=
+Definition apply {F : Set} (f : F) : M unit :=
   let* f := M.alloc f in
   let* _ : M.Val unit :=
     let* α0 : (ref F) -> unit -> M _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
@@ -127,11 +127,7 @@ where
     container.last() - container.first()
 }
 *)
-Definition difference
-    {A B C : Set}
-    {ℋ_0 : generics_associated_types_problem.Contains.Trait C (A := A) (B := B)}
-    (container : ref C)
-    : M i32.t :=
+Definition difference {A B C : Set} (container : ref C) : M i32.t :=
   let* container := M.alloc container in
   let* α0 : (ref C) -> M i32.t :=
     ltac:(M.get_method (fun ℐ =>

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
@@ -159,11 +159,7 @@ fn difference<C: Contains>(container: &C) -> i32 {
     container.last() - container.first()
 }
 *)
-Definition difference
-    {C : Set}
-    {ℋ_0 : generics_associated_types_solution.Contains.Trait C}
-    (container : ref C)
-    : M i32.t :=
+Definition difference {C : Set} (container : ref C) : M i32.t :=
   let* container := M.alloc container in
   let* α0 : (ref C) -> M i32.t :=
     ltac:(M.get_method (fun ℐ =>
@@ -186,11 +182,7 @@ fn get_a<C: Contains>(container: &C) -> C::A {
     container.a()
 }
 *)
-Definition get_a
-    {C : Set}
-    {ℋ_0 : generics_associated_types_solution.Contains.Trait C}
-    (container : ref C)
-    : M C::type["A"].t :=
+Definition get_a {C : Set} (container : ref C) : M C::type["A"].t :=
   let* container := M.alloc container in
   let* α0 : (ref C) -> M _ :=
     ltac:(M.get_method (fun ℐ =>

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
@@ -116,11 +116,7 @@ fn print_debug<T: Debug>(t: &T) {
     println!("{:?}", t);
 }
 *)
-Definition print_debug
-    {T : Set}
-    {ℋ_0 : core.fmt.Debug.Trait T}
-    (t : ref T)
-    : M unit :=
+Definition print_debug {T : Set} (t : ref T) : M unit :=
   let* t := M.alloc t in
   let* _ : M.Val unit :=
     let* _ : M.Val unit :=
@@ -147,11 +143,7 @@ fn area<T: HasArea>(t: &T) -> f64 {
     t.area()
 }
 *)
-Definition area
-    {T : Set}
-    {ℋ_0 : generics_bounds.HasArea.Trait T}
-    (t : ref T)
-    : M f64.t :=
+Definition area {T : Set} (t : ref T) : M f64.t :=
   let* t := M.alloc t in
   let* α0 : (ref T) -> M f64.t :=
     ltac:(M.get_method (fun ℐ =>

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds_test_case_empty_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds_test_case_empty_bounds.v
@@ -61,11 +61,7 @@ fn red<T: Red>(_: &T) -> &'static str {
     "red"
 }
 *)
-Definition red
-    {T : Set}
-    {ℋ_0 : generics_bounds_test_case_empty_bounds.Red.Trait T}
-    (arg : ref T)
-    : M (ref str.t) :=
+Definition red {T : Set} (arg : ref T) : M (ref str.t) :=
   let* arg := M.alloc arg in
   M.read (mk_str "red").
 
@@ -74,11 +70,7 @@ fn blue<T: Blue>(_: &T) -> &'static str {
     "blue"
 }
 *)
-Definition blue
-    {T : Set}
-    {ℋ_0 : generics_bounds_test_case_empty_bounds.Blue.Trait T}
-    (arg : ref T)
-    : M (ref str.t) :=
+Definition blue {T : Set} (arg : ref T) : M (ref str.t) :=
   let* arg := M.alloc arg in
   M.read (mk_str "blue").
 

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_multiple_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_multiple_bounds.v
@@ -7,12 +7,7 @@ fn compare_prints<T: Debug + Display>(t: &T) {
     println!("Display: `{}`", t);
 }
 *)
-Definition compare_prints
-    {T : Set}
-    {ℋ_0 : core.fmt.Debug.Trait T}
-    {ℋ_1 : core.fmt.Display.Trait T}
-    (t : ref T)
-    : M unit :=
+Definition compare_prints {T : Set} (t : ref T) : M unit :=
   let* t := M.alloc t in
   let* _ : M.Val unit :=
     let* _ : M.Val unit :=
@@ -57,13 +52,7 @@ fn compare_types<T: Debug, U: Debug>(t: &T, u: &U) {
     println!("u: `{:?}`", u);
 }
 *)
-Definition compare_types
-    {T U : Set}
-    {ℋ_0 : core.fmt.Debug.Trait T}
-    {ℋ_1 : core.fmt.Debug.Trait U}
-    (t : ref T)
-    (u : ref U)
-    : M unit :=
+Definition compare_types {T U : Set} (t : ref T) (u : ref U) : M unit :=
   let* t := M.alloc t in
   let* u := M.alloc u in
   let* _ : M.Val unit :=

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -60,7 +60,7 @@ where
     println!("`print`: t is {:?}", t);
 }
 *)
-Definition print {T : Set} {ℋ_0 : core.fmt.Debug.Trait T} (t : T) : M unit :=
+Definition print {T : Set} (t : T) : M unit :=
   let* t := M.alloc t in
   let* _ : M.Val unit :=
     let* _ : M.Val unit :=
@@ -90,11 +90,7 @@ where
     println!("`print_ref`: t is {:?}", t);
 }
 *)
-Definition print_ref
-    {T : Set}
-    {ℋ_0 : core.fmt.Debug.Trait T}
-    (t : ref T)
-    : M unit :=
+Definition print_ref {T : Set} (t : ref T) : M unit :=
   let* t := M.alloc t in
   let* _ : M.Val unit :=
     let* _ : M.Val unit :=

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -147,7 +147,6 @@ Section Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account_t
   *)
   Definition hash
       {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H}
       (self : ref Self)
       (state : mut_ref __H)
       : M unit :=
@@ -184,16 +183,13 @@ Section Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account_t
     let* α0 : M.Val unit := M.alloc α3 in
     M.read α0.
   
-  Global Instance AssociatedFunction_hash
-      {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H} :
+  Global Instance AssociatedFunction_hash {__H : Set} :
     Notations.DoubleColon Self "hash" := {
     Notations.double_colon := hash (__H := __H);
   }.
   
   Global Instance ℐ : core.hash.Hash.Required.Trait Self := {
-    core.hash.Hash.hash {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H} :=
-      hash (__H := __H);
+    core.hash.Hash.hash {__H : Set} := hash (__H := __H);
     core.hash.Hash.hash_slice := Datatypes.None;
   }.
 End Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account_t.

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
@@ -12,7 +12,6 @@ where
 *)
 Definition read_lines
     {P : Set}
-    {ℋ_0 : core.convert.AsRef.Trait P (T := std.path.Path.t)}
     (filename : P)
     :
       M

--- a/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
@@ -27,7 +27,6 @@ Section Impl_core_hash_Hash_for_hash_Person_t.
   *)
   Definition hash
       {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H}
       (self : ref Self)
       (state : mut_ref __H)
       : M unit :=
@@ -64,16 +63,13 @@ Section Impl_core_hash_Hash_for_hash_Person_t.
     let* α0 : M.Val unit := M.alloc α3 in
     M.read α0.
   
-  Global Instance AssociatedFunction_hash
-      {__H : Set}
-      {ℋ_0 : core.hash.Hasher.Trait __H} :
+  Global Instance AssociatedFunction_hash {__H : Set} :
     Notations.DoubleColon Self "hash" := {
     Notations.double_colon := hash (__H := __H);
   }.
   
   Global Instance ℐ : core.hash.Hash.Required.Trait Self := {
-    core.hash.Hash.hash {__H : Set} {ℋ_0 : core.hash.Hasher.Trait __H} :=
-      hash (__H := __H);
+    core.hash.Hash.hash {__H : Set} := hash (__H := __H);
     core.hash.Hash.hash_slice := Datatypes.None;
   }.
 End Impl_core_hash_Hash_for_hash_Person_t.
@@ -86,11 +82,7 @@ fn calculate_hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 *)
-Definition calculate_hash
-    {T : Set}
-    {ℋ_0 : core.hash.Hash.Trait T}
-    (t : ref T)
-    : M u64.t :=
+Definition calculate_hash {T : Set} (t : ref T) : M u64.t :=
   let* t := M.alloc t in
   let* s : M.Val std.hash.random.DefaultHasher.t :=
     let* α0 : std.hash.random.DefaultHasher.t :=

--- a/CoqOfRust/examples/default/examples/rust_book/traits/supertraits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/supertraits.v
@@ -53,7 +53,6 @@ fn comp_sci_student_greeting(student: &dyn CompSciStudent) -> String {
 *)
 Definition comp_sci_student_greeting
     {DynT : Set}
-    {ℋ_0 : supertraits.CompSciStudent.Trait.Trait DynT}
     (student : ref DynT)
     : M alloc.string.String.t :=
   let* student := M.alloc student in

--- a/CoqOfRust/examples/default/examples/subtle.v
+++ b/CoqOfRust/examples/default/examples/subtle.v
@@ -3043,11 +3043,7 @@ Section Impl_subtle_CtOption_t_T.
           T::conditional_select(&def, &self.value, self.is_some)
       }
   *)
-  Definition unwrap_or
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      (self : Self)
-      (def : T)
-      : M T :=
+  Definition unwrap_or (self : Self) (def : T) : M T :=
     let* self := M.alloc self in
     let* def := M.alloc def in
     let* α0 : (ref T) -> (ref T) -> subtle.Choice.t -> M T :=
@@ -3058,8 +3054,7 @@ Section Impl_subtle_CtOption_t_T.
     let* α1 : subtle.Choice.t := M.read (subtle.CtOption.Get_is_some self) in
     M.call (α0 (borrow def) (borrow (subtle.CtOption.Get_value self)) α1).
   
-  Global Instance AssociatedFunction_unwrap_or
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T} :
+  Global Instance AssociatedFunction_unwrap_or :
     Notations.DoubleColon Self "unwrap_or" := {
     Notations.double_colon := unwrap_or;
   }.
@@ -3073,13 +3068,7 @@ Section Impl_subtle_CtOption_t_T.
           T::conditional_select(&f(), &self.value, self.is_some)
       }
   *)
-  Definition unwrap_or_else
-      {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)}
-      (self : Self)
-      (f : F)
-      : M T :=
+  Definition unwrap_or_else {F : Set} (self : Self) (f : F) : M T :=
     let* self := M.alloc self in
     let* f := M.alloc f in
     let* α0 : (ref T) -> (ref T) -> subtle.Choice.t -> M T :=
@@ -3099,10 +3088,7 @@ Section Impl_subtle_CtOption_t_T.
     let* α5 : subtle.Choice.t := M.read (subtle.CtOption.Get_is_some self) in
     M.call (α0 (borrow α4) (borrow (subtle.CtOption.Get_value self)) α5).
   
-  Global Instance AssociatedFunction_unwrap_or_else
-      {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)} :
+  Global Instance AssociatedFunction_unwrap_or_else {F : Set} :
     Notations.DoubleColon Self "unwrap_or_else" := {
     Notations.double_colon := unwrap_or_else (F := F);
   }.
@@ -3158,14 +3144,7 @@ Section Impl_subtle_CtOption_t_T.
           )
       }
   *)
-  Definition map
-      {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)}
-      (self : Self)
-      (f : F)
-      : M (subtle.CtOption.t U) :=
+  Definition map {U F : Set} (self : Self) (f : F) : M (subtle.CtOption.t U) :=
     let* self := M.alloc self in
     let* f := M.alloc f in
     let* α0 : F -> T -> M _ :=
@@ -3192,11 +3171,7 @@ Section Impl_subtle_CtOption_t_T.
     let* α9 : subtle.Choice.t := M.read (subtle.CtOption.Get_is_some self) in
     M.call ((subtle.CtOption.t U)::["new"] α8 α9).
   
-  Global Instance AssociatedFunction_map
-      {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)} :
+  Global Instance AssociatedFunction_map {U F : Set} :
     Notations.DoubleColon Self "map" := {
     Notations.double_colon := map (U := U) (F := F);
   }.
@@ -3219,9 +3194,6 @@ Section Impl_subtle_CtOption_t_T.
   *)
   Definition and_then
       {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)}
       (self : Self)
       (f : F)
       : M (subtle.CtOption.t U) :=
@@ -3263,11 +3235,7 @@ Section Impl_subtle_CtOption_t_T.
       M.alloc α2 in
     M.read tmp.
   
-  Global Instance AssociatedFunction_and_then
-      {U F : Set}
-      {ℋ_0 : core.default.Default.Trait T}
-      {ℋ_1 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_2 : core.ops.function.FnOnce.Trait F (Args := T)} :
+  Global Instance AssociatedFunction_and_then {U F : Set} :
     Notations.DoubleColon Self "and_then" := {
     Notations.double_colon := and_then (U := U) (F := F);
   }.
@@ -3286,8 +3254,6 @@ Section Impl_subtle_CtOption_t_T.
   *)
   Definition or_else
       {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)}
       (self : Self)
       (f : F)
       : M (subtle.CtOption.t T) :=
@@ -3321,10 +3287,7 @@ Section Impl_subtle_CtOption_t_T.
     let* α0 : M.Val (subtle.CtOption.t T) := M.alloc α2 in
     M.read α0.
   
-  Global Instance AssociatedFunction_or_else
-      {F : Set}
-      {ℋ_0 : subtle.ConditionallySelectable.Trait T}
-      {ℋ_1 : core.ops.function.FnOnce.Trait F (Args := unit)} :
+  Global Instance AssociatedFunction_or_else {F : Set} :
     Notations.DoubleColon Self "or_else" := {
     Notations.double_colon := or_else (F := F);
   }.

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -61,7 +61,6 @@ enum TraitItem {
 #[derive(Debug, Eq, Hash, PartialEq)]
 struct FunDefinition {
     ty_params: Vec<String>,
-    where_predicates: Vec<Rc<WherePredicate>>,
     signature_and_body: Rc<FnSigAndBody>,
     is_dead_code: bool,
 }
@@ -1324,21 +1323,6 @@ impl DynNameGen {
         full_name
     }
 
-    fn get_predicates(&self) -> Vec<Rc<WherePredicate>> {
-        self.predicates
-            .iter()
-            .map(|(path, dyn_name)| {
-                Rc::new(WherePredicate {
-                    bound: Rc::new(TraitBound {
-                        name: path.clone(),
-                        ty_params: vec![],
-                    }),
-                    ty: Rc::new(CoqType::Var(dyn_name.clone())),
-                })
-            })
-            .collect()
-    }
-
     fn get_type_parm_list(&self) -> Vec<String> {
         self.predicates
             .iter()
@@ -1379,7 +1363,6 @@ impl FunDefinition {
         is_dead_code: bool,
         is_axiom: bool,
     ) -> Rc<Self> {
-        let tcx = env.tcx;
         let mut dyn_name_gen = DynNameGen::new("T".to_string());
         let FnSigAndBody { args, ret_ty, body } =
             &*compile_fn_sig_and_body(env, fn_sig_and_body, default, is_axiom);
@@ -1393,11 +1376,6 @@ impl FunDefinition {
         ]
         .concat();
 
-        let where_predicates = [
-            get_where_predicates(&tcx, env, generics),
-            dyn_name_gen.get_predicates(),
-        ]
-        .concat();
         let signature_and_body = Rc::new(FnSigAndBody {
             args,
             ret_ty: ret_ty.clone(),
@@ -1406,7 +1384,6 @@ impl FunDefinition {
 
         Rc::new(FunDefinition {
             ty_params,
-            where_predicates,
             signature_and_body,
             is_dead_code,
         })
@@ -1415,7 +1392,6 @@ impl FunDefinition {
     fn mt(&self) -> Rc<Self> {
         Rc::new(FunDefinition {
             ty_params: self.ty_params.clone(),
-            where_predicates: self.where_predicates.clone(),
             signature_and_body: self.signature_and_body.mt(),
             is_dead_code: self.is_dead_code,
         })
@@ -1515,13 +1491,6 @@ impl FunDefinition {
                                                     coq::ArgSpecKind::Implicit,
                                                 )],
                                             ),
-                                            // where predicates types
-                                            optional_insert_vec(
-                                                self.where_predicates.is_empty(),
-                                                vec![WherePredicate::vec_to_coq(
-                                                    &self.where_predicates,
-                                                )],
-                                            ),
                                         ]
                                         .concat(),
                                         image: Rc::new(
@@ -1554,11 +1523,6 @@ impl FunDefinition {
                                         &self.ty_params,
                                         coq::ArgSpecKind::Implicit,
                                     )],
-                                ),
-                                // where predicates types
-                                optional_insert_vec(
-                                    self.where_predicates.is_empty(),
-                                    vec![WherePredicate::vec_to_coq(&self.where_predicates)],
                                 ),
                                 // argument types
                                 self.signature_and_body
@@ -1597,7 +1561,6 @@ impl ImplItemKind {
         instance_prefix: &'a str,
         name: &'a str,
         ty_params: Option<&'a [String]>,
-        where_predicates: Option<&'a [Rc<WherePredicate>]>,
         class_name: &'a str,
         method_name: &'a str,
     ) -> coq::TopLevelItem<'a> {
@@ -1609,11 +1572,6 @@ impl ImplItemKind {
             },
             coq::ArgSpecKind::Implicit,
         );
-        // where predicates types
-        let where_predicates = match where_predicates {
-            None | Some([]) => WherePredicate::vec_to_coq(&[]),
-            Some(where_predicates) => WherePredicate::vec_to_coq(where_predicates),
-        };
 
         let body = coq::Expression::just_name(name);
         let entry = match ty_params {
@@ -1633,7 +1591,7 @@ impl ImplItemKind {
 
         coq::TopLevelItem::Instance(coq::Instance::new(
             &format!("{instance_prefix}_{name}"),
-            &[ty_params_arg, where_predicates],
+            &[ty_params_arg],
             coq::Expression::just_name(class_name)
                 .apply(&coq::Expression::just_name(format!("\"{name}\"").as_str())),
             &coq::Expression::Record {
@@ -1680,7 +1638,6 @@ impl ImplItemKind {
                     "AssociatedFunction",
                     name,
                     None,
-                    None,
                     "Notations.DoubleColon Self",
                     "Notations.double_colon",
                 ),
@@ -1692,7 +1649,6 @@ impl ImplItemKind {
                     "AssociatedFunction",
                     name,
                     Some(&definition.ty_params),
-                    Some(&definition.where_predicates),
                     "Notations.DoubleColon Self",
                     "Notations.double_colon",
                 ),
@@ -2392,14 +2348,10 @@ impl TopLevelItem {
                                                     &Path::concat(&[of_trait.to_owned(), Path::new(&[name])]),
                                                     &match optional_item {
                                                         Some(ImplItemKind::Definition { definition, ..}) => {
-                                                            let FunDefinition {ty_params, where_predicates, ..} = &**definition;
+                                                            let FunDefinition {ty_params, ..} = &**definition;
                                                             [optional_insert_vec(
                                                                 ty_params.is_empty(),
                                                                 vec![coq::ArgDecl::of_ty_params(ty_params, coq::ArgSpecKind::Implicit)]
-                                                              ),
-                                                              optional_insert_vec(
-                                                                where_predicates.is_empty(),
-                                                                vec![WherePredicate::vec_to_coq(where_predicates)]
                                                               )].concat()
                                                         }
                                                         _ => vec![],


### PR DESCRIPTION
Remove where clauses of functions. This would simplify the handling of reordering of definitions.

- remove `where_predicates` from `FunDefinition` struct
- remove trait constraints from functions in `hash.v`
- regenerate snapshots of translations of examples
- add example that don't compile to blacklist (there are only two of them: `ink_contracts/payment_channel.v` and `generics_associated_types_problem.v` from the Rust book)