### PR TITLE
Add `pair` to the list of Coq reserved names

### DIFF
--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -10,7 +10,6 @@ examples/axiomatized/examples/subtle.v
 examples/default/examples/rust_book/error_handling/pulling_results_out_of_options_with_stop_error_processing.v
 examples/default/examples/rust_book/flow_of_control/match_destructuring_arrays_slices.v
 examples/default/examples/rust_book/primitives/arrays_and_slices.v
-examples/default/examples/rust_book/primitives/tuples.v
 ink/
 MonadicNotationExample.v
 num_traits.v

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
@@ -319,7 +319,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
                     ("bottom_right", α2)
                   ]) in
             let* _unit := M.alloc (Value.StructTuple "structures::Unit" []) in
-            let* pair :=
+            let* pair_ :=
               let* α0 := M.read UnsupportedLiteral in
               M.alloc
                 (Value.StructTuple
@@ -346,7 +346,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
                 let* α7 :=
                   M.call_closure
                     α6
-                    [ M.get_struct_tuple_field pair "structures::Pair" 0 ] in
+                    [ M.get_struct_tuple_field pair_ "structures::Pair" 0 ] in
                 let* α8 :=
                   M.get_associated_function
                     (Ty.path "core::fmt::rt::Argument")
@@ -355,7 +355,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
                 let* α9 :=
                   M.call_closure
                     α8
-                    [ M.get_struct_tuple_field pair "structures::Pair" 1 ] in
+                    [ M.get_struct_tuple_field pair_ "structures::Pair" 1 ] in
                 let* α10 := M.alloc (Value.Array [ α7; α9 ]) in
                 let* α11 :=
                   M.call_closure
@@ -368,7 +368,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
                 M.alloc α12 in
               M.alloc (Value.Tuple []) in
             match_operator
-              pair
+              pair_
               [
                 fun γ =>
                   let* γ0_0 :=

--- a/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
@@ -586,7 +586,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
       let* α2 := M.read UnsupportedLiteral in
       let* α3 := M.call_closure α0 [ square; α1; α2 ] in
       M.alloc α3 in
-    let* pair :=
+    let* pair_ :=
       let* α0 :=
         M.get_associated_function
           (Ty.apply
@@ -613,7 +613,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
           (Ty.path "associated_functions_and_methods::Pair")
           "destroy"
           [] in
-      let* α1 := M.read pair in
+      let* α1 := M.read pair_ in
       let* α2 := M.call_closure α0 [ α1 ] in
       M.alloc α2 in
     let* α0 := M.alloc (Value.Tuple []) in

--- a/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
+++ b/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
@@ -11,11 +11,11 @@ fn reverse(pair: (i32, bool)) -> (bool, i32) {
 *)
 Definition reverse (𝜏 : list Ty.t) (α : list Value.t) : M :=
   match 𝜏, α with
-  | [], [ pair ] =>
-    let* pair := M.alloc pair in
+  | [], [ pair_ ] =>
+    let* pair_ := M.alloc pair_ in
     let* α0 :=
       match_operator
-        pair
+        pair_
         [
           fun γ =>
             let γ0_0 := M.get_tuple_field γ 0 in
@@ -261,7 +261,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
         let* α9 := M.call_closure α0 [ α8 ] in
         M.alloc α9 in
       M.alloc (Value.Tuple []) in
-    let* pair :=
+    let* pair_ :=
       M.alloc (Value.Tuple [ Value.Integer Integer.I32 1; Value.Bool true ]) in
     let* _ :=
       let* _ :=
@@ -280,7 +280,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
             (Ty.path "core::fmt::rt::Argument")
             "new_debug"
             [ Ty.tuple [ Ty.path "i32"; Ty.path "bool" ] ] in
-        let* α6 := M.call_closure α5 [ pair ] in
+        let* α6 := M.call_closure α5 [ pair_ ] in
         let* α7 := M.alloc (Value.Array [ α6 ]) in
         let* α8 :=
           M.call_closure
@@ -310,7 +310,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
             "new_debug"
             [ Ty.tuple [ Ty.path "bool"; Ty.path "i32" ] ] in
         let* α6 := M.get_function "tuples::reverse" [] in
-        let* α7 := M.read pair in
+        let* α7 := M.read pair_ in
         let* α8 := M.call_closure α6 [ α7 ] in
         let* α9 := M.alloc α8 in
         let* α10 := M.call_closure α5 [ α9 ] in

--- a/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
@@ -273,7 +273,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
         let* α9 := M.call_closure α0 [ α8 ] in
         M.alloc α9 in
       M.alloc (Value.Tuple []) in
-    let* pair :=
+    let* pair_ :=
       let* α0 :=
         M.get_associated_function
           (Ty.apply
@@ -308,7 +308,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
             (Ty.path "core::fmt::rt::Argument")
             "new_debug"
             [ Ty.path "clone::Pair" ] in
-        let* α6 := M.call_closure α5 [ pair ] in
+        let* α6 := M.call_closure α5 [ pair_ ] in
         let* α7 := M.alloc (Value.Array [ α6 ]) in
         let* α8 :=
           M.call_closure
@@ -320,7 +320,7 @@ Definition main (𝜏 : list Ty.t) (α : list Value.t) : M :=
         let* α9 := M.call_closure α0 [ α8 ] in
         M.alloc α9 in
       M.alloc (Value.Tuple []) in
-    let* moved_pair := M.copy pair in
+    let* moved_pair := M.copy pair_ in
     let* _ :=
       let* _ :=
         let* α0 := M.get_function "std::io::stdio::_print" [] in

--- a/lib/src/path.rs
+++ b/lib/src/path.rs
@@ -124,7 +124,7 @@ pub(crate) enum StructOrVariant {
 
 pub(crate) fn to_valid_coq_name(str: &str) -> String {
     let reserved_names = [
-        "Set", "Type", "Unset", "by", "exists", "end", "tt", "array", "unit",
+        "Set", "Type", "Unset", "by", "exists", "end", "tt", "array", "unit", "pair",
     ];
 
     if reserved_names.contains(&str) {


### PR DESCRIPTION
Add `pair` to the list of Coq reserved names. This is done due to avoid a name clash with the constructor for a product type from Coq's standad library. This fixes an issue (#308) with [primitives/tuple.rs](https://github.com/formal-land/coq-of-rust/blob/main/examples/rust_book/primitives/tuples.rs) example.