### PR TITLE
Monadic `coq::Expression::Let`

### DIFF
--- a/lib/src/coq.rs
+++ b/lib/src/coq.rs
@@ -438,8 +438,7 @@ impl<'a> Expression<'a> {
             } => {
                 // NOTE: The following variable is intended to bypass self-referencing issue for borrow checkers.
                 // See: https://users.rust-lang.org/t/argument-requires-that-1-must-outlive-a/105444
-                // let mut name_string = String::new();
-                let name_string = match name {
+                let name = match name {
                     Some(name) => name.as_str(),
                     None => "_",
                 }
@@ -453,7 +452,7 @@ impl<'a> Expression<'a> {
                                     text("let"),
                                     optional_insert(!*is_monadic, text("*")),
                                     line(),
-                                    text(name_string),
+                                    text(name),
                                 ]),
                                 match ty {
                                     None => nil(),

--- a/lib/src/coq.rs
+++ b/lib/src/coq.rs
@@ -430,6 +430,7 @@ impl<'a> Expression<'a> {
             }
             Self::Let {
                 name,
+                is_monadic,
                 ty,
                 value,
                 body,
@@ -438,7 +439,15 @@ impl<'a> Expression<'a> {
                 group([
                     nest([
                         nest([
-                            nest([text("let"), line(), text(name.to_owned())]),
+                            nest([
+                                text("let"),
+                                optional_insert(!*is_monadic, text("*")),
+                                line(),
+                                text(match name {
+                                    Some(name) => name.as_str(),
+                                    None => "_",
+                                }),
+                            ]),
                             match ty {
                                 None => nil(),
                                 Some(ty) => concat([text(" :"), line(), ty.to_doc(false)]),
@@ -446,13 +455,38 @@ impl<'a> Expression<'a> {
                             text(" :="),
                         ]),
                         line(),
-                        value.to_doc(false),
+                        value.to_doc(false), // init
                         text(" in"),
                     ]),
                     line(),
                     body.to_doc(false),
                 ]),
             ),
+            // Self::Let {
+            //     name,
+            //     ty,
+            //     value,
+            //     body,
+            // } => paren(
+            //     with_paren,
+            //     group([
+            //         nest([
+            //             nest([
+            //                 nest([text("let"), line(), text(name.to_owned())]),
+            //                 match ty {
+            //                     None => nil(),
+            //                     Some(ty) => concat([text(" :"), line(), ty.to_doc(false)]),
+            //                 },
+            //                 text(" :="),
+            //             ]),
+            //             line(),
+            //             value.to_doc(false),
+            //             text(" in"),
+            //         ]),
+            //         line(),
+            //         body.to_doc(false),
+            //     ]),
+            // ),
             Self::Match { scrutinees, arms } => group([
                 group([
                     nest([

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -1292,7 +1292,8 @@ impl FunDefinition {
                             ty: Some(coq::Expression::just_name("M")),
                             body: if !generic_tys.is_empty() && !with_extra_self_ty {
                                 coq::Expression::Let {
-                                    name: "Self".to_string(),
+                                    name: Some("Self".to_string()),
+                                    is_monadic: false,
                                     ty: Some(Rc::new(coq::Expression::just_name("Ty.t"))),
                                     value: Rc::new(
                                         coq::Expression::just_name("Self").apply_many(
@@ -1367,7 +1368,8 @@ impl ImplItemKind {
                                 ty: Some(coq::Expression::just_name("Value.t")),
                                 body: if !generic_tys.is_empty() {
                                     coq::Expression::Let {
-                                        name: "Self".to_string(),
+                                        name: Some("Self".to_string()),
+                                        is_monadic: false,
                                         ty: Some(Rc::new(coq::Expression::just_name("Ty.t"))),
                                         value: Rc::new(
                                             coq::Expression::just_name("Self").apply_many(


### PR DESCRIPTION
This PR:
- Enhanced `coq::Expression::Let` so that it can also represent `let*` when needed.