### PR TITLE
Remove `arrays_and_slices` example from the blacklist

### DIFF
--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -8,7 +8,6 @@ examples/axiomatized/examples/custom/provided_method.v
 examples/axiomatized/examples/rust_book/traits/traits.v
 examples/axiomatized/examples/subtle.v
 examples/default/examples/rust_book/error_handling/pulling_results_out_of_options_with_stop_error_processing.v
-examples/default/examples/rust_book/primitives/arrays_and_slices.v
 ink/
 MonadicNotationExample.v
 num_traits.v


### PR DESCRIPTION
This example had a problem related to handling of array indices. This problem appears to be fixed after [feat: add support of array index](https://github.com/formal-land/coq-of-rust/commit/98ca5f564772a9e6facdc0c9148931e9f1d0c739) commit.