### PR TITLE
 ERC-721 specifications for stateful functions

### DIFF
--- a/CoqOfRust/core/simulations/result.v
+++ b/CoqOfRust/core/simulations/result.v
@@ -1,0 +1,17 @@
+Require Import CoqOfRust.CoqOfRust.
+Require Import simulations.M.
+Require CoqOfRust.core.simulations.default.
+Import simulations.M.Notations.
+
+Module Result.
+  Global Instance IsToValue 
+      (A B : Set) (_ : ToValue A) (_ : ToValue B) :
+      ToValue (A + B) := {
+    Φ := Ty.apply (Ty.path "core::result::Result") [Φ A; Φ B];
+    φ x :=
+      match x with
+      | inl e => Value.StructTuple "core::result::Result::Err" [φ e]
+      | inr x => Value.StructTuple "core::result::Result::Ok" [φ x]
+      end;
+  }.
+End Result.

--- a/CoqOfRust/examples/default/examples/ink_contracts/proofs/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/proofs/erc721.v
@@ -266,3 +266,236 @@ Lemma run_is_approved_for_all
 Proof.
   admit.
 Admitted.
+
+Module Output.
+  Record t : Set := {
+    result : Value.t + Exception.t;
+    state : State.t;
+  }.
+  Arguments t : clear implicits.
+End Output.
+
+Definition lift_simulation {A : Set} `{ToValue A}
+  (simulation : MS? simulations.erc721.State.t string A)
+  (storage : erc721.Erc721.t) :
+  Output.t :=
+  let '(result, (storage, events)) := simulation (storage, []) in
+  let result :=
+    match result with
+    | inl result => inl (φ result)
+    | inr error => inr (M.Exception.Panic error)
+    end in
+  {|
+    Output.result := result;
+    Output.state := State.of_simulation (storage, events);
+  |}.
+
+(** The simulation [clear_approval] is equal. *)
+Lemma run_clear_approval
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.clear_approval token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.clear_approval [] [self; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [set_approval_for_all] is equal. *)
+Lemma run_set_approval_for_all
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (approved : bool) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.set_approval_for_all env to approved) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.set_approval_for_all [] [self; φ to; φ approved] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [approve_for] is equal. *)
+Lemma run_approve_for
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.approve_for env to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.approve_for [] [self; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+
+(** The simulation [approve] is equal. *)
+Lemma run_approve
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.approve env to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.approve [] [self; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [remove_token_from] is equal. *)
+Lemma run_remove_token_from
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (from : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.remove_token_from from token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.remove_token_from [] [self; φ from; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [add_token_to] is equal. *)
+Lemma run_add_token_to
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.add_token_to to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.add_token_to [] [self; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [transfer_token_from] is equal. *)
+Lemma run_transfer_token_from
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (from : erc721.AccountId.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.transfer_token_from env from to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.transfer_token_from [] [self; φ from; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [transfer] is equal. *)
+Lemma run_transfer
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.transfer env to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.transfer [] [self; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [tansfer_from] is equal. *)
+Lemma run_transfer_from
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (from : erc721.AccountId.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.transfer_from env from to token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.transfer_from [] [self; φ from; φ to; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [mint] is equal. *)
+Lemma run_mint
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (to : erc721.AccountId.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.mint env token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.mint [] [self; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.
+
+(** The simulation [burn] is equal. *)
+Lemma run_burn
+    (env : erc721.Env.t)
+    (storage : erc721.Erc721.t)
+    (token_id : erc721.TokenId.t) :
+  let state := State.of_storage storage in
+  let self := Value.Pointer (Pointer.Mutable Address.storage []) in
+  let simulation :=
+    lift_simulation
+      (simulations.erc721.burn env token_id) storage in
+  {{ Environment.of_env env, state |
+    erc721.Impl_erc721_Erc721.burn [] [self; φ token_id] ⇓
+    simulation.(Output.result)
+  | simulation.(Output.state) }}.
+Proof.
+  admit.
+Admitted.

--- a/CoqOfRust/examples/default/examples/ink_contracts/simulations/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/simulations/erc721.v
@@ -1,6 +1,7 @@
 Require Import CoqOfRust.CoqOfRust.
 Require CoqOfRust.core.simulations.default.
 Require Import CoqOfRust.core.simulations.option.
+Require Import CoqOfRust.core.simulations.result.
 Require Import CoqOfRust.core.simulations.integer.
 Require Import CoqOfRust.core.simulations.bool.
 Require CoqOfRust.examples.default.examples.ink_contracts.simulations.lib.
@@ -463,7 +464,7 @@ Definition transfer
   letS? _ := transfer_token_from env caller destination token_id in
   returnS? (inr tt).
 
-Definition tansfer_from
+Definition transfer_from
     (env : erc721.Env.t)
     (from : erc721.AccountId.t)
     (to : erc721.AccountId.t)


### PR DESCRIPTION
State equivalence of the ERC-721 code and simulations for stateful functions.
This is a folow-up after PR #530 and closes #516.