### PR TITLE
Fix: add back catch return

### DIFF
--- a/CoqOfRust/examples/default/examples/ink_contracts/dns.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/dns.v
@@ -709,107 +709,119 @@ Module Impl_dns_DomainNameService.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         let name := M.alloc (| name |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_associated_function (|
-                              Ty.apply
-                                (Ty.path "dns::Mapping")
-                                [
-                                  Ty.apply (Ty.path "array") [ Ty.path "u8" ];
-                                  Ty.path "dns::AccountId"
-                                ],
-                              "contains",
-                              []
-                            |),
-                            [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "dns::DomainNameService"
-                                "name_to_owner";
-                              name
-                            ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "dns::Error::NameAlreadyExists" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "dns::Mapping")
-                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "dns::DomainNameService"
-                    "name_to_owner";
-                  M.read (| name |);
-                  M.read (| caller |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "dns::Event::Register"
-                    [
-                      Value.StructRecord
-                        "dns::Register"
-                        [ ("name", M.read (| name |)); ("from", M.read (| caller |)) ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_associated_function (|
+                                  Ty.apply
+                                    (Ty.path "dns::Mapping")
+                                    [
+                                      Ty.apply (Ty.path "array") [ Ty.path "u8" ];
+                                      Ty.path "dns::AccountId"
+                                    ],
+                                  "contains",
+                                  []
+                                |),
+                                [
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "dns::DomainNameService"
+                                    "name_to_owner";
+                                  name
+                                ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "dns::Error::NameAlreadyExists" [] ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "dns::Mapping")
+                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
+                      "insert",
+                      []
+                    |),
+                    [
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "dns::DomainNameService"
+                        "name_to_owner";
+                      M.read (| name |);
+                      M.read (| caller |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "dns::Event::Register"
+                        [
+                          Value.StructRecord
+                            "dns::Register"
+                            [ ("name", M.read (| name |)); ("from", M.read (| caller |)) ]
+                        ]
+                    ]
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -893,133 +905,145 @@ Module Impl_dns_DomainNameService.
         (let self := M.alloc (| self |) in
         let name := M.alloc (| name |) in
         let new_address := M.alloc (| new_address |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let owner :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "dns::DomainNameService",
-                  "get_owner_or_default",
-                  []
-                |),
-                [ M.read (| self |); M.read (| name |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "dns::AccountId",
-                              [ Ty.path "dns::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [ caller; owner ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "dns::Error::CallerIsNotOwner" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let old_address :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "dns::Mapping")
-                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
-                  "get",
-                  []
-                |),
-                [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "dns::DomainNameService"
-                    "name_to_address";
-                  name
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "dns::Mapping")
-                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "dns::DomainNameService"
-                    "name_to_address";
-                  M.read (| name |);
-                  M.read (| new_address |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "dns::Event::SetAddress"
+                    ]
+                  |)
+                |) in
+              let owner :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "dns::DomainNameService",
+                      "get_owner_or_default",
+                      []
+                    |),
+                    [ M.read (| self |); M.read (| name |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "dns::AccountId",
+                                  [ Ty.path "dns::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [ caller; owner ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "dns::Error::CallerIsNotOwner" [] ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let old_address :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "dns::Mapping")
+                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
+                      "get",
+                      []
+                    |),
                     [
-                      Value.StructRecord
-                        "dns::SetAddress"
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "dns::DomainNameService"
+                        "name_to_address";
+                      name
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "dns::Mapping")
+                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
+                      "insert",
+                      []
+                    |),
+                    [
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "dns::DomainNameService"
+                        "name_to_address";
+                      M.read (| name |);
+                      M.read (| new_address |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "dns::Event::SetAddress"
                         [
-                          ("name", M.read (| name |));
-                          ("from", M.read (| caller |));
-                          ("old_address", M.read (| old_address |));
-                          ("new_address", M.read (| new_address |))
+                          Value.StructRecord
+                            "dns::SetAddress"
+                            [
+                              ("name", M.read (| name |));
+                              ("from", M.read (| caller |));
+                              ("old_address", M.read (| old_address |));
+                              ("new_address", M.read (| new_address |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1054,133 +1078,145 @@ Module Impl_dns_DomainNameService.
         (let self := M.alloc (| self |) in
         let name := M.alloc (| name |) in
         let to := M.alloc (| to |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let owner :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "dns::DomainNameService",
-                  "get_owner_or_default",
-                  []
-                |),
-                [ M.read (| self |); M.read (| name |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "dns::AccountId",
-                              [ Ty.path "dns::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [ caller; owner ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "dns::Error::CallerIsNotOwner" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let old_owner :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "dns::Mapping")
-                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
-                  "get",
-                  []
-                |),
-                [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "dns::DomainNameService"
-                    "name_to_owner";
-                  name
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "dns::Mapping")
-                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "dns::DomainNameService"
-                    "name_to_owner";
-                  M.read (| name |);
-                  M.read (| to |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "dns::DomainNameService", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "dns::Event::Transfer"
+                    ]
+                  |)
+                |) in
+              let owner :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "dns::DomainNameService",
+                      "get_owner_or_default",
+                      []
+                    |),
+                    [ M.read (| self |); M.read (| name |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "dns::AccountId",
+                                  [ Ty.path "dns::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [ caller; owner ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "dns::Error::CallerIsNotOwner" [] ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let old_owner :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "dns::Mapping")
+                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
+                      "get",
+                      []
+                    |),
                     [
-                      Value.StructRecord
-                        "dns::Transfer"
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "dns::DomainNameService"
+                        "name_to_owner";
+                      name
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "dns::Mapping")
+                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ]; Ty.path "dns::AccountId" ],
+                      "insert",
+                      []
+                    |),
+                    [
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "dns::DomainNameService"
+                        "name_to_owner";
+                      M.read (| name |);
+                      M.read (| to |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "dns::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "dns::DomainNameService",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "dns::Event::Transfer"
                         [
-                          ("name", M.read (| name |));
-                          ("from", M.read (| caller |));
-                          ("old_owner", M.read (| old_owner |));
-                          ("new_owner", M.read (| to |))
+                          Value.StructRecord
+                            "dns::Transfer"
+                            [
+                              ("name", M.read (| name |));
+                              ("from", M.read (| caller |));
+                              ("old_owner", M.read (| old_owner |));
+                              ("new_owner", M.read (| to |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
@@ -845,113 +845,122 @@ Module Impl_erc1155_Contract.
         (let self := M.alloc (| self |) in
         let token_id := M.alloc (| token_id |) in
         let value := M.alloc (| value |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (BinOp.Pure.le
-                              (M.read (| token_id |))
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc1155::Contract"
-                                  "token_id_nonce"
-                              |)))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
-                                    []
-                                  |),
-                                  [ Value.StructTuple "erc1155::Error::UnexistentToken" [] ]
-                                |)
-                              ]
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (BinOp.Pure.le
+                                  (M.read (| token_id |))
+                                  (M.read (|
+                                    M.get_struct_record_field
+                                      (M.read (| self |))
+                                      "erc1155::Contract"
+                                      "token_id_nonce"
+                                  |)))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::UnexistentToken" [] ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "erc1155::Mapping")
-                    [ Ty.tuple [ Ty.path "erc1155::AccountId"; Ty.path "u128" ]; Ty.path "u128" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
-                  Value.Tuple [ M.read (| caller |); M.read (| token_id |) ];
-                  M.read (| value |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "erc1155::Event::TransferSingle"
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "erc1155::Mapping")
+                        [ Ty.tuple [ Ty.path "erc1155::AccountId"; Ty.path "u128" ]; Ty.path "u128"
+                        ],
+                      "insert",
+                      []
+                    |),
                     [
-                      Value.StructRecord
-                        "erc1155::TransferSingle"
+                      M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                      Value.Tuple [ M.read (| caller |); M.read (| token_id |) ];
+                      M.read (| value |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "erc1155::Event::TransferSingle"
                         [
-                          ("operator",
-                            Value.StructTuple "core::option::Option::Some" [ M.read (| caller |) ]);
-                          ("from", Value.StructTuple "core::option::Option::None" []);
-                          ("to",
-                            Value.StructTuple "core::option::Option::Some" [ M.read (| caller |) ]);
-                          ("token_id", M.read (| token_id |));
-                          ("value", M.read (| value |))
+                          Value.StructRecord
+                            "erc1155::TransferSingle"
+                            [
+                              ("operator",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| caller |) ]);
+                              ("from", Value.StructTuple "core::option::Option::None" []);
+                              ("to",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| caller |) ]);
+                              ("token_id", M.read (| token_id |));
+                              ("value", M.read (| value |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1342,236 +1351,251 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
         let token_id := M.alloc (| token_id |) in
         let value := M.alloc (| value |) in
         let data := M.alloc (| data |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "erc1155::AccountId",
-                              [ Ty.path "erc1155::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [ caller; from ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    let _ :=
-                      M.match_operator (|
-                        M.alloc (| Value.Tuple [] |),
-                        [
-                          fun γ =>
-                            ltac:(M.monadic
-                              (let γ :=
-                                M.use
-                                  (M.alloc (|
-                                    UnOp.Pure.not
-                                      (M.call_closure (|
-                                        M.get_trait_method (|
-                                          "erc1155::Erc1155",
-                                          Ty.path "erc1155::Contract",
-                                          [],
-                                          "is_approved_for_all",
-                                          []
-                                        |),
-                                        [ M.read (| self |); M.read (| from |); M.read (| caller |)
-                                        ]
-                                      |))
-                                  |)) in
-                              let _ :=
-                                M.is_constant_or_break_match (|
-                                  M.read (| γ |),
-                                  Value.Bool true
-                                |) in
-                              M.alloc (|
-                                M.never_to_any (|
-                                  M.read (|
-                                    M.return_ (|
-                                      Value.StructTuple
-                                        "core::result::Result::Err"
-                                        [
-                                          M.call_closure (|
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "erc1155::AccountId",
+                                  [ Ty.path "erc1155::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [ caller; from ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        let _ :=
+                          M.match_operator (|
+                            M.alloc (| Value.Tuple [] |),
+                            [
+                              fun γ =>
+                                ltac:(M.monadic
+                                  (let γ :=
+                                    M.use
+                                      (M.alloc (|
+                                        UnOp.Pure.not
+                                          (M.call_closure (|
                                             M.get_trait_method (|
-                                              "core::convert::Into",
-                                              Ty.path "erc1155::Error",
-                                              [ Ty.path "erc1155::Error" ],
-                                              "into",
+                                              "erc1155::Erc1155",
+                                              Ty.path "erc1155::Contract",
+                                              [],
+                                              "is_approved_for_all",
                                               []
                                             |),
-                                            [ Value.StructTuple "erc1155::Error::NotApproved" [] ]
-                                          |)
-                                        ]
+                                            [
+                                              M.read (| self |);
+                                              M.read (| from |);
+                                              M.read (| caller |)
+                                            ]
+                                          |))
+                                      |)) in
+                                  let _ :=
+                                    M.is_constant_or_break_match (|
+                                      M.read (| γ |),
+                                      Value.Bool true
+                                    |) in
+                                  M.alloc (|
+                                    M.never_to_any (|
+                                      M.read (|
+                                        M.return_ (|
+                                          Value.StructTuple
+                                            "core::result::Result::Err"
+                                            [
+                                              M.call_closure (|
+                                                M.get_trait_method (|
+                                                  "core::convert::Into",
+                                                  Ty.path "erc1155::Error",
+                                                  [ Ty.path "erc1155::Error" ],
+                                                  "into",
+                                                  []
+                                                |),
+                                                [ Value.StructTuple "erc1155::Error::NotApproved" []
+                                                ]
+                                              |)
+                                            ]
+                                        |)
+                                      |)
                                     |)
-                                  |)
-                                |)
-                              |)));
-                          fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-                        ]
-                      |) in
-                    M.alloc (| Value.Tuple [] |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (M.call_closure (|
-                              M.get_trait_method (|
-                                "core::cmp::PartialEq",
-                                Ty.path "erc1155::AccountId",
-                                [ Ty.path "erc1155::AccountId" ],
-                                "ne",
-                                []
-                              |),
-                              [
-                                to;
-                                M.alloc (|
-                                  M.call_closure (|
-                                    M.get_function (| "erc1155::zero_address", [] |),
-                                    []
-                                  |)
-                                |)
-                              ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
+                                  |)));
+                              fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                            ]
+                          |) in
+                        M.alloc (| Value.Tuple [] |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (M.call_closure (|
                                   M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
+                                    "core::cmp::PartialEq",
+                                    Ty.path "erc1155::AccountId",
+                                    [ Ty.path "erc1155::AccountId" ],
+                                    "ne",
                                     []
                                   |),
-                                  [ Value.StructTuple "erc1155::Error::ZeroAddressTransfer" [] ]
-                                |)
-                              ]
+                                  [
+                                    to;
+                                    M.alloc (|
+                                      M.call_closure (|
+                                        M.get_function (| "erc1155::zero_address", [] |),
+                                        []
+                                      |)
+                                    |)
+                                  ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::ZeroAddressTransfer" [] ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let balance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_trait_method (|
-                  "erc1155::Erc1155",
-                  Ty.path "erc1155::Contract",
-                  [],
-                  "balance_of",
-                  []
-                |),
-                [ M.read (| self |); M.read (| from |); M.read (| token_id |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not (BinOp.Pure.ge (M.read (| balance |)) (M.read (| value |)))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
-                                    []
-                                  |),
-                                  [ Value.StructTuple "erc1155::Error::InsufficientBalance" [] ]
-                                |)
-                              ]
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let balance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_trait_method (|
+                      "erc1155::Erc1155",
+                      Ty.path "erc1155::Contract",
+                      [],
+                      "balance_of",
+                      []
+                    |),
+                    [ M.read (| self |); M.read (| from |); M.read (| token_id |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (BinOp.Pure.ge (M.read (| balance |)) (M.read (| value |)))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::InsufficientBalance" [] ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Contract", "perform_transfer", [] |),
-                [
-                  M.read (| self |);
-                  M.read (| from |);
-                  M.read (| to |);
-                  M.read (| token_id |);
-                  M.read (| value |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "erc1155::Contract",
-                  "transfer_acceptance_check",
-                  []
-                |),
-                [
-                  M.read (| self |);
-                  M.read (| caller |);
-                  M.read (| from |);
-                  M.read (| to |);
-                  M.read (| token_id |);
-                  M.read (| value |);
-                  M.read (| data |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "erc1155::Contract",
+                      "perform_transfer",
+                      []
+                    |),
+                    [
+                      M.read (| self |);
+                      M.read (| from |);
+                      M.read (| to |);
+                      M.read (| token_id |);
+                      M.read (| value |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "erc1155::Contract",
+                      "transfer_acceptance_check",
+                      []
+                    |),
+                    [
+                      M.read (| self |);
+                      M.read (| caller |);
+                      M.read (| from |);
+                      M.read (| to |);
+                      M.read (| token_id |);
+                      M.read (| value |);
+                      M.read (| data |)
+                    ]
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1624,336 +1648,334 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
         let token_ids := M.alloc (| token_ids |) in
         let values := M.alloc (| values |) in
         let data := M.alloc (| data |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "erc1155::AccountId",
-                              [ Ty.path "erc1155::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [ caller; from ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    let _ :=
-                      M.match_operator (|
-                        M.alloc (| Value.Tuple [] |),
-                        [
-                          fun γ =>
-                            ltac:(M.monadic
-                              (let γ :=
-                                M.use
-                                  (M.alloc (|
-                                    UnOp.Pure.not
-                                      (M.call_closure (|
-                                        M.get_trait_method (|
-                                          "erc1155::Erc1155",
-                                          Ty.path "erc1155::Contract",
-                                          [],
-                                          "is_approved_for_all",
-                                          []
-                                        |),
-                                        [ M.read (| self |); M.read (| from |); M.read (| caller |)
-                                        ]
-                                      |))
-                                  |)) in
-                              let _ :=
-                                M.is_constant_or_break_match (|
-                                  M.read (| γ |),
-                                  Value.Bool true
-                                |) in
-                              M.alloc (|
-                                M.never_to_any (|
-                                  M.read (|
-                                    M.return_ (|
-                                      Value.StructTuple
-                                        "core::result::Result::Err"
-                                        [
-                                          M.call_closure (|
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "erc1155::AccountId",
+                                  [ Ty.path "erc1155::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [ caller; from ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        let _ :=
+                          M.match_operator (|
+                            M.alloc (| Value.Tuple [] |),
+                            [
+                              fun γ =>
+                                ltac:(M.monadic
+                                  (let γ :=
+                                    M.use
+                                      (M.alloc (|
+                                        UnOp.Pure.not
+                                          (M.call_closure (|
                                             M.get_trait_method (|
-                                              "core::convert::Into",
-                                              Ty.path "erc1155::Error",
-                                              [ Ty.path "erc1155::Error" ],
-                                              "into",
+                                              "erc1155::Erc1155",
+                                              Ty.path "erc1155::Contract",
+                                              [],
+                                              "is_approved_for_all",
                                               []
                                             |),
-                                            [ Value.StructTuple "erc1155::Error::NotApproved" [] ]
-                                          |)
-                                        ]
+                                            [
+                                              M.read (| self |);
+                                              M.read (| from |);
+                                              M.read (| caller |)
+                                            ]
+                                          |))
+                                      |)) in
+                                  let _ :=
+                                    M.is_constant_or_break_match (|
+                                      M.read (| γ |),
+                                      Value.Bool true
+                                    |) in
+                                  M.alloc (|
+                                    M.never_to_any (|
+                                      M.read (|
+                                        M.return_ (|
+                                          Value.StructTuple
+                                            "core::result::Result::Err"
+                                            [
+                                              M.call_closure (|
+                                                M.get_trait_method (|
+                                                  "core::convert::Into",
+                                                  Ty.path "erc1155::Error",
+                                                  [ Ty.path "erc1155::Error" ],
+                                                  "into",
+                                                  []
+                                                |),
+                                                [ Value.StructTuple "erc1155::Error::NotApproved" []
+                                                ]
+                                              |)
+                                            ]
+                                        |)
+                                      |)
                                     |)
-                                  |)
-                                |)
-                              |)));
-                          fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-                        ]
-                      |) in
-                    M.alloc (| Value.Tuple [] |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (M.call_closure (|
-                              M.get_trait_method (|
-                                "core::cmp::PartialEq",
-                                Ty.path "erc1155::AccountId",
-                                [ Ty.path "erc1155::AccountId" ],
-                                "ne",
-                                []
-                              |),
-                              [
-                                to;
-                                M.alloc (|
-                                  M.call_closure (|
-                                    M.get_function (| "erc1155::zero_address", [] |),
-                                    []
-                                  |)
-                                |)
-                              ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
+                                  |)));
+                              fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                            ]
+                          |) in
+                        M.alloc (| Value.Tuple [] |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (M.call_closure (|
                                   M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
+                                    "core::cmp::PartialEq",
+                                    Ty.path "erc1155::AccountId",
+                                    [ Ty.path "erc1155::AccountId" ],
+                                    "ne",
                                     []
                                   |),
-                                  [ Value.StructTuple "erc1155::Error::ZeroAddressTransfer" [] ]
-                                |)
-                              ]
+                                  [
+                                    to;
+                                    M.alloc (|
+                                      M.call_closure (|
+                                        M.get_function (| "erc1155::zero_address", [] |),
+                                        []
+                                      |)
+                                    |)
+                                  ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::ZeroAddressTransfer" [] ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (UnOp.Pure.not
-                              (M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.apply
-                                    (Ty.path "alloc::vec::Vec")
-                                    [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                                  "is_empty",
-                                  []
-                                |),
-                                [ token_ids ]
-                              |)))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
-                                    []
-                                  |),
-                                  [ Value.StructTuple "erc1155::Error::BatchTransferMismatch" [] ]
-                                |)
-                              ]
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (UnOp.Pure.not
+                                  (M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.apply
+                                        (Ty.path "alloc::vec::Vec")
+                                        [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                                      "is_empty",
+                                      []
+                                    |),
+                                    [ token_ids ]
+                                  |)))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::BatchTransferMismatch" []
+                                      ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (BinOp.Pure.eq
-                              (M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.apply
-                                    (Ty.path "alloc::vec::Vec")
-                                    [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                                  "len",
-                                  []
-                                |),
-                                [ token_ids ]
-                              |))
-                              (M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.apply
-                                    (Ty.path "alloc::vec::Vec")
-                                    [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                                  "len",
-                                  []
-                                |),
-                                [ values ]
-                              |)))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
-                                    []
-                                  |),
-                                  [ Value.StructTuple "erc1155::Error::BatchTransferMismatch" [] ]
-                                |)
-                              ]
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (BinOp.Pure.eq
+                                  (M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.apply
+                                        (Ty.path "alloc::vec::Vec")
+                                        [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                                      "len",
+                                      []
+                                    |),
+                                    [ token_ids ]
+                                  |))
+                                  (M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.apply
+                                        (Ty.path "alloc::vec::Vec")
+                                        [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                                      "len",
+                                      []
+                                    |),
+                                    [ values ]
+                                  |)))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::BatchTransferMismatch" []
+                                      ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let transfers :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_trait_method (|
-                  "core::iter::traits::iterator::Iterator",
-                  Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ],
-                  [],
-                  "zip",
-                  [ Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ] ]
-                |),
-                [
-                  M.call_closure (|
-                    M.get_associated_function (|
-                      Ty.apply (Ty.path "slice") [ Ty.path "u128" ],
-                      "iter",
-                      []
-                    |),
-                    [
-                      M.call_closure (|
-                        M.get_trait_method (|
-                          "core::ops::deref::Deref",
-                          Ty.apply
-                            (Ty.path "alloc::vec::Vec")
-                            [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                          [],
-                          "deref",
-                          []
-                        |),
-                        [ token_ids ]
-                      |)
-                    ]
-                  |);
-                  M.call_closure (|
-                    M.get_associated_function (|
-                      Ty.apply (Ty.path "slice") [ Ty.path "u128" ],
-                      "iter",
-                      []
-                    |),
-                    [
-                      M.call_closure (|
-                        M.get_trait_method (|
-                          "core::ops::deref::Deref",
-                          Ty.apply
-                            (Ty.path "alloc::vec::Vec")
-                            [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                          [],
-                          "deref",
-                          []
-                        |),
-                        [ values ]
-                      |)
-                    ]
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.use
-              (M.match_operator (|
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let transfers :=
                 M.alloc (|
                   M.call_closure (|
                     M.get_trait_method (|
-                      "core::iter::traits::collect::IntoIterator",
-                      Ty.apply
-                        (Ty.path "core::iter::adapters::zip::Zip")
-                        [
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ];
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ]
-                        ],
+                      "core::iter::traits::iterator::Iterator",
+                      Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ],
                       [],
-                      "into_iter",
-                      []
+                      "zip",
+                      [ Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ] ]
                     |),
                     [
                       M.call_closure (|
+                        M.get_associated_function (|
+                          Ty.apply (Ty.path "slice") [ Ty.path "u128" ],
+                          "iter",
+                          []
+                        |),
+                        [
+                          M.call_closure (|
+                            M.get_trait_method (|
+                              "core::ops::deref::Deref",
+                              Ty.apply
+                                (Ty.path "alloc::vec::Vec")
+                                [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                              [],
+                              "deref",
+                              []
+                            |),
+                            [ token_ids ]
+                          |)
+                        ]
+                      |);
+                      M.call_closure (|
+                        M.get_associated_function (|
+                          Ty.apply (Ty.path "slice") [ Ty.path "u128" ],
+                          "iter",
+                          []
+                        |),
+                        [
+                          M.call_closure (|
+                            M.get_trait_method (|
+                              "core::ops::deref::Deref",
+                              Ty.apply
+                                (Ty.path "alloc::vec::Vec")
+                                [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                              [],
+                              "deref",
+                              []
+                            |),
+                            [ values ]
+                          |)
+                        ]
+                      |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.use
+                  (M.match_operator (|
+                    M.alloc (|
+                      M.call_closure (|
                         M.get_trait_method (|
-                          "core::clone::Clone",
+                          "core::iter::traits::collect::IntoIterator",
                           Ty.apply
                             (Ty.path "core::iter::adapters::zip::Zip")
                             [
@@ -1961,266 +1983,290 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                               Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ]
                             ],
                           [],
-                          "clone",
+                          "into_iter",
                           []
                         |),
-                        [ transfers ]
+                        [
+                          M.call_closure (|
+                            M.get_trait_method (|
+                              "core::clone::Clone",
+                              Ty.apply
+                                (Ty.path "core::iter::adapters::zip::Zip")
+                                [
+                                  Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ];
+                                  Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ]
+                                ],
+                              [],
+                              "clone",
+                              []
+                            |),
+                            [ transfers ]
+                          |)
+                        ]
                       |)
-                    ]
-                  |)
-                |),
-                [
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let iter := M.copy (| γ |) in
-                      M.loop (|
+                    |),
+                    [
+                      fun γ =>
                         ltac:(M.monadic
-                          (let _ :=
-                            M.match_operator (|
-                              M.alloc (|
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::iter::traits::iterator::Iterator",
-                                    Ty.apply
-                                      (Ty.path "core::iter::adapters::zip::Zip")
-                                      [
+                          (let iter := M.copy (| γ |) in
+                          M.loop (|
+                            ltac:(M.monadic
+                              (let _ :=
+                                M.match_operator (|
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::iter::traits::iterator::Iterator",
                                         Ty.apply
-                                          (Ty.path "core::slice::iter::Iter")
-                                          [ Ty.path "u128" ];
-                                        Ty.apply
-                                          (Ty.path "core::slice::iter::Iter")
-                                          [ Ty.path "u128" ]
-                                      ],
-                                    [],
-                                    "next",
-                                    []
+                                          (Ty.path "core::iter::adapters::zip::Zip")
+                                          [
+                                            Ty.apply
+                                              (Ty.path "core::slice::iter::Iter")
+                                              [ Ty.path "u128" ];
+                                            Ty.apply
+                                              (Ty.path "core::slice::iter::Iter")
+                                              [ Ty.path "u128" ]
+                                          ],
+                                        [],
+                                        "next",
+                                        []
+                                      |),
+                                      [ iter ]
+                                    |)
                                   |),
-                                  [ iter ]
-                                |)
-                              |),
-                              [
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (M.alloc (| M.never_to_any (| M.read (| M.break (||) |) |) |)));
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
-                                        γ,
-                                        "core::option::Option::Some",
-                                        0
-                                      |) in
-                                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                    let γ1_1 := M.get_tuple_field γ0_0 1 in
-                                    let γ1_0 := M.read (| γ1_0 |) in
-                                    let id := M.copy (| γ1_0 |) in
-                                    let γ1_1 := M.read (| γ1_1 |) in
-                                    let v := M.copy (| γ1_1 |) in
-                                    let balance :=
-                                      M.alloc (|
-                                        M.call_closure (|
-                                          M.get_trait_method (|
-                                            "erc1155::Erc1155",
-                                            Ty.path "erc1155::Contract",
-                                            [],
-                                            "balance_of",
-                                            []
-                                          |),
-                                          [ M.read (| self |); M.read (| from |); M.read (| id |) ]
-                                        |)
-                                      |) in
-                                    let _ :=
-                                      M.match_operator (|
-                                        M.alloc (| Value.Tuple [] |),
-                                        [
-                                          fun γ =>
-                                            ltac:(M.monadic
-                                              (let γ :=
-                                                M.use
-                                                  (M.alloc (|
-                                                    UnOp.Pure.not
-                                                      (BinOp.Pure.ge
-                                                        (M.read (| balance |))
-                                                        (M.read (| v |)))
-                                                  |)) in
-                                              let _ :=
-                                                M.is_constant_or_break_match (|
-                                                  M.read (| γ |),
-                                                  Value.Bool true
-                                                |) in
-                                              M.alloc (|
-                                                M.never_to_any (|
-                                                  M.read (|
-                                                    M.return_ (|
-                                                      Value.StructTuple
-                                                        "core::result::Result::Err"
-                                                        [
-                                                          M.call_closure (|
-                                                            M.get_trait_method (|
-                                                              "core::convert::Into",
-                                                              Ty.path "erc1155::Error",
-                                                              [ Ty.path "erc1155::Error" ],
-                                                              "into",
-                                                              []
-                                                            |),
+                                  [
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (M.alloc (|
+                                          M.never_to_any (| M.read (| M.break (||) |) |)
+                                        |)));
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (let γ0_0 :=
+                                          M.get_struct_tuple_field_or_break_match (|
+                                            γ,
+                                            "core::option::Option::Some",
+                                            0
+                                          |) in
+                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
+                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.read (| γ1_0 |) in
+                                        let id := M.copy (| γ1_0 |) in
+                                        let γ1_1 := M.read (| γ1_1 |) in
+                                        let v := M.copy (| γ1_1 |) in
+                                        let balance :=
+                                          M.alloc (|
+                                            M.call_closure (|
+                                              M.get_trait_method (|
+                                                "erc1155::Erc1155",
+                                                Ty.path "erc1155::Contract",
+                                                [],
+                                                "balance_of",
+                                                []
+                                              |),
+                                              [
+                                                M.read (| self |);
+                                                M.read (| from |);
+                                                M.read (| id |)
+                                              ]
+                                            |)
+                                          |) in
+                                        let _ :=
+                                          M.match_operator (|
+                                            M.alloc (| Value.Tuple [] |),
+                                            [
+                                              fun γ =>
+                                                ltac:(M.monadic
+                                                  (let γ :=
+                                                    M.use
+                                                      (M.alloc (|
+                                                        UnOp.Pure.not
+                                                          (BinOp.Pure.ge
+                                                            (M.read (| balance |))
+                                                            (M.read (| v |)))
+                                                      |)) in
+                                                  let _ :=
+                                                    M.is_constant_or_break_match (|
+                                                      M.read (| γ |),
+                                                      Value.Bool true
+                                                    |) in
+                                                  M.alloc (|
+                                                    M.never_to_any (|
+                                                      M.read (|
+                                                        M.return_ (|
+                                                          Value.StructTuple
+                                                            "core::result::Result::Err"
                                                             [
-                                                              Value.StructTuple
-                                                                "erc1155::Error::InsufficientBalance"
-                                                                []
+                                                              M.call_closure (|
+                                                                M.get_trait_method (|
+                                                                  "core::convert::Into",
+                                                                  Ty.path "erc1155::Error",
+                                                                  [ Ty.path "erc1155::Error" ],
+                                                                  "into",
+                                                                  []
+                                                                |),
+                                                                [
+                                                                  Value.StructTuple
+                                                                    "erc1155::Error::InsufficientBalance"
+                                                                    []
+                                                                ]
+                                                              |)
                                                             ]
-                                                          |)
-                                                        ]
+                                                        |)
+                                                      |)
                                                     |)
-                                                  |)
-                                                |)
-                                              |)));
-                                          fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-                                        ]
-                                      |) in
-                                    M.alloc (| Value.Tuple [] |)))
-                              ]
-                            |) in
-                          M.alloc (| Value.Tuple [] |)))
-                      |)))
-                ]
-              |)) in
-          let _ :=
-            M.use
-              (M.match_operator (|
+                                                  |)));
+                                              fun γ =>
+                                                ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                                            ]
+                                          |) in
+                                        M.alloc (| Value.Tuple [] |)))
+                                  ]
+                                |) in
+                              M.alloc (| Value.Tuple [] |)))
+                          |)))
+                    ]
+                  |)) in
+              let _ :=
+                M.use
+                  (M.match_operator (|
+                    M.alloc (|
+                      M.call_closure (|
+                        M.get_trait_method (|
+                          "core::iter::traits::collect::IntoIterator",
+                          Ty.apply
+                            (Ty.path "core::iter::adapters::zip::Zip")
+                            [
+                              Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ];
+                              Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ]
+                            ],
+                          [],
+                          "into_iter",
+                          []
+                        |),
+                        [ M.read (| transfers |) ]
+                      |)
+                    |),
+                    [
+                      fun γ =>
+                        ltac:(M.monadic
+                          (let iter := M.copy (| γ |) in
+                          M.loop (|
+                            ltac:(M.monadic
+                              (let _ :=
+                                M.match_operator (|
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::iter::traits::iterator::Iterator",
+                                        Ty.apply
+                                          (Ty.path "core::iter::adapters::zip::Zip")
+                                          [
+                                            Ty.apply
+                                              (Ty.path "core::slice::iter::Iter")
+                                              [ Ty.path "u128" ];
+                                            Ty.apply
+                                              (Ty.path "core::slice::iter::Iter")
+                                              [ Ty.path "u128" ]
+                                          ],
+                                        [],
+                                        "next",
+                                        []
+                                      |),
+                                      [ iter ]
+                                    |)
+                                  |),
+                                  [
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (M.alloc (|
+                                          M.never_to_any (| M.read (| M.break (||) |) |)
+                                        |)));
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (let γ0_0 :=
+                                          M.get_struct_tuple_field_or_break_match (|
+                                            γ,
+                                            "core::option::Option::Some",
+                                            0
+                                          |) in
+                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
+                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.read (| γ1_0 |) in
+                                        let id := M.copy (| γ1_0 |) in
+                                        let γ1_1 := M.read (| γ1_1 |) in
+                                        let v := M.copy (| γ1_1 |) in
+                                        let _ :=
+                                          M.alloc (|
+                                            M.call_closure (|
+                                              M.get_associated_function (|
+                                                Ty.path "erc1155::Contract",
+                                                "perform_transfer",
+                                                []
+                                              |),
+                                              [
+                                                M.read (| self |);
+                                                M.read (| from |);
+                                                M.read (| to |);
+                                                M.read (| id |);
+                                                M.read (| v |)
+                                              ]
+                                            |)
+                                          |) in
+                                        M.alloc (| Value.Tuple [] |)))
+                                  ]
+                                |) in
+                              M.alloc (| Value.Tuple [] |)))
+                          |)))
+                    ]
+                  |)) in
+              let _ :=
                 M.alloc (|
                   M.call_closure (|
-                    M.get_trait_method (|
-                      "core::iter::traits::collect::IntoIterator",
-                      Ty.apply
-                        (Ty.path "core::iter::adapters::zip::Zip")
-                        [
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ];
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u128" ]
-                        ],
-                      [],
-                      "into_iter",
+                    M.get_associated_function (|
+                      Ty.path "erc1155::Contract",
+                      "transfer_acceptance_check",
                       []
                     |),
-                    [ M.read (| transfers |) ]
+                    [
+                      M.read (| self |);
+                      M.read (| caller |);
+                      M.read (| from |);
+                      M.read (| to |);
+                      M.read (|
+                        M.call_closure (|
+                          M.get_trait_method (|
+                            "core::ops::index::Index",
+                            Ty.apply
+                              (Ty.path "alloc::vec::Vec")
+                              [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                            [ Ty.path "usize" ],
+                            "index",
+                            []
+                          |),
+                          [ token_ids; Value.Integer Integer.Usize 0 ]
+                        |)
+                      |);
+                      M.read (|
+                        M.call_closure (|
+                          M.get_trait_method (|
+                            "core::ops::index::Index",
+                            Ty.apply
+                              (Ty.path "alloc::vec::Vec")
+                              [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
+                            [ Ty.path "usize" ],
+                            "index",
+                            []
+                          |),
+                          [ values; Value.Integer Integer.Usize 0 ]
+                        |)
+                      |);
+                      M.read (| data |)
+                    ]
                   |)
-                |),
-                [
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let iter := M.copy (| γ |) in
-                      M.loop (|
-                        ltac:(M.monadic
-                          (let _ :=
-                            M.match_operator (|
-                              M.alloc (|
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::iter::traits::iterator::Iterator",
-                                    Ty.apply
-                                      (Ty.path "core::iter::adapters::zip::Zip")
-                                      [
-                                        Ty.apply
-                                          (Ty.path "core::slice::iter::Iter")
-                                          [ Ty.path "u128" ];
-                                        Ty.apply
-                                          (Ty.path "core::slice::iter::Iter")
-                                          [ Ty.path "u128" ]
-                                      ],
-                                    [],
-                                    "next",
-                                    []
-                                  |),
-                                  [ iter ]
-                                |)
-                              |),
-                              [
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (M.alloc (| M.never_to_any (| M.read (| M.break (||) |) |) |)));
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
-                                        γ,
-                                        "core::option::Option::Some",
-                                        0
-                                      |) in
-                                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                    let γ1_1 := M.get_tuple_field γ0_0 1 in
-                                    let γ1_0 := M.read (| γ1_0 |) in
-                                    let id := M.copy (| γ1_0 |) in
-                                    let γ1_1 := M.read (| γ1_1 |) in
-                                    let v := M.copy (| γ1_1 |) in
-                                    let _ :=
-                                      M.alloc (|
-                                        M.call_closure (|
-                                          M.get_associated_function (|
-                                            Ty.path "erc1155::Contract",
-                                            "perform_transfer",
-                                            []
-                                          |),
-                                          [
-                                            M.read (| self |);
-                                            M.read (| from |);
-                                            M.read (| to |);
-                                            M.read (| id |);
-                                            M.read (| v |)
-                                          ]
-                                        |)
-                                      |) in
-                                    M.alloc (| Value.Tuple [] |)))
-                              ]
-                            |) in
-                          M.alloc (| Value.Tuple [] |)))
-                      |)))
-                ]
-              |)) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "erc1155::Contract",
-                  "transfer_acceptance_check",
-                  []
-                |),
-                [
-                  M.read (| self |);
-                  M.read (| caller |);
-                  M.read (| from |);
-                  M.read (| to |);
-                  M.read (|
-                    M.call_closure (|
-                      M.get_trait_method (|
-                        "core::ops::index::Index",
-                        Ty.apply
-                          (Ty.path "alloc::vec::Vec")
-                          [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                        [ Ty.path "usize" ],
-                        "index",
-                        []
-                      |),
-                      [ token_ids; Value.Integer Integer.Usize 0 ]
-                    |)
-                  |);
-                  M.read (|
-                    M.call_closure (|
-                      M.get_trait_method (|
-                        "core::ops::index::Index",
-                        Ty.apply
-                          (Ty.path "alloc::vec::Vec")
-                          [ Ty.path "u128"; Ty.path "alloc::alloc::Global" ],
-                        [ Ty.path "usize" ],
-                        "index",
-                        []
-                      |),
-                      [ values; Value.Integer Integer.Usize 0 ]
-                    |)
-                  |);
-                  M.read (| data |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -2453,155 +2499,162 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
         (let self := M.alloc (| self |) in
         let operator := M.alloc (| operator |) in
         let approved := M.alloc (| approved |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (M.call_closure (|
-                              M.get_trait_method (|
-                                "core::cmp::PartialEq",
-                                Ty.path "erc1155::AccountId",
-                                [ Ty.path "erc1155::AccountId" ],
-                                "ne",
-                                []
-                              |),
-                              [ operator; caller ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::Into",
-                                    Ty.path "erc1155::Error",
-                                    [ Ty.path "erc1155::Error" ],
-                                    "into",
-                                    []
-                                  |),
-                                  [ Value.StructTuple "erc1155::Error::SelfApproval" [] ]
-                                |)
-                              ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ := M.use approved in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    let _ :=
-                      M.alloc (|
-                        M.call_closure (|
-                          M.get_associated_function (|
-                            Ty.apply
-                              (Ty.path "erc1155::Mapping")
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::cmp::PartialEq",
+                                    Ty.path "erc1155::AccountId",
+                                    [ Ty.path "erc1155::AccountId" ],
+                                    "ne",
+                                    []
+                                  |),
+                                  [ operator; caller ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::Into",
+                                        Ty.path "erc1155::Error",
+                                        [ Ty.path "erc1155::Error" ],
+                                        "into",
+                                        []
+                                      |),
+                                      [ Value.StructTuple "erc1155::Error::SelfApproval" [] ]
+                                    |)
+                                  ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ := M.use approved in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        let _ :=
+                          M.alloc (|
+                            M.call_closure (|
+                              M.get_associated_function (|
+                                Ty.apply
+                                  (Ty.path "erc1155::Mapping")
+                                  [
+                                    Ty.tuple
+                                      [ Ty.path "erc1155::AccountId"; Ty.path "erc1155::AccountId"
+                                      ];
+                                    Ty.tuple []
+                                  ],
+                                "insert",
+                                []
+                              |),
                               [
-                                Ty.tuple
-                                  [ Ty.path "erc1155::AccountId"; Ty.path "erc1155::AccountId" ];
-                                Ty.tuple []
-                              ],
-                            "insert",
-                            []
-                          |),
-                          [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "erc1155::Contract"
-                              "approvals";
-                            Value.Tuple [ M.read (| caller |); M.read (| operator |) ];
-                            Value.Tuple []
-                          ]
-                        |)
-                      |) in
-                    M.alloc (| Value.Tuple [] |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let _ :=
-                      M.alloc (|
-                        M.call_closure (|
-                          M.get_associated_function (|
-                            Ty.apply
-                              (Ty.path "erc1155::Mapping")
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "erc1155::Contract"
+                                  "approvals";
+                                Value.Tuple [ M.read (| caller |); M.read (| operator |) ];
+                                Value.Tuple []
+                              ]
+                            |)
+                          |) in
+                        M.alloc (| Value.Tuple [] |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let _ :=
+                          M.alloc (|
+                            M.call_closure (|
+                              M.get_associated_function (|
+                                Ty.apply
+                                  (Ty.path "erc1155::Mapping")
+                                  [
+                                    Ty.tuple
+                                      [ Ty.path "erc1155::AccountId"; Ty.path "erc1155::AccountId"
+                                      ];
+                                    Ty.tuple []
+                                  ],
+                                "remove",
+                                []
+                              |),
                               [
-                                Ty.tuple
-                                  [ Ty.path "erc1155::AccountId"; Ty.path "erc1155::AccountId" ];
-                                Ty.tuple []
-                              ],
-                            "remove",
-                            []
-                          |),
-                          [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "erc1155::Contract"
-                              "approvals";
-                            Value.Tuple [ M.read (| caller |); M.read (| operator |) ]
-                          ]
-                        |)
-                      |) in
-                    M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc1155::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "erc1155::Event::ApprovalForAll"
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "erc1155::Contract"
+                                  "approvals";
+                                Value.Tuple [ M.read (| caller |); M.read (| operator |) ]
+                              ]
+                            |)
+                          |) in
+                        M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc1155::Env", "emit_event", [] |),
                     [
-                      Value.StructRecord
-                        "erc1155::ApprovalForAll"
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc1155::Contract", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "erc1155::Event::ApprovalForAll"
                         [
-                          ("owner", M.read (| caller |));
-                          ("operator", M.read (| operator |));
-                          ("approved", M.read (| approved |))
+                          Value.StructRecord
+                            "erc1155::ApprovalForAll"
+                            [
+                              ("owner", M.read (| caller |));
+                              ("operator", M.read (| operator |));
+                              ("approved", M.read (| approved |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
@@ -654,113 +654,117 @@ Module Impl_erc20_Erc20.
         let from := M.alloc (| from |) in
         let to := M.alloc (| to |) in
         let value := M.alloc (| value |) in
-        M.read (|
-          let from_balance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc20::Erc20", "balance_of_impl", [] |),
-                [ M.read (| self |); M.read (| from |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt (M.read (| from_balance |)) (M.read (| value |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc20::Error::InsufficientBalance" [] ]
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let from_balance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc20::Erc20", "balance_of_impl", [] |),
+                    [ M.read (| self |); M.read (| from |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt (M.read (| from_balance |)) (M.read (| value |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc20::Error::InsufficientBalance" [] ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "erc20::Mapping")
-                    [ Ty.path "erc20::AccountId"; Ty.path "u128" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
-                  M.read (| M.read (| from |) |);
-                  BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          let to_balance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc20::Erc20", "balance_of_impl", [] |),
-                [ M.read (| self |); M.read (| to |) ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "erc20::Mapping")
-                    [ Ty.path "erc20::AccountId"; Ty.path "u128" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
-                  M.read (| M.read (| to |) |);
-                  BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc20::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc20::Erc20", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "erc20::Event::Transfer"
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "erc20::Mapping")
+                        [ Ty.path "erc20::AccountId"; Ty.path "u128" ],
+                      "insert",
+                      []
+                    |),
                     [
-                      Value.StructRecord
-                        "erc20::Transfer"
+                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
+                      M.read (| M.read (| from |) |);
+                      BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              let to_balance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc20::Erc20", "balance_of_impl", [] |),
+                    [ M.read (| self |); M.read (| to |) ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "erc20::Mapping")
+                        [ Ty.path "erc20::AccountId"; Ty.path "u128" ],
+                      "insert",
+                      []
+                    |),
+                    [
+                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
+                      M.read (| M.read (| to |) |);
+                      BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc20::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc20::Erc20", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "erc20::Event::Transfer"
                         [
-                          ("from",
-                            Value.StructTuple
-                              "core::option::Option::Some"
-                              [ M.read (| M.read (| from |) |) ]);
-                          ("to",
-                            Value.StructTuple
-                              "core::option::Option::Some"
-                              [ M.read (| M.read (| to |) |) ]);
-                          ("value", M.read (| value |))
+                          Value.StructRecord
+                            "erc20::Transfer"
+                            [
+                              ("from",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| M.read (| from |) |) ]);
+                              ("to",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| M.read (| to |) |) ]);
+                              ("value", M.read (| value |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -914,146 +918,153 @@ Module Impl_erc20_Erc20.
         let from := M.alloc (| from |) in
         let to := M.alloc (| to |) in
         let value := M.alloc (| value |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc20::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc20::Erc20", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let allowance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc20::Erc20", "allowance_impl", [] |),
-                [ M.read (| self |); from; caller ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt (M.read (| allowance |)) (M.read (| value |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc20::Error::InsufficientAllowance" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc20::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc20::Erc20", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc20::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
+                    ]
+                  |)
+                |) in
+              let allowance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc20::Erc20", "allowance_impl", [] |),
+                    [ M.read (| self |); from; caller ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "erc20::Erc20",
-                        "transfer_from_to",
-                        []
-                      |),
-                      [ M.read (| self |); from; to; M.read (| value |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc20::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc20::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt (M.read (| allowance |)) (M.read (| value |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc20::Error::InsufficientAllowance" [] ]
+                              |)
                             |)
                           |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc20::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc20::Erc20",
+                            "transfer_from_to",
+                            []
+                          |),
+                          [ M.read (| self |); from; to; M.read (| value |) ]
                         |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "erc20::Mapping")
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc20::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc20::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "erc20::Mapping")
+                        [
+                          Ty.tuple [ Ty.path "erc20::AccountId"; Ty.path "erc20::AccountId" ];
+                          Ty.path "u128"
+                        ],
+                      "insert",
+                      []
+                    |),
                     [
-                      Ty.tuple [ Ty.path "erc20::AccountId"; Ty.path "erc20::AccountId" ];
-                      Ty.path "u128"
-                    ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "allowances";
-                  Value.Tuple [ M.read (| from |); M.read (| caller |) ];
-                  BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "allowances";
+                      Value.Tuple [ M.read (| from |); M.read (| caller |) ];
+                      BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
@@ -1059,143 +1059,148 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let to := M.alloc (| to |) in
         let approved := M.alloc (| approved |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "erc721::AccountId",
-                              [ Ty.path "erc721::AccountId" ],
-                              "eq",
-                              []
-                            |),
-                            [ to; caller ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "erc721::Event::ApprovalForAll"
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "erc721::AccountId",
+                                  [ Ty.path "erc721::AccountId" ],
+                                  "eq",
+                                  []
+                                |),
+                                [ to; caller ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
                     [
-                      Value.StructRecord
-                        "erc721::ApprovalForAll"
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "erc721::Event::ApprovalForAll"
                         [
-                          ("owner", M.read (| caller |));
-                          ("operator", M.read (| to |));
-                          ("approved", M.read (| approved |))
+                          Value.StructRecord
+                            "erc721::ApprovalForAll"
+                            [
+                              ("owner", M.read (| caller |));
+                              ("operator", M.read (| to |));
+                              ("approved", M.read (| approved |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ := M.use approved in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    let _ :=
-                      M.alloc (|
-                        M.call_closure (|
-                          M.get_associated_function (|
-                            Ty.apply
-                              (Ty.path "erc721::Mapping")
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ := M.use approved in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        let _ :=
+                          M.alloc (|
+                            M.call_closure (|
+                              M.get_associated_function (|
+                                Ty.apply
+                                  (Ty.path "erc721::Mapping")
+                                  [
+                                    Ty.tuple
+                                      [ Ty.path "erc721::AccountId"; Ty.path "erc721::AccountId" ];
+                                    Ty.tuple []
+                                  ],
+                                "insert",
+                                []
+                              |),
                               [
-                                Ty.tuple
-                                  [ Ty.path "erc721::AccountId"; Ty.path "erc721::AccountId" ];
-                                Ty.tuple []
-                              ],
-                            "insert",
-                            []
-                          |),
-                          [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "erc721::Erc721"
-                              "operator_approvals";
-                            Value.Tuple [ M.read (| caller |); M.read (| to |) ];
-                            Value.Tuple []
-                          ]
-                        |)
-                      |) in
-                    M.alloc (| Value.Tuple [] |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let _ :=
-                      M.alloc (|
-                        M.call_closure (|
-                          M.get_associated_function (|
-                            Ty.apply
-                              (Ty.path "erc721::Mapping")
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "erc721::Erc721"
+                                  "operator_approvals";
+                                Value.Tuple [ M.read (| caller |); M.read (| to |) ];
+                                Value.Tuple []
+                              ]
+                            |)
+                          |) in
+                        M.alloc (| Value.Tuple [] |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let _ :=
+                          M.alloc (|
+                            M.call_closure (|
+                              M.get_associated_function (|
+                                Ty.apply
+                                  (Ty.path "erc721::Mapping")
+                                  [
+                                    Ty.tuple
+                                      [ Ty.path "erc721::AccountId"; Ty.path "erc721::AccountId" ];
+                                    Ty.tuple []
+                                  ],
+                                "remove",
+                                []
+                              |),
                               [
-                                Ty.tuple
-                                  [ Ty.path "erc721::AccountId"; Ty.path "erc721::AccountId" ];
-                                Ty.tuple []
-                              ],
-                            "remove",
-                            []
-                          |),
-                          [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "erc721::Erc721"
-                              "operator_approvals";
-                            Value.Tuple [ M.read (| caller |); M.read (| to |) ]
-                          ]
-                        |)
-                      |) in
-                    M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "erc721::Erc721"
+                                  "operator_approvals";
+                                Value.Tuple [ M.read (| caller |); M.read (| to |) ]
+                              ]
+                            |)
+                          |) in
+                        M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1216,79 +1221,85 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let to := M.alloc (| to |) in
         let approved := M.alloc (| approved |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc721::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "erc721::Erc721",
-                        "approve_for_all",
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc721::Error" ],
+                        [],
+                        "branch",
                         []
                       |),
-                      [ M.read (| self |); M.read (| to |); M.read (| approved |) ]
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc721::Erc721",
+                            "approve_for_all",
+                            []
+                          |),
+                          [ M.read (| self |); M.read (| to |); M.read (| approved |) ]
+                        |)
+                      ]
                     |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc721::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc721::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc721::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1332,242 +1343,248 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let to := M.alloc (| to |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          let owner :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Erc721", "owner_of", [] |),
-                [ M.read (| self |); M.read (| id |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (LogicalOp.or (|
+                |) in
+              let owner :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Erc721", "owner_of", [] |),
+                    [ M.read (| self |); M.read (| id |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (LogicalOp.or (|
+                                  M.call_closure (|
+                                    M.get_trait_method (|
+                                      "core::cmp::PartialEq",
+                                      Ty.apply
+                                        (Ty.path "core::option::Option")
+                                        [ Ty.path "erc721::AccountId" ],
+                                      [
+                                        Ty.apply
+                                          (Ty.path "core::option::Option")
+                                          [ Ty.path "erc721::AccountId" ]
+                                      ],
+                                      "eq",
+                                      []
+                                    |),
+                                    [
+                                      owner;
+                                      M.alloc (|
+                                        Value.StructTuple
+                                          "core::option::Option::Some"
+                                          [ M.read (| caller |) ]
+                                      |)
+                                    ]
+                                  |),
+                                  ltac:(M.monadic
+                                    (M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "erc721::Erc721",
+                                        "approved_for_all",
+                                        []
+                                      |),
+                                      [
+                                        M.read (| self |);
+                                        M.call_closure (|
+                                          M.get_associated_function (|
+                                            Ty.apply
+                                              (Ty.path "core::option::Option")
+                                              [ Ty.path "erc721::AccountId" ],
+                                            "expect",
+                                            []
+                                          |),
+                                          [
+                                            M.read (| owner |);
+                                            M.read (| Value.String "Error with AccountId" |)
+                                          ]
+                                        |);
+                                        M.read (| caller |)
+                                      ]
+                                    |)))
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
                               M.call_closure (|
                                 M.get_trait_method (|
                                   "core::cmp::PartialEq",
-                                  Ty.apply
-                                    (Ty.path "core::option::Option")
-                                    [ Ty.path "erc721::AccountId" ],
-                                  [
-                                    Ty.apply
-                                      (Ty.path "core::option::Option")
-                                      [ Ty.path "erc721::AccountId" ]
-                                  ],
+                                  Ty.path "erc721::AccountId",
+                                  [ Ty.path "erc721::AccountId" ],
                                   "eq",
                                   []
                                 |),
                                 [
-                                  owner;
+                                  M.read (| to |);
                                   M.alloc (|
-                                    Value.StructTuple
-                                      "core::option::Option::Some"
-                                      [ M.read (| caller |) ]
-                                  |)
-                                ]
-                              |),
-                              ltac:(M.monadic
-                                (M.call_closure (|
-                                  M.get_associated_function (|
-                                    Ty.path "erc721::Erc721",
-                                    "approved_for_all",
-                                    []
-                                  |),
-                                  [
-                                    M.read (| self |);
                                     M.call_closure (|
-                                      M.get_associated_function (|
-                                        Ty.apply
-                                          (Ty.path "core::option::Option")
-                                          [ Ty.path "erc721::AccountId" ],
-                                        "expect",
+                                      M.get_trait_method (|
+                                        "core::convert::From",
+                                        Ty.path "erc721::AccountId",
+                                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ] ],
+                                        "from",
                                         []
                                       |),
-                                      [
-                                        M.read (| owner |);
-                                        M.read (| Value.String "Error with AccountId" |)
-                                      ]
-                                    |);
-                                    M.read (| caller |)
-                                  ]
-                                |)))
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "erc721::AccountId",
-                              [ Ty.path "erc721::AccountId" ],
-                              "eq",
-                              []
-                            |),
-                            [
-                              M.read (| to |);
-                              M.alloc (|
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::From",
-                                    Ty.path "erc721::AccountId",
-                                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ] ],
-                                    "from",
-                                    []
-                                  |),
-                                  [ repeat (Value.Integer Integer.U8 0) 32 ]
-                                |)
+                                      [ repeat (Value.Integer Integer.U8 0) 32 ]
+                                    |)
+                                  |)
+                                ]
                               |)
-                            ]
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
+                              |)
+                            |)
                           |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc721::Error::NotAllowed" [] ]
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_associated_function (|
+                                  Ty.apply
+                                    (Ty.path "erc721::Mapping")
+                                    [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
+                                  "contains",
+                                  []
+                                |),
+                                [
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "erc721::Erc721"
+                                    "token_approvals";
+                                  id
+                                ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "erc721::Error::CannotInsert" [] ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_associated_function (|
-                              Ty.apply
-                                (Ty.path "erc721::Mapping")
-                                [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
-                              "contains",
-                              []
-                            |),
-                            [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "erc721::Erc721"
-                                "token_approvals";
-                              id
-                            ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "erc721::Error::CannotInsert" [] ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let _ :=
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let _ :=
+                          M.alloc (|
+                            M.call_closure (|
+                              M.get_associated_function (|
+                                Ty.apply
+                                  (Ty.path "erc721::Mapping")
+                                  [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
+                                "insert",
+                                []
+                              |),
+                              [
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "erc721::Erc721"
+                                  "token_approvals";
+                                M.read (| id |);
+                                M.read (| M.read (| to |) |)
+                              ]
+                            |)
+                          |) in
+                        M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
+                    [
                       M.alloc (|
                         M.call_closure (|
-                          M.get_associated_function (|
-                            Ty.apply
-                              (Ty.path "erc721::Mapping")
-                              [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
-                            "insert",
-                            []
-                          |),
-                          [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "erc721::Erc721"
-                              "token_approvals";
-                            M.read (| id |);
-                            M.read (| M.read (| to |) |)
-                          ]
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
-                      |) in
-                    M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "erc721::Event::Approval"
-                    [
-                      Value.StructRecord
-                        "erc721::Approval"
+                      |);
+                      Value.StructTuple
+                        "erc721::Event::Approval"
                         [
-                          ("from", M.read (| caller |));
-                          ("to", M.read (| M.read (| to |) |));
-                          ("id", M.read (| id |))
+                          Value.StructRecord
+                            "erc721::Approval"
+                            [
+                              ("from", M.read (| caller |));
+                              ("to", M.read (| M.read (| to |) |));
+                              ("id", M.read (| id |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1587,75 +1604,85 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let to := M.alloc (| to |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc721::Error" ],
-                    [],
-                    "branch",
-                    []
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc721::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc721::Erc721",
+                            "approve_for",
+                            []
+                          |),
+                          [ M.read (| self |); to; M.read (| id |) ]
+                        |)
+                      ]
+                    |)
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "approve_for", [] |),
-                      [ M.read (| self |); to; M.read (| id |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc721::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc721::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc721::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1691,221 +1718,233 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let from := M.alloc (| from |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          M.match_operator (|
-            self,
-            [
-              fun γ =>
-                ltac:(M.monadic
-                  (let γ := M.read (| γ |) in
-                  let γ1_0 :=
-                    M.get_struct_record_field_or_break_match (|
-                      γ,
-                      "erc721::Erc721",
-                      "token_owner"
-                    |) in
-                  let γ1_1 :=
-                    M.get_struct_record_field_or_break_match (|
-                      γ,
-                      "erc721::Erc721",
-                      "owned_tokens_count"
-                    |) in
-                  let token_owner := M.alloc (| γ1_0 |) in
-                  let owned_tokens_count := M.alloc (| γ1_1 |) in
-                  let _ :=
-                    M.match_operator (|
-                      M.alloc (| Value.Tuple [] |),
-                      [
-                        fun γ =>
-                          ltac:(M.monadic
-                            (let γ :=
-                              M.use
-                                (M.alloc (|
-                                  UnOp.Pure.not
-                                    (M.call_closure (|
-                                      M.get_associated_function (|
-                                        Ty.apply
-                                          (Ty.path "erc721::Mapping")
-                                          [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
-                                        "contains",
-                                        []
-                                      |),
-                                      [ M.read (| token_owner |); id ]
-                                    |))
-                                |)) in
-                            let _ :=
-                              M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                            M.alloc (|
-                              M.never_to_any (|
-                                M.read (|
-                                  M.return_ (|
-                                    Value.StructTuple
-                                      "core::result::Result::Err"
-                                      [ Value.StructTuple "erc721::Error::TokenNotFound" [] ]
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              M.match_operator (|
+                self,
+                [
+                  fun γ =>
+                    ltac:(M.monadic
+                      (let γ := M.read (| γ |) in
+                      let γ1_0 :=
+                        M.get_struct_record_field_or_break_match (|
+                          γ,
+                          "erc721::Erc721",
+                          "token_owner"
+                        |) in
+                      let γ1_1 :=
+                        M.get_struct_record_field_or_break_match (|
+                          γ,
+                          "erc721::Erc721",
+                          "owned_tokens_count"
+                        |) in
+                      let token_owner := M.alloc (| γ1_0 |) in
+                      let owned_tokens_count := M.alloc (| γ1_1 |) in
+                      let _ :=
+                        M.match_operator (|
+                          M.alloc (| Value.Tuple [] |),
+                          [
+                            fun γ =>
+                              ltac:(M.monadic
+                                (let γ :=
+                                  M.use
+                                    (M.alloc (|
+                                      UnOp.Pure.not
+                                        (M.call_closure (|
+                                          M.get_associated_function (|
+                                            Ty.apply
+                                              (Ty.path "erc721::Mapping")
+                                              [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
+                                            "contains",
+                                            []
+                                          |),
+                                          [ M.read (| token_owner |); id ]
+                                        |))
+                                    |)) in
+                                let _ :=
+                                  M.is_constant_or_break_match (|
+                                    M.read (| γ |),
+                                    Value.Bool true
+                                  |) in
+                                M.alloc (|
+                                  M.never_to_any (|
+                                    M.read (|
+                                      M.return_ (|
+                                        Value.StructTuple
+                                          "core::result::Result::Err"
+                                          [ Value.StructTuple "erc721::Error::TokenNotFound" [] ]
+                                      |)
+                                    |)
                                   |)
-                                |)
-                              |)
-                            |)));
-                        fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-                      ]
-                    |) in
-                  let count :=
-                    M.copy (|
-                      M.match_operator (|
-                        M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::ops::try_trait::Try",
-                              Ty.apply
-                                (Ty.path "core::result::Result")
-                                [ Ty.path "u32"; Ty.path "erc721::Error" ],
-                              [],
-                              "branch",
-                              []
-                            |),
-                            [
+                                |)));
+                            fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                          ]
+                        |) in
+                      let count :=
+                        M.copy (|
+                          M.match_operator (|
+                            M.alloc (|
                               M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.apply (Ty.path "core::option::Option") [ Ty.path "u32" ],
-                                  "ok_or",
-                                  [ Ty.path "erc721::Error" ]
+                                M.get_trait_method (|
+                                  "core::ops::try_trait::Try",
+                                  Ty.apply
+                                    (Ty.path "core::result::Result")
+                                    [ Ty.path "u32"; Ty.path "erc721::Error" ],
+                                  [],
+                                  "branch",
+                                  []
                                 |),
                                 [
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "core::option::Option") [ Ty.path "u32" ],
-                                      "map",
-                                      [
-                                        Ty.path "u32";
-                                        Ty.function [ Ty.tuple [ Ty.path "u32" ] ] (Ty.path "u32")
-                                      ]
+                                      "ok_or",
+                                      [ Ty.path "erc721::Error" ]
                                     |),
                                     [
                                       M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
-                                            (Ty.path "erc721::Mapping")
-                                            [ Ty.path "erc721::AccountId"; Ty.path "u32" ],
-                                          "get",
-                                          []
+                                            (Ty.path "core::option::Option")
+                                            [ Ty.path "u32" ],
+                                          "map",
+                                          [
+                                            Ty.path "u32";
+                                            Ty.function
+                                              [ Ty.tuple [ Ty.path "u32" ] ]
+                                              (Ty.path "u32")
+                                          ]
                                         |),
-                                        [ M.read (| owned_tokens_count |); M.read (| from |) ]
+                                        [
+                                          M.call_closure (|
+                                            M.get_associated_function (|
+                                              Ty.apply
+                                                (Ty.path "erc721::Mapping")
+                                                [ Ty.path "erc721::AccountId"; Ty.path "u32" ],
+                                              "get",
+                                              []
+                                            |),
+                                            [ M.read (| owned_tokens_count |); M.read (| from |) ]
+                                          |);
+                                          M.closure
+                                            (fun γ =>
+                                              ltac:(M.monadic
+                                                match γ with
+                                                | [ α0 ] =>
+                                                  M.match_operator (|
+                                                    M.alloc (| α0 |),
+                                                    [
+                                                      fun γ =>
+                                                        ltac:(M.monadic
+                                                          (let c := M.copy (| γ |) in
+                                                          BinOp.Panic.sub (|
+                                                            M.read (| c |),
+                                                            M.read (|
+                                                              M.use
+                                                                (M.alloc (|
+                                                                  Value.Integer Integer.U32 1
+                                                                |))
+                                                            |)
+                                                          |)))
+                                                    ]
+                                                  |)
+                                                | _ => M.impossible (||)
+                                                end))
+                                        ]
                                       |);
-                                      M.closure
-                                        (fun γ =>
-                                          ltac:(M.monadic
-                                            match γ with
-                                            | [ α0 ] =>
-                                              M.match_operator (|
-                                                M.alloc (| α0 |),
-                                                [
-                                                  fun γ =>
-                                                    ltac:(M.monadic
-                                                      (let c := M.copy (| γ |) in
-                                                      BinOp.Panic.sub (|
-                                                        M.read (| c |),
-                                                        M.read (|
-                                                          M.use
-                                                            (M.alloc (|
-                                                              Value.Integer Integer.U32 1
-                                                            |))
-                                                        |)
-                                                      |)))
-                                                ]
-                                              |)
-                                            | _ => M.impossible (||)
-                                            end))
+                                      Value.StructTuple "erc721::Error::CannotFetchValue" []
                                     ]
-                                  |);
-                                  Value.StructTuple "erc721::Error::CannotFetchValue" []
+                                  |)
                                 ]
                               |)
-                            ]
-                          |)
-                        |),
-                        [
-                          fun γ =>
-                            ltac:(M.monadic
-                              (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
-                                  γ,
-                                  "core::ops::control_flow::ControlFlow::Break",
-                                  0
-                                |) in
-                              let residual := M.copy (| γ0_0 |) in
-                              M.alloc (|
-                                M.never_to_any (|
-                                  M.read (|
-                                    M.return_ (|
-                                      M.call_closure (|
-                                        M.get_trait_method (|
-                                          "core::ops::try_trait::FromResidual",
-                                          Ty.apply
-                                            (Ty.path "core::result::Result")
-                                            [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                          [
-                                            Ty.apply
-                                              (Ty.path "core::result::Result")
+                            |),
+                            [
+                              fun γ =>
+                                ltac:(M.monadic
+                                  (let γ0_0 :=
+                                    M.get_struct_tuple_field_or_break_match (|
+                                      γ,
+                                      "core::ops::control_flow::ControlFlow::Break",
+                                      0
+                                    |) in
+                                  let residual := M.copy (| γ0_0 |) in
+                                  M.alloc (|
+                                    M.never_to_any (|
+                                      M.read (|
+                                        M.return_ (|
+                                          M.call_closure (|
+                                            M.get_trait_method (|
+                                              "core::ops::try_trait::FromResidual",
+                                              Ty.apply
+                                                (Ty.path "core::result::Result")
+                                                [ Ty.tuple []; Ty.path "erc721::Error" ],
                                               [
-                                                Ty.path "core::convert::Infallible";
-                                                Ty.path "erc721::Error"
-                                              ]
-                                          ],
-                                          "from_residual",
-                                          []
-                                        |),
-                                        [ M.read (| residual |) ]
+                                                Ty.apply
+                                                  (Ty.path "core::result::Result")
+                                                  [
+                                                    Ty.path "core::convert::Infallible";
+                                                    Ty.path "erc721::Error"
+                                                  ]
+                                              ],
+                                              "from_residual",
+                                              []
+                                            |),
+                                            [ M.read (| residual |) ]
+                                          |)
+                                        |)
                                       |)
                                     |)
-                                  |)
-                                |)
-                              |)));
-                          fun γ =>
-                            ltac:(M.monadic
-                              (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
-                                  γ,
-                                  "core::ops::control_flow::ControlFlow::Continue",
-                                  0
-                                |) in
-                              let val := M.copy (| γ0_0 |) in
-                              val))
-                        ]
-                      |)
-                    |) in
-                  let _ :=
-                    M.alloc (|
-                      M.call_closure (|
-                        M.get_associated_function (|
-                          Ty.apply
-                            (Ty.path "erc721::Mapping")
-                            [ Ty.path "erc721::AccountId"; Ty.path "u32" ],
-                          "insert",
-                          []
-                        |),
-                        [
-                          M.read (| owned_tokens_count |);
-                          M.read (| M.read (| from |) |);
-                          M.read (| count |)
-                        ]
-                      |)
-                    |) in
-                  let _ :=
-                    M.alloc (|
-                      M.call_closure (|
-                        M.get_associated_function (|
-                          Ty.apply
-                            (Ty.path "erc721::Mapping")
-                            [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
-                          "remove",
-                          []
-                        |),
-                        [ M.read (| token_owner |); M.read (| id |) ]
-                      |)
-                    |) in
-                  M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)))
-            ]
-          |)
+                                  |)));
+                              fun γ =>
+                                ltac:(M.monadic
+                                  (let γ0_0 :=
+                                    M.get_struct_tuple_field_or_break_match (|
+                                      γ,
+                                      "core::ops::control_flow::ControlFlow::Continue",
+                                      0
+                                    |) in
+                                  let val := M.copy (| γ0_0 |) in
+                                  val))
+                            ]
+                          |)
+                        |) in
+                      let _ :=
+                        M.alloc (|
+                          M.call_closure (|
+                            M.get_associated_function (|
+                              Ty.apply
+                                (Ty.path "erc721::Mapping")
+                                [ Ty.path "erc721::AccountId"; Ty.path "u32" ],
+                              "insert",
+                              []
+                            |),
+                            [
+                              M.read (| owned_tokens_count |);
+                              M.read (| M.read (| from |) |);
+                              M.read (| count |)
+                            ]
+                          |)
+                        |) in
+                      let _ :=
+                        M.alloc (|
+                          M.call_closure (|
+                            M.get_associated_function (|
+                              Ty.apply
+                                (Ty.path "erc721::Mapping")
+                                [ Ty.path "u32"; Ty.path "erc721::AccountId" ],
+                              "remove",
+                              []
+                            |),
+                            [ M.read (| token_owner |); M.read (| id |) ]
+                          |)
+                        |) in
+                      M.alloc (|
+                        Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ]
+                      |)))
+                ]
+              |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1988,93 +2027,99 @@ Module Impl_erc721_Erc721.
         (let self := M.alloc (| self |) in
         let destination := M.alloc (| destination |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc721::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "erc721::Erc721",
-                        "transfer_token_from",
-                        []
-                      |),
-                      [ M.read (| self |); caller; destination; M.read (| id |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc721::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc721::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc721::Erc721",
+                            "transfer_token_from",
+                            []
+                          |),
+                          [ M.read (| self |); caller; destination; M.read (| id |) ]
+                        |)
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc721::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc721::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -2100,79 +2145,85 @@ Module Impl_erc721_Erc721.
         let from := M.alloc (| from |) in
         let to := M.alloc (| to |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc721::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "erc721::Erc721",
-                        "transfer_token_from",
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc721::Error" ],
+                        [],
+                        "branch",
                         []
                       |),
-                      [ M.read (| self |); from; to; M.read (| id |) ]
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc721::Erc721",
+                            "transfer_token_from",
+                            []
+                          |),
+                          [ M.read (| self |); from; to; M.read (| id |) ]
+                        |)
+                      ]
                     |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc721::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc721::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc721::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -2198,129 +2249,141 @@ Module Impl_erc721_Erc721.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         let id := M.alloc (| id |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "erc721::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "add_token_to", [] |),
-                      [ M.read (| self |); caller; M.read (| id |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "erc721::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [ Ty.path "core::convert::Infallible"; Ty.path "erc721::Error" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
-                [
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
                   M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
-                      [ M.read (| self |) ]
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "erc721::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "erc721::Erc721",
+                            "add_token_to",
+                            []
+                          |),
+                          [ M.read (| self |); caller; M.read (| id |) ]
+                        |)
+                      ]
                     |)
-                  |);
-                  Value.StructTuple
-                    "erc721::Event::Transfer"
-                    [
-                      Value.StructRecord
-                        "erc721::Transfer"
-                        [
-                          ("from",
-                            Value.StructTuple
-                              "core::option::Option::Some"
-                              [
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
                                 M.call_closure (|
                                   M.get_trait_method (|
-                                    "core::convert::From",
-                                    Ty.path "erc721::AccountId",
-                                    [ Ty.apply (Ty.path "array") [ Ty.path "u8" ] ],
-                                    "from",
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "erc721::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "erc721::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
                                     []
                                   |),
-                                  [ repeat (Value.Integer Integer.U8 0) 32 ]
+                                  [ M.read (| residual |) ]
                                 |)
-                              ]);
-                          ("to",
-                            Value.StructTuple "core::option::Option::Some" [ M.read (| caller |) ]);
-                          ("id", M.read (| id |))
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "erc721::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "erc721::Erc721", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "erc721::Event::Transfer"
+                        [
+                          Value.StructRecord
+                            "erc721::Transfer"
+                            [
+                              ("from",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::From",
+                                        Ty.path "erc721::AccountId",
+                                        [ Ty.apply (Ty.path "array") [ Ty.path "u8" ] ],
+                                        "from",
+                                        []
+                                      |),
+                                      [ repeat (Value.Integer Integer.U8 0) 32 ]
+                                    |)
+                                  ]);
+                              ("to",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| caller |) ]);
+                              ("id", M.read (| id |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
@@ -878,274 +878,284 @@ Module Impl_payment_channel_PaymentChannel.
         (let self := M.alloc (| self |) in
         let amount := M.alloc (| amount |) in
         let signature := M.alloc (| signature |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "payment_channel::AccountId",
-                              [ Ty.path "payment_channel::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [
-                              M.alloc (|
-                                M.call_closure (|
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "payment_channel::AccountId",
+                                  [ Ty.path "payment_channel::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "payment_channel::Env",
+                                        "caller",
+                                        []
+                                      |),
+                                      [
+                                        M.alloc (|
+                                          M.call_closure (|
+                                            M.get_associated_function (|
+                                              Ty.path "payment_channel::PaymentChannel",
+                                              "env",
+                                              []
+                                            |),
+                                            [ M.read (| self |) ]
+                                          |)
+                                        |)
+                                      ]
+                                    |)
+                                  |);
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "recipient"
+                                ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    Value.StructTuple
+                                      "payment_channel::Error::CallerIsNotRecipient"
+                                      []
+                                  ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt
+                                (M.read (| amount |))
+                                (M.read (|
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "withdrawn"
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    Value.StructTuple
+                                      "payment_channel::Error::AmountIsLessThanWithdrawn"
+                                      []
+                                  ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (M.call_closure (|
                                   M.get_associated_function (|
-                                    Ty.path "payment_channel::Env",
-                                    "caller",
+                                    Ty.path "payment_channel::PaymentChannel",
+                                    "is_signature_valid",
                                     []
                                   |),
-                                  [
-                                    M.alloc (|
-                                      M.call_closure (|
-                                        M.get_associated_function (|
-                                          Ty.path "payment_channel::PaymentChannel",
-                                          "env",
-                                          []
-                                        |),
-                                        [ M.read (| self |) ]
-                                      |)
-                                    |)
-                                  ]
-                                |)
-                              |);
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "recipient"
-                            ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "payment_channel::Error::CallerIsNotRecipient" []
-                              ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt
-                            (M.read (| amount |))
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "withdrawn"
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
+                                  [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
                                 Value.StructTuple
-                                  "payment_channel::Error::AmountIsLessThanWithdrawn"
-                                  []
-                              ]
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "payment_channel::Error::InvalidSignature" []
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (M.call_closure (|
-                              M.get_associated_function (|
-                                Ty.path "payment_channel::PaymentChannel",
-                                "is_signature_valid",
-                                []
-                              |),
-                              [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "payment_channel::Error::InvalidSignature" [] ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
                         Ty.apply
                           (Ty.path "core::result::Result")
                           [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                        "map_err",
-                        [
-                          Ty.path "payment_channel::Error";
-                          Ty.function
-                            [ Ty.tuple [ Ty.path "payment_channel::Error" ] ]
-                            (Ty.path "payment_channel::Error")
-                        ]
+                        [],
+                        "branch",
+                        []
                       |),
                       [
                         M.call_closure (|
                           M.get_associated_function (|
-                            Ty.path "payment_channel::Env",
-                            "transfer",
-                            []
+                            Ty.apply
+                              (Ty.path "core::result::Result")
+                              [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                            "map_err",
+                            [
+                              Ty.path "payment_channel::Error";
+                              Ty.function
+                                [ Ty.tuple [ Ty.path "payment_channel::Error" ] ]
+                                (Ty.path "payment_channel::Error")
+                            ]
                           |),
                           [
-                            M.alloc (|
-                              M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.path "payment_channel::PaymentChannel",
-                                  "env",
-                                  []
-                                |),
-                                [ M.read (| self |) ]
-                              |)
-                            |);
-                            M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "recipient"
-                            |);
-                            BinOp.Panic.sub (|
-                              M.read (| amount |),
-                              M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "payment_channel::PaymentChannel"
-                                  "withdrawn"
-                              |)
-                            |)
-                          ]
-                        |);
-                        M.closure
-                          (fun γ =>
-                            ltac:(M.monadic
-                              match γ with
-                              | [ α0 ] =>
-                                M.match_operator (|
-                                  M.alloc (| α0 |),
-                                  [
-                                    fun γ =>
-                                      ltac:(M.monadic
-                                        (Value.StructTuple
-                                          "payment_channel::Error::TransferFailed"
-                                          []))
-                                  ]
-                                |)
-                              | _ => M.impossible (||)
-                              end))
-                      ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
                             M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "payment_channel::Error"
-                                    ]
-                                ],
-                                "from_residual",
+                              M.get_associated_function (|
+                                Ty.path "payment_channel::Env",
+                                "transfer",
                                 []
                               |),
-                              [ M.read (| residual |) ]
+                              [
+                                M.alloc (|
+                                  M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.path "payment_channel::PaymentChannel",
+                                      "env",
+                                      []
+                                    |),
+                                    [ M.read (| self |) ]
+                                  |)
+                                |);
+                                M.read (|
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "recipient"
+                                |);
+                                BinOp.Panic.sub (|
+                                  M.read (| amount |),
+                                  M.read (|
+                                    M.get_struct_record_field
+                                      (M.read (| self |))
+                                      "payment_channel::PaymentChannel"
+                                      "withdrawn"
+                                  |)
+                                |)
+                              ]
+                            |);
+                            M.closure
+                              (fun γ =>
+                                ltac:(M.monadic
+                                  match γ with
+                                  | [ α0 ] =>
+                                    M.match_operator (|
+                                      M.alloc (| α0 |),
+                                      [
+                                        fun γ =>
+                                          ltac:(M.monadic
+                                            (Value.StructTuple
+                                              "payment_channel::Error::TransferFailed"
+                                              []))
+                                      ]
+                                    |)
+                                  | _ => M.impossible (||)
+                                  end))
+                          ]
+                        |)
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "payment_channel::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1167,110 +1177,113 @@ Module Impl_payment_channel_PaymentChannel.
         (let self := M.alloc (| self |) in
         let amount := M.alloc (| amount |) in
         let signature := M.alloc (| signature |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "payment_channel::PaymentChannel",
-                        "close_inner",
-                        []
-                      |),
-                      [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "payment_channel::Error"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "payment_channel::Env",
-                  "terminate_contract",
-                  []
-                |),
-                [
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
                   M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "payment_channel::PaymentChannel",
-                        "env",
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                        [],
+                        "branch",
                         []
                       |),
-                      [ M.read (| self |) ]
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "payment_channel::PaymentChannel",
+                            "close_inner",
+                            []
+                          |),
+                          [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
+                        |)
+                      ]
                     |)
-                  |);
-                  M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "payment_channel::PaymentChannel"
-                      "sender"
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "payment_channel::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "payment_channel::Env",
+                      "terminate_contract",
+                      []
+                    |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "payment_channel::PaymentChannel",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      M.read (|
+                        M.get_struct_record_field
+                          (M.read (| self |))
+                          "payment_channel::PaymentChannel"
+                          "sender"
+                      |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1302,145 +1315,154 @@ Module Impl_payment_channel_PaymentChannel.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "payment_channel::AccountId",
-                              [ Ty.path "payment_channel::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [
-                              M.alloc (|
-                                M.call_closure (|
-                                  M.get_associated_function (|
-                                    Ty.path "payment_channel::Env",
-                                    "caller",
-                                    []
-                                  |),
-                                  [
-                                    M.alloc (|
-                                      M.call_closure (|
-                                        M.get_associated_function (|
-                                          Ty.path "payment_channel::PaymentChannel",
-                                          "env",
-                                          []
-                                        |),
-                                        [ M.read (| self |) ]
-                                      |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "payment_channel::AccountId",
+                                  [ Ty.path "payment_channel::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "payment_channel::Env",
+                                        "caller",
+                                        []
+                                      |),
+                                      [
+                                        M.alloc (|
+                                          M.call_closure (|
+                                            M.get_associated_function (|
+                                              Ty.path "payment_channel::PaymentChannel",
+                                              "env",
+                                              []
+                                            |),
+                                            [ M.read (| self |) ]
+                                          |)
+                                        |)
+                                      ]
                                     |)
+                                  |);
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "sender"
+                                ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "payment_channel::Error::CallerIsNotSender" []
                                   ]
-                                |)
-                              |);
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "sender"
-                            ]
+                              |)
+                            |)
                           |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "payment_channel::Error::CallerIsNotSender" [] ]
-                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let now :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "payment_channel::Env",
+                      "block_timestamp",
+                      []
+                    |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "payment_channel::PaymentChannel",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let now :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.path "payment_channel::Env",
-                  "block_timestamp",
-                  []
-                |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "payment_channel::PaymentChannel",
-                        "env",
-                        []
-                      |),
-                      [ M.read (| self |) ]
+                    ]
+                  |)
+                |) in
+              let expiration :=
+                M.alloc (|
+                  BinOp.Panic.add (|
+                    M.read (| now |),
+                    M.read (|
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "payment_channel::PaymentChannel"
+                        "close_duration"
                     |)
                   |)
-                ]
-              |)
-            |) in
-          let expiration :=
-            M.alloc (|
-              BinOp.Panic.add (|
-                M.read (| now |),
-                M.read (|
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "payment_channel::Env",
+                      "emit_event",
+                      []
+                    |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "payment_channel::PaymentChannel",
+                            "env",
+                            []
+                          |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "payment_channel::Event::SenderCloseStarted"
+                        [
+                          Value.StructRecord
+                            "payment_channel::SenderCloseStarted"
+                            [
+                              ("expiration", M.read (| expiration |));
+                              ("close_duration",
+                                M.read (|
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "close_duration"
+                                |))
+                            ]
+                        ]
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.assign (|
                   M.get_struct_record_field
                     (M.read (| self |))
                     "payment_channel::PaymentChannel"
-                    "close_duration"
-                |)
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "payment_channel::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "payment_channel::PaymentChannel",
-                        "env",
-                        []
-                      |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "payment_channel::Event::SenderCloseStarted"
-                    [
-                      Value.StructRecord
-                        "payment_channel::SenderCloseStarted"
-                        [
-                          ("expiration", M.read (| expiration |));
-                          ("close_duration",
-                            M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "close_duration"
-                            |))
-                        ]
-                    ]
-                ]
-              |)
-            |) in
-          let _ :=
-            M.assign (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "payment_channel::PaymentChannel"
-                "expiration",
-              Value.StructTuple "core::option::Option::Some" [ M.read (| expiration |) ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                    "expiration",
+                  Value.StructTuple "core::option::Option::Some" [ M.read (| expiration |) ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1473,110 +1495,121 @@ Module Impl_payment_channel_PaymentChannel.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (|
-          M.match_operator (|
-            M.get_struct_record_field
-              (M.read (| self |))
-              "payment_channel::PaymentChannel"
-              "expiration",
-            [
-              fun γ =>
-                ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
-                  let expiration := M.copy (| γ0_0 |) in
-                  let now :=
-                    M.alloc (|
-                      M.call_closure (|
-                        M.get_associated_function (|
-                          Ty.path "payment_channel::Env",
-                          "block_timestamp",
-                          []
-                        |),
-                        [
-                          M.alloc (|
-                            M.call_closure (|
-                              M.get_associated_function (|
-                                Ty.path "payment_channel::PaymentChannel",
-                                "env",
-                                []
-                              |),
-                              [ M.read (| self |) ]
-                            |)
-                          |)
-                        ]
-                      |)
-                    |) in
-                  let _ :=
-                    M.match_operator (|
-                      M.alloc (| Value.Tuple [] |),
-                      [
-                        fun γ =>
-                          ltac:(M.monadic
-                            (let γ :=
-                              M.use
-                                (M.alloc (|
-                                  BinOp.Pure.lt (M.read (| now |)) (M.read (| expiration |))
-                                |)) in
-                            let _ :=
-                              M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                            M.alloc (|
-                              M.never_to_any (|
-                                M.read (|
-                                  M.return_ (|
-                                    Value.StructTuple
-                                      "core::result::Result::Err"
-                                      [ Value.StructTuple "payment_channel::Error::NotYetExpired" []
-                                      ]
-                                  |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              M.match_operator (|
+                M.get_struct_record_field
+                  (M.read (| self |))
+                  "payment_channel::PaymentChannel"
+                  "expiration",
+                [
+                  fun γ =>
+                    ltac:(M.monadic
+                      (let γ0_0 :=
+                        M.get_struct_tuple_field_or_break_match (|
+                          γ,
+                          "core::option::Option::Some",
+                          0
+                        |) in
+                      let expiration := M.copy (| γ0_0 |) in
+                      let now :=
+                        M.alloc (|
+                          M.call_closure (|
+                            M.get_associated_function (|
+                              Ty.path "payment_channel::Env",
+                              "block_timestamp",
+                              []
+                            |),
+                            [
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_associated_function (|
+                                    Ty.path "payment_channel::PaymentChannel",
+                                    "env",
+                                    []
+                                  |),
+                                  [ M.read (| self |) ]
                                 |)
                               |)
-                            |)));
-                        fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-                      ]
-                    |) in
-                  let _ :=
-                    M.alloc (|
-                      M.call_closure (|
-                        M.get_associated_function (|
-                          Ty.path "payment_channel::Env",
-                          "terminate_contract",
-                          []
-                        |),
-                        [
-                          M.alloc (|
-                            M.call_closure (|
-                              M.get_associated_function (|
-                                Ty.path "payment_channel::PaymentChannel",
-                                "env",
-                                []
-                              |),
-                              [ M.read (| self |) ]
-                            |)
-                          |);
-                          M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "payment_channel::PaymentChannel"
-                              "sender"
+                            ]
                           |)
-                        ]
-                      |)
-                    |) in
-                  M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)));
-              fun γ =>
-                ltac:(M.monadic
-                  (M.alloc (|
-                    Value.StructTuple
-                      "core::result::Result::Err"
-                      [ Value.StructTuple "payment_channel::Error::NotYetExpired" [] ]
-                  |)))
-            ]
-          |)
+                        |) in
+                      let _ :=
+                        M.match_operator (|
+                          M.alloc (| Value.Tuple [] |),
+                          [
+                            fun γ =>
+                              ltac:(M.monadic
+                                (let γ :=
+                                  M.use
+                                    (M.alloc (|
+                                      BinOp.Pure.lt (M.read (| now |)) (M.read (| expiration |))
+                                    |)) in
+                                let _ :=
+                                  M.is_constant_or_break_match (|
+                                    M.read (| γ |),
+                                    Value.Bool true
+                                  |) in
+                                M.alloc (|
+                                  M.never_to_any (|
+                                    M.read (|
+                                      M.return_ (|
+                                        Value.StructTuple
+                                          "core::result::Result::Err"
+                                          [
+                                            Value.StructTuple
+                                              "payment_channel::Error::NotYetExpired"
+                                              []
+                                          ]
+                                      |)
+                                    |)
+                                  |)
+                                |)));
+                            fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                          ]
+                        |) in
+                      let _ :=
+                        M.alloc (|
+                          M.call_closure (|
+                            M.get_associated_function (|
+                              Ty.path "payment_channel::Env",
+                              "terminate_contract",
+                              []
+                            |),
+                            [
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_associated_function (|
+                                    Ty.path "payment_channel::PaymentChannel",
+                                    "env",
+                                    []
+                                  |),
+                                  [ M.read (| self |) ]
+                                |)
+                              |);
+                              M.read (|
+                                M.get_struct_record_field
+                                  (M.read (| self |))
+                                  "payment_channel::PaymentChannel"
+                                  "sender"
+                              |)
+                            ]
+                          |)
+                        |) in
+                      M.alloc (|
+                        Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ]
+                      |)));
+                  fun γ =>
+                    ltac:(M.monadic
+                      (M.alloc (|
+                        Value.StructTuple
+                          "core::result::Result::Err"
+                          [ Value.StructTuple "payment_channel::Error::NotYetExpired" [] ]
+                      |)))
+                ]
+              |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1617,288 +1650,298 @@ Module Impl_payment_channel_PaymentChannel.
         (let self := M.alloc (| self |) in
         let amount := M.alloc (| amount |) in
         let signature := M.alloc (| signature |) in
-        M.read (|
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          M.call_closure (|
-                            M.get_trait_method (|
-                              "core::cmp::PartialEq",
-                              Ty.path "payment_channel::AccountId",
-                              [ Ty.path "payment_channel::AccountId" ],
-                              "ne",
-                              []
-                            |),
-                            [
-                              M.alloc (|
-                                M.call_closure (|
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              M.call_closure (|
+                                M.get_trait_method (|
+                                  "core::cmp::PartialEq",
+                                  Ty.path "payment_channel::AccountId",
+                                  [ Ty.path "payment_channel::AccountId" ],
+                                  "ne",
+                                  []
+                                |),
+                                [
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "payment_channel::Env",
+                                        "caller",
+                                        []
+                                      |),
+                                      [
+                                        M.alloc (|
+                                          M.call_closure (|
+                                            M.get_associated_function (|
+                                              Ty.path "payment_channel::PaymentChannel",
+                                              "env",
+                                              []
+                                            |),
+                                            [ M.read (| self |) ]
+                                          |)
+                                        |)
+                                      ]
+                                    |)
+                                  |);
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "recipient"
+                                ]
+                              |)
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    Value.StructTuple
+                                      "payment_channel::Error::CallerIsNotRecipient"
+                                      []
+                                  ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              UnOp.Pure.not
+                                (M.call_closure (|
                                   M.get_associated_function (|
-                                    Ty.path "payment_channel::Env",
-                                    "caller",
+                                    Ty.path "payment_channel::PaymentChannel",
+                                    "is_signature_valid",
                                     []
                                   |),
-                                  [
-                                    M.alloc (|
-                                      M.call_closure (|
-                                        M.get_associated_function (|
-                                          Ty.path "payment_channel::PaymentChannel",
-                                          "env",
-                                          []
-                                        |),
-                                        [ M.read (| self |) ]
-                                      |)
-                                    |)
-                                  ]
-                                |)
-                              |);
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "recipient"
-                            ]
-                          |)
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "payment_channel::Error::CallerIsNotRecipient" []
-                              ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          UnOp.Pure.not
-                            (M.call_closure (|
-                              M.get_associated_function (|
-                                Ty.path "payment_channel::PaymentChannel",
-                                "is_signature_valid",
-                                []
-                              |),
-                              [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "payment_channel::Error::InvalidSignature" [] ]
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt
-                            (M.read (| amount |))
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "withdrawn"
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
+                                  [ M.read (| self |); M.read (| amount |); M.read (| signature |) ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
                                 Value.StructTuple
-                                  "payment_channel::Error::AmountIsLessThanWithdrawn"
-                                  []
-                              ]
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "payment_channel::Error::InvalidSignature" []
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let amount_to_withdraw :=
-            M.alloc (|
-              BinOp.Panic.sub (|
-                M.read (| amount |),
-                M.read (|
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt
+                                (M.read (| amount |))
+                                (M.read (|
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "withdrawn"
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    Value.StructTuple
+                                      "payment_channel::Error::AmountIsLessThanWithdrawn"
+                                      []
+                                  ]
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let amount_to_withdraw :=
+                M.alloc (|
+                  BinOp.Panic.sub (|
+                    M.read (| amount |),
+                    M.read (|
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "payment_channel::PaymentChannel"
+                        "withdrawn"
+                    |)
+                  |)
+                |) in
+              let _ :=
+                let β :=
                   M.get_struct_record_field
                     (M.read (| self |))
                     "payment_channel::PaymentChannel"
-                    "withdrawn"
-                |)
-              |)
-            |) in
-          let _ :=
-            let β :=
-              M.get_struct_record_field
-                (M.read (| self |))
-                "payment_channel::PaymentChannel"
-                "withdrawn" in
-            M.assign (|
-              β,
-              BinOp.Panic.add (| M.read (| β |), M.read (| amount_to_withdraw |) |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+                    "withdrawn" in
+                M.assign (|
+                  β,
+                  BinOp.Panic.add (| M.read (| β |), M.read (| amount_to_withdraw |) |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
                         Ty.apply
                           (Ty.path "core::result::Result")
                           [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                        "map_err",
-                        [
-                          Ty.path "payment_channel::Error";
-                          Ty.function
-                            [ Ty.tuple [ Ty.path "payment_channel::Error" ] ]
-                            (Ty.path "payment_channel::Error")
-                        ]
+                        [],
+                        "branch",
+                        []
                       |),
                       [
                         M.call_closure (|
                           M.get_associated_function (|
-                            Ty.path "payment_channel::Env",
-                            "transfer",
-                            []
+                            Ty.apply
+                              (Ty.path "core::result::Result")
+                              [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                            "map_err",
+                            [
+                              Ty.path "payment_channel::Error";
+                              Ty.function
+                                [ Ty.tuple [ Ty.path "payment_channel::Error" ] ]
+                                (Ty.path "payment_channel::Error")
+                            ]
                           |),
                           [
-                            M.alloc (|
-                              M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.path "payment_channel::PaymentChannel",
-                                  "env",
-                                  []
-                                |),
-                                [ M.read (| self |) ]
-                              |)
-                            |);
-                            M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "payment_channel::PaymentChannel"
-                                "recipient"
-                            |);
-                            M.read (| amount_to_withdraw |)
-                          ]
-                        |);
-                        M.closure
-                          (fun γ =>
-                            ltac:(M.monadic
-                              match γ with
-                              | [ α0 ] =>
-                                M.match_operator (|
-                                  M.alloc (| α0 |),
-                                  [
-                                    fun γ =>
-                                      ltac:(M.monadic
-                                        (Value.StructTuple
-                                          "payment_channel::Error::TransferFailed"
-                                          []))
-                                  ]
-                                |)
-                              | _ => M.impossible (||)
-                              end))
-                      ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
                             M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "payment_channel::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "payment_channel::Error"
-                                    ]
-                                ],
-                                "from_residual",
+                              M.get_associated_function (|
+                                Ty.path "payment_channel::Env",
+                                "transfer",
                                 []
                               |),
-                              [ M.read (| residual |) ]
+                              [
+                                M.alloc (|
+                                  M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.path "payment_channel::PaymentChannel",
+                                      "env",
+                                      []
+                                    |),
+                                    [ M.read (| self |) ]
+                                  |)
+                                |);
+                                M.read (|
+                                  M.get_struct_record_field
+                                    (M.read (| self |))
+                                    "payment_channel::PaymentChannel"
+                                    "recipient"
+                                |);
+                                M.read (| amount_to_withdraw |)
+                              ]
+                            |);
+                            M.closure
+                              (fun γ =>
+                                ltac:(M.monadic
+                                  match γ with
+                                  | [ α0 ] =>
+                                    M.match_operator (|
+                                      M.alloc (| α0 |),
+                                      [
+                                        fun γ =>
+                                          ltac:(M.monadic
+                                            (Value.StructTuple
+                                              "payment_channel::Error::TransferFailed"
+                                              []))
+                                      ]
+                                    |)
+                                  | _ => M.impossible (||)
+                                  end))
+                          ]
+                        |)
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "payment_channel::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "payment_channel::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
@@ -740,113 +740,125 @@ Module Impl_trait_erc20_Erc20.
         let from := M.alloc (| from |) in
         let to := M.alloc (| to |) in
         let value := M.alloc (| value |) in
-        M.read (|
-          let from_balance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "trait_erc20::Erc20", "balance_of_impl", [] |),
-                [ M.read (| self |); M.read (| from |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt (M.read (| from_balance |)) (M.read (| value |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "trait_erc20::Error::InsufficientBalance" [] ]
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let from_balance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "trait_erc20::Erc20",
+                      "balance_of_impl",
+                      []
+                    |),
+                    [ M.read (| self |); M.read (| from |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt (M.read (| from_balance |)) (M.read (| value |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "trait_erc20::Error::InsufficientBalance" [] ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "trait_erc20::Mapping")
-                    [ Ty.path "trait_erc20::AccountId"; Ty.path "u128" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
-                  M.read (| M.read (| from |) |);
-                  BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          let to_balance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "trait_erc20::Erc20", "balance_of_impl", [] |),
-                [ M.read (| self |); M.read (| to |) ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "trait_erc20::Mapping")
-                    [ Ty.path "trait_erc20::AccountId"; Ty.path "u128" ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
-                  M.read (| M.read (| to |) |);
-                  BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "trait_erc20::Env", "emit_event", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "trait_erc20::Erc20", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |);
-                  Value.StructTuple
-                    "trait_erc20::Event::Transfer"
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "trait_erc20::Mapping")
+                        [ Ty.path "trait_erc20::AccountId"; Ty.path "u128" ],
+                      "insert",
+                      []
+                    |),
                     [
-                      Value.StructRecord
-                        "trait_erc20::Transfer"
+                      M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
+                      M.read (| M.read (| from |) |);
+                      BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              let to_balance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "trait_erc20::Erc20",
+                      "balance_of_impl",
+                      []
+                    |),
+                    [ M.read (| self |); M.read (| to |) ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "trait_erc20::Mapping")
+                        [ Ty.path "trait_erc20::AccountId"; Ty.path "u128" ],
+                      "insert",
+                      []
+                    |),
+                    [
+                      M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
+                      M.read (| M.read (| to |) |);
+                      BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "trait_erc20::Env", "emit_event", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "trait_erc20::Erc20", "env", [] |),
+                          [ M.read (| self |) ]
+                        |)
+                      |);
+                      Value.StructTuple
+                        "trait_erc20::Event::Transfer"
                         [
-                          ("from",
-                            Value.StructTuple
-                              "core::option::Option::Some"
-                              [ M.read (| M.read (| from |) |) ]);
-                          ("to",
-                            Value.StructTuple
-                              "core::option::Option::Some"
-                              [ M.read (| M.read (| to |) |) ]);
-                          ("value", M.read (| value |))
+                          Value.StructRecord
+                            "trait_erc20::Transfer"
+                            [
+                              ("from",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| M.read (| from |) |) ]);
+                              ("to",
+                                Value.StructTuple
+                                  "core::option::Option::Some"
+                                  [ M.read (| M.read (| to |) |) ]);
+                              ("value", M.read (| value |))
+                            ]
                         ]
                     ]
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.
@@ -1054,150 +1066,162 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
         let from := M.alloc (| from |) in
         let to := M.alloc (| to |) in
         let value := M.alloc (| value |) in
-        M.read (|
-          let caller :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "trait_erc20::Env", "caller", [] |),
-                [
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "trait_erc20::Erc20", "env", [] |),
-                      [ M.read (| self |) ]
-                    |)
-                  |)
-                ]
-              |)
-            |) in
-          let allowance :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.path "trait_erc20::Erc20", "allowance_impl", [] |),
-                [ M.read (| self |); from; caller ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.lt (M.read (| allowance |)) (M.read (| value |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [ Value.StructTuple "trait_erc20::Error::InsufficientAllowance" [] ]
-                          |)
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let caller :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "trait_erc20::Env", "caller", [] |),
+                    [
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "trait_erc20::Erc20", "env", [] |),
+                          [ M.read (| self |) ]
                         |)
                       |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.tuple []; Ty.path "trait_erc20::Error" ],
-                    [],
-                    "branch",
-                    []
-                  |),
+                    ]
+                  |)
+                |) in
+              let allowance :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.path "trait_erc20::Erc20",
+                      "allowance_impl",
+                      []
+                    |),
+                    [ M.read (| self |); from; caller ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "trait_erc20::Erc20",
-                        "transfer_from_to",
-                        []
-                      |),
-                      [ M.read (| self |); from; to; M.read (| value |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "trait_erc20::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "trait_erc20::Error"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.lt (M.read (| allowance |)) (M.read (| value |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [ Value.StructTuple "trait_erc20::Error::InsufficientAllowance" []
+                                  ]
+                              |)
                             |)
                           |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.tuple []; Ty.path "trait_erc20::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "trait_erc20::Erc20",
+                            "transfer_from_to",
+                            []
+                          |),
+                          [ M.read (| self |); from; to; M.read (| value |) ]
                         |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |) in
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "trait_erc20::Mapping")
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "trait_erc20::Error" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "trait_erc20::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |) in
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_associated_function (|
+                      Ty.apply
+                        (Ty.path "trait_erc20::Mapping")
+                        [
+                          Ty.tuple
+                            [ Ty.path "trait_erc20::AccountId"; Ty.path "trait_erc20::AccountId" ];
+                          Ty.path "u128"
+                        ],
+                      "insert",
+                      []
+                    |),
                     [
-                      Ty.tuple
-                        [ Ty.path "trait_erc20::AccountId"; Ty.path "trait_erc20::AccountId" ];
-                      Ty.path "u128"
-                    ],
-                  "insert",
-                  []
-                |),
-                [
-                  M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "allowances";
-                  Value.Tuple [ M.read (| from |); M.read (| caller |) ];
-                  BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                      M.get_struct_record_field
+                        (M.read (| self |))
+                        "trait_erc20::Erc20"
+                        "allowances";
+                      Value.Tuple [ M.read (| from |); M.read (| caller |) ];
+                      BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
+                    ]
+                  |)
+                |) in
+              M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
@@ -22,94 +22,97 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
     ltac:(M.monadic
       (let first_number_str := M.alloc (| first_number_str |) in
       let second_number_str := M.alloc (| second_number_str |) in
-      M.read (|
-        let first_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                  [ M.read (| first_number_str |) ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
-                    let first_number := M.copy (| γ0_0 |) in
-                    first_number));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
-                    let e := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let first_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                      [ M.read (| first_number_str |) ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
+                        let first_number := M.copy (| γ0_0 |) in
+                        first_number));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
+                        let e := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)))
-              ]
-            |)
-          |) in
-        let second_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                  [ M.read (| second_number_str |) ]
+                        |)))
+                  ]
                 |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
-                    let second_number := M.copy (| γ0_0 |) in
-                    second_number));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
-                    let e := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
+              |) in
+            let second_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                      [ M.read (| second_number_str |) ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
+                        let second_number := M.copy (| γ0_0 |) in
+                        second_number));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
+                        let e := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)))
-              ]
+                        |)))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
+                [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
             |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
@@ -15,156 +15,159 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
     ltac:(M.monadic
       (let first_number_str := M.alloc (| first_number_str |) in
       let second_number_str := M.alloc (| second_number_str |) in
-      M.read (|
-        let first_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                    [],
-                    "branch",
-                    []
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let first_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                          [ M.read (| first_number_str |) ]
+                        |)
+                      ]
+                    |)
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                      [ M.read (| first_number_str |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "core::num::error::ParseIntError"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "core::num::error::ParseIntError"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            let second_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                          [ M.read (| second_number_str |) ]
                         |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |)
-          |) in
-        let second_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                    [],
-                    "branch",
-                    []
+                      ]
+                    |)
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                      [ M.read (| second_number_str |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "core::num::error::ParseIntError"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "core::num::error::ParseIntError"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
+                [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
             |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
@@ -15,120 +15,123 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
     ltac:(M.monadic
       (let first_number_str := M.alloc (| first_number_str |) in
       let second_number_str := M.alloc (| second_number_str |) in
-      M.read (|
-        let first_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                  [ M.read (| first_number_str |) ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
-                    let err := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::From",
-                                    Ty.path "core::num::error::ParseIntError",
-                                    [ Ty.path "core::num::error::ParseIntError" ],
-                                    "from",
-                                    []
-                                  |),
-                                  [ M.read (| err |) ]
-                                |)
-                              ]
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let first_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                      [ M.read (| first_number_str |) ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
+                        let err := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::From",
+                                        Ty.path "core::num::error::ParseIntError",
+                                        [ Ty.path "core::num::error::ParseIntError" ],
+                                        "from",
+                                        []
+                                      |),
+                                      [ M.read (| err |) ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)))
-              ]
-            |)
-          |) in
-        let second_number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                  [ M.read (| second_number_str |) ]
+                        |)))
+                  ]
                 |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
-                    let err := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple
-                              "core::result::Result::Err"
-                              [
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::convert::From",
-                                    Ty.path "core::num::error::ParseIntError",
-                                    [ Ty.path "core::num::error::ParseIntError" ],
-                                    "from",
-                                    []
-                                  |),
-                                  [ M.read (| err |) ]
-                                |)
-                              ]
+              |) in
+            let second_number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                      [ M.read (| second_number_str |) ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
+                        let err := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple
+                                  "core::result::Result::Err"
+                                  [
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::convert::From",
+                                        Ty.path "core::num::error::ParseIntError",
+                                        [ Ty.path "core::num::error::ParseIntError" ],
+                                        "from",
+                                        []
+                                      |),
+                                      [ M.read (| err |) ]
+                                    |)
+                                  ]
+                              |)
+                            |)
                           |)
-                        |)
-                      |)
-                    |)))
-              ]
+                        |)))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
+                [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
             |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [ BinOp.Panic.mul (| M.read (| first_number |), M.read (| second_number |) |) ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
@@ -105,207 +105,213 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
   | [], [ vec ] =>
     ltac:(M.monadic
       (let vec := M.alloc (| vec |) in
-      M.read (|
-        let first :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [
-                        Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ];
-                        Ty.path "other_uses_of_question_mark::EmptyVec"
-                      ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let first :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
                         Ty.apply
-                          (Ty.path "core::option::Option")
-                          [ Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ] ],
-                        "ok_or",
-                        [ Ty.path "other_uses_of_question_mark::EmptyVec" ]
+                          (Ty.path "core::result::Result")
+                          [
+                            Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ];
+                            Ty.path "other_uses_of_question_mark::EmptyVec"
+                          ],
+                        [],
+                        "branch",
+                        []
                       |),
                       [
                         M.call_closure (|
                           M.get_associated_function (|
-                            Ty.apply (Ty.path "slice") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ],
-                            "first",
-                            []
+                            Ty.apply
+                              (Ty.path "core::option::Option")
+                              [ Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
+                              ],
+                            "ok_or",
+                            [ Ty.path "other_uses_of_question_mark::EmptyVec" ]
                           |),
                           [
                             M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::deref::Deref",
+                              M.get_associated_function (|
                                 Ty.apply
-                                  (Ty.path "alloc::vec::Vec")
-                                  [
-                                    Ty.apply (Ty.path "&") [ Ty.path "str" ];
-                                    Ty.path "alloc::alloc::Global"
-                                  ],
-                                [],
-                                "deref",
+                                  (Ty.path "slice")
+                                  [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ],
+                                "first",
                                 []
                               |),
-                              [ vec ]
-                            |)
+                              [
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::deref::Deref",
+                                    Ty.apply
+                                      (Ty.path "alloc::vec::Vec")
+                                      [
+                                        Ty.apply (Ty.path "&") [ Ty.path "str" ];
+                                        Ty.path "alloc::alloc::Global"
+                                      ],
+                                    [],
+                                    "deref",
+                                    []
+                                  |),
+                                  [ vec ]
+                                |)
+                              ]
+                            |);
+                            Value.StructTuple "other_uses_of_question_mark::EmptyVec" []
                           ]
-                        |);
-                        Value.StructTuple "other_uses_of_question_mark::EmptyVec" []
+                        |)
                       ]
                     |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [
-                                    Ty.path "i32";
-                                    Ty.apply
-                                      (Ty.path "alloc::boxed::Box")
-                                      [
-                                        Ty.dyn [ ("core::error::Error::Trait", []) ];
-                                        Ty.path "alloc::alloc::Global"
-                                      ]
-                                  ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "other_uses_of_question_mark::EmptyVec"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |)
-          |) in
-        let parsed :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                    [],
-                    "branch",
-                    []
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                      [ M.read (| M.read (| first |) |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [
-                                    Ty.path "i32";
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
                                     Ty.apply
-                                      (Ty.path "alloc::boxed::Box")
+                                      (Ty.path "core::result::Result")
                                       [
-                                        Ty.dyn [ ("core::error::Error::Trait", []) ];
-                                        Ty.path "alloc::alloc::Global"
-                                      ]
-                                  ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                                        Ty.path "i32";
+                                        Ty.apply
+                                          (Ty.path "alloc::boxed::Box")
+                                          [
+                                            Ty.dyn [ ("core::error::Error::Trait", []) ];
+                                            Ty.path "alloc::alloc::Global"
+                                          ]
+                                      ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "core::num::error::ParseIntError"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "other_uses_of_question_mark::EmptyVec"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            let parsed :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                          [ M.read (| M.read (| first |) |) ]
                         |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [
+                                        Ty.path "i32";
+                                        Ty.apply
+                                          (Ty.path "alloc::boxed::Box")
+                                          [
+                                            Ty.dyn [ ("core::error::Error::Trait", []) ];
+                                            Ty.path "alloc::alloc::Global"
+                                          ]
+                                      ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "core::num::error::ParseIntError"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
+                [ BinOp.Panic.mul (| Value.Integer Integer.I32 2, M.read (| parsed |) |) ]
             |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [ BinOp.Panic.mul (| Value.Integer Integer.I32 2, M.read (| parsed |) |) ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
@@ -16,87 +16,94 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
   match τ, α with
   | [], [] =>
     ltac:(M.monadic
-      (M.read (|
-        let number_str := M.copy (| Value.String "10" |) in
-        let number :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                  [ M.read (| number_str |) ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
-                    let number := M.copy (| γ0_0 |) in
-                    number));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
-                    let e := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
-                          |)
-                        |)
-                      |)
-                    |)))
-              ]
-            |)
-          |) in
-        let _ :=
-          let _ :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_function (| "std::io::stdio::_print", [] |),
-                [
-                  M.call_closure (|
-                    M.get_associated_function (| Ty.path "core::fmt::Arguments", "new_v1", [] |),
-                    [
-                      (* Unsize *)
-                      M.pointer_coercion
-                        (M.alloc (|
-                          Value.Array
-                            [ M.read (| Value.String "" |); M.read (| Value.String "
-" |) ]
-                        |));
-                      (* Unsize *)
-                      M.pointer_coercion
-                        (M.alloc (|
-                          Value.Array
-                            [
-                              M.call_closure (|
-                                M.get_associated_function (|
-                                  Ty.path "core::fmt::rt::Argument",
-                                  "new_display",
-                                  [ Ty.path "i32" ]
-                                |),
-                                [ number ]
+      (M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let number_str := M.copy (| Value.String "10" |) in
+            let number :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                      [ M.read (| number_str |) ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
+                        let number := M.copy (| γ0_0 |) in
+                        number));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
+                        let e := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
                               |)
-                            ]
-                        |))
+                            |)
+                          |)
+                        |)))
+                  ]
+                |)
+              |) in
+            let _ :=
+              let _ :=
+                M.alloc (|
+                  M.call_closure (|
+                    M.get_function (| "std::io::stdio::_print", [] |),
+                    [
+                      M.call_closure (|
+                        M.get_associated_function (|
+                          Ty.path "core::fmt::Arguments",
+                          "new_v1",
+                          []
+                        |),
+                        [
+                          (* Unsize *)
+                          M.pointer_coercion
+                            (M.alloc (|
+                              Value.Array
+                                [ M.read (| Value.String "" |); M.read (| Value.String "
+" |) ]
+                            |));
+                          (* Unsize *)
+                          M.pointer_coercion
+                            (M.alloc (|
+                              Value.Array
+                                [
+                                  M.call_closure (|
+                                    M.get_associated_function (|
+                                      Ty.path "core::fmt::rt::Argument",
+                                      "new_display",
+                                      [ Ty.path "i32" ]
+                                    |),
+                                    [ number ]
+                                  |)
+                                ]
+                            |))
+                        ]
+                      |)
                     ]
                   |)
-                ]
-              |)
-            |) in
-          M.alloc (| Value.Tuple [] |) in
-        M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+                |) in
+              M.alloc (| Value.Tuple [] |) in
+            M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
@@ -127,143 +127,146 @@ Module Impl_unpacking_options_via_question_mark_Person.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (|
-          M.get_struct_record_field
-            (M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::option::Option")
-                      [ Ty.path "unpacking_options_via_question_mark::PhoneNumber" ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
-                    M.read (|
-                      M.get_struct_record_field
-                        (M.match_operator (|
-                          M.alloc (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::Try",
-                                Ty.apply
-                                  (Ty.path "core::option::Option")
-                                  [ Ty.path "unpacking_options_via_question_mark::Job" ],
-                                [],
-                                "branch",
-                                []
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              M.get_struct_record_field
+                (M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::option::Option")
+                          [ Ty.path "unpacking_options_via_question_mark::PhoneNumber" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.read (|
+                          M.get_struct_record_field
+                            (M.match_operator (|
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::Try",
+                                    Ty.apply
+                                      (Ty.path "core::option::Option")
+                                      [ Ty.path "unpacking_options_via_question_mark::Job" ],
+                                    [],
+                                    "branch",
+                                    []
+                                  |),
+                                  [
+                                    M.read (|
+                                      M.get_struct_record_field
+                                        (M.read (| self |))
+                                        "unpacking_options_via_question_mark::Person"
+                                        "job"
+                                    |)
+                                  ]
+                                |)
                               |),
                               [
-                                M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "unpacking_options_via_question_mark::Person"
-                                    "job"
-                                |)
-                              ]
-                            |)
-                          |),
-                          [
-                            fun γ =>
-                              ltac:(M.monadic
-                                (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
-                                    γ,
-                                    "core::ops::control_flow::ControlFlow::Break",
-                                    0
-                                  |) in
-                                let residual := M.copy (| γ0_0 |) in
-                                M.alloc (|
-                                  M.never_to_any (|
-                                    M.read (|
-                                      M.return_ (|
-                                        M.call_closure (|
-                                          M.get_trait_method (|
-                                            "core::ops::try_trait::FromResidual",
-                                            Ty.apply
-                                              (Ty.path "core::option::Option")
-                                              [ Ty.path "u8" ],
-                                            [
-                                              Ty.apply
-                                                (Ty.path "core::option::Option")
-                                                [ Ty.path "core::convert::Infallible" ]
-                                            ],
-                                            "from_residual",
-                                            []
-                                          |),
-                                          [ M.read (| residual |) ]
+                                fun γ =>
+                                  ltac:(M.monadic
+                                    (let γ0_0 :=
+                                      M.get_struct_tuple_field_or_break_match (|
+                                        γ,
+                                        "core::ops::control_flow::ControlFlow::Break",
+                                        0
+                                      |) in
+                                    let residual := M.copy (| γ0_0 |) in
+                                    M.alloc (|
+                                      M.never_to_any (|
+                                        M.read (|
+                                          M.return_ (|
+                                            M.call_closure (|
+                                              M.get_trait_method (|
+                                                "core::ops::try_trait::FromResidual",
+                                                Ty.apply
+                                                  (Ty.path "core::option::Option")
+                                                  [ Ty.path "u8" ],
+                                                [
+                                                  Ty.apply
+                                                    (Ty.path "core::option::Option")
+                                                    [ Ty.path "core::convert::Infallible" ]
+                                                ],
+                                                "from_residual",
+                                                []
+                                              |),
+                                              [ M.read (| residual |) ]
+                                            |)
+                                          |)
                                         |)
                                       |)
-                                    |)
-                                  |)
-                                |)));
-                            fun γ =>
-                              ltac:(M.monadic
-                                (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
-                                    γ,
-                                    "core::ops::control_flow::ControlFlow::Continue",
-                                    0
-                                  |) in
-                                let val := M.copy (| γ0_0 |) in
-                                val))
-                          ]
-                        |))
-                        "unpacking_options_via_question_mark::Job"
-                        "phone_number"
+                                    |)));
+                                fun γ =>
+                                  ltac:(M.monadic
+                                    (let γ0_0 :=
+                                      M.get_struct_tuple_field_or_break_match (|
+                                        γ,
+                                        "core::ops::control_flow::ControlFlow::Continue",
+                                        0
+                                      |) in
+                                    let val := M.copy (| γ0_0 |) in
+                                    val))
+                              ]
+                            |))
+                            "unpacking_options_via_question_mark::Job"
+                            "phone_number"
+                        |)
+                      ]
                     |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply (Ty.path "core::option::Option") [ Ty.path "u8" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::option::Option")
-                                    [ Ty.path "core::convert::Infallible" ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply (Ty.path "core::option::Option") [ Ty.path "u8" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::option::Option")
+                                        [ Ty.path "core::convert::Infallible" ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |))
-            "unpacking_options_via_question_mark::PhoneNumber"
-            "area_code"
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |))
+                "unpacking_options_via_question_mark::PhoneNumber"
+                "area_code"
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
@@ -287,191 +287,197 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
   | [], [ vec ] =>
     ltac:(M.monadic
       (let vec := M.alloc (| vec |) in
-      M.read (|
-        let first :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [
-                        Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ];
-                        Ty.path "wrapping_errors::DoubleError"
-                      ],
-                    [],
-                    "branch",
-                    []
-                  |),
-                  [
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let first :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
                     M.call_closure (|
-                      M.get_associated_function (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
                         Ty.apply
-                          (Ty.path "core::option::Option")
-                          [ Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ] ],
-                        "ok_or",
-                        [ Ty.path "wrapping_errors::DoubleError" ]
+                          (Ty.path "core::result::Result")
+                          [
+                            Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ];
+                            Ty.path "wrapping_errors::DoubleError"
+                          ],
+                        [],
+                        "branch",
+                        []
                       |),
                       [
                         M.call_closure (|
                           M.get_associated_function (|
-                            Ty.apply (Ty.path "slice") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ],
-                            "first",
-                            []
+                            Ty.apply
+                              (Ty.path "core::option::Option")
+                              [ Ty.apply (Ty.path "&") [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
+                              ],
+                            "ok_or",
+                            [ Ty.path "wrapping_errors::DoubleError" ]
                           |),
                           [
                             M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::deref::Deref",
+                              M.get_associated_function (|
                                 Ty.apply
-                                  (Ty.path "alloc::vec::Vec")
-                                  [
-                                    Ty.apply (Ty.path "&") [ Ty.path "str" ];
-                                    Ty.path "alloc::alloc::Global"
-                                  ],
-                                [],
-                                "deref",
+                                  (Ty.path "slice")
+                                  [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ],
+                                "first",
                                 []
                               |),
-                              [ vec ]
-                            |)
+                              [
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::deref::Deref",
+                                    Ty.apply
+                                      (Ty.path "alloc::vec::Vec")
+                                      [
+                                        Ty.apply (Ty.path "&") [ Ty.path "str" ];
+                                        Ty.path "alloc::alloc::Global"
+                                      ],
+                                    [],
+                                    "deref",
+                                    []
+                                  |),
+                                  [ vec ]
+                                |)
+                              ]
+                            |);
+                            Value.StructTuple "wrapping_errors::DoubleError::EmptyVec" []
                           ]
-                        |);
-                        Value.StructTuple "wrapping_errors::DoubleError::EmptyVec" []
+                        |)
                       ]
                     |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.path "i32"; Ty.path "wrapping_errors::DoubleError" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "wrapping_errors::DoubleError"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |)
-          |) in
-        let parsed :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
-                    [],
-                    "branch",
-                    []
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                      [ M.read (| M.read (| first |) |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.path "i32"; Ty.path "wrapping_errors::DoubleError" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.path "i32"; Ty.path "wrapping_errors::DoubleError" ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "core::num::error::ParseIntError"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "wrapping_errors::DoubleError"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            let parsed :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "i32"; Ty.path "core::num::error::ParseIntError" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
+                          [ M.read (| M.read (| first |) |) ]
                         |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.path "i32"; Ty.path "wrapping_errors::DoubleError" ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "core::num::error::ParseIntError"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
+                [ BinOp.Panic.mul (| Value.Integer Integer.I32 2, M.read (| parsed |) |) ]
             |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [ BinOp.Panic.mul (| Value.Integer Integer.I32 2, M.read (| parsed |) |) ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
@@ -18,30 +18,33 @@ Definition is_divisible_by (τ : list Ty.t) (α : list Value.t) : M :=
     ltac:(M.monadic
       (let lhs := M.alloc (| lhs |) in
       let rhs := M.alloc (| rhs |) in
-      M.read (|
-        let _ :=
-          M.match_operator (|
-            M.alloc (| Value.Tuple [] |),
-            [
-              fun γ =>
-                ltac:(M.monadic
-                  (let γ :=
-                    M.use
-                      (M.alloc (|
-                        BinOp.Pure.eq (M.read (| rhs |)) (Value.Integer Integer.U32 0)
-                      |)) in
-                  let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                  M.alloc (|
-                    M.never_to_any (| M.read (| M.return_ (| Value.Bool false |) |) |)
-                  |)));
-              fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-            ]
-          |) in
-        M.alloc (|
-          BinOp.Pure.eq
-            (BinOp.Panic.rem (| M.read (| lhs |), M.read (| rhs |) |))
-            (Value.Integer Integer.U32 0)
-        |)
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let _ :=
+              M.match_operator (|
+                M.alloc (| Value.Tuple [] |),
+                [
+                  fun γ =>
+                    ltac:(M.monadic
+                      (let γ :=
+                        M.use
+                          (M.alloc (|
+                            BinOp.Pure.eq (M.read (| rhs |)) (Value.Integer Integer.U32 0)
+                          |)) in
+                      let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                      M.alloc (|
+                        M.never_to_any (| M.read (| M.return_ (| Value.Bool false |) |) |)
+                      |)));
+                  fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                ]
+              |) in
+            M.alloc (|
+              BinOp.Pure.eq
+                (BinOp.Panic.rem (| M.read (| lhs |), M.read (| rhs |) |))
+                (Value.Integer Integer.U32 0)
+            |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
@@ -251,173 +251,182 @@ Module checked.
       ltac:(M.monadic
         (let x := M.alloc (| x |) in
         let y := M.alloc (| y |) in
-        M.read (|
-          let ratio :=
-            M.copy (|
-              M.match_operator (|
-                M.alloc (|
-                  M.call_closure (|
-                    M.get_trait_method (|
-                      "core::ops::try_trait::Try",
-                      Ty.apply
-                        (Ty.path "core::result::Result")
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let ratio :=
+                M.copy (|
+                  M.match_operator (|
+                    M.alloc (|
+                      M.call_closure (|
+                        M.get_trait_method (|
+                          "core::ops::try_trait::Try",
+                          Ty.apply
+                            (Ty.path "core::result::Result")
+                            [
+                              Ty.path "f64";
+                              Ty.path "result_chaining_with_question_mark::checked::MathError"
+                            ],
+                          [],
+                          "branch",
+                          []
+                        |),
                         [
-                          Ty.path "f64";
-                          Ty.path "result_chaining_with_question_mark::checked::MathError"
-                        ],
-                      [],
-                      "branch",
-                      []
+                          M.call_closure (|
+                            M.get_function (|
+                              "result_chaining_with_question_mark::checked::div",
+                              []
+                            |),
+                            [ M.read (| x |); M.read (| y |) ]
+                          |)
+                        ]
+                      |)
                     |),
                     [
-                      M.call_closure (|
-                        M.get_function (| "result_chaining_with_question_mark::checked::div", [] |),
-                        [ M.read (| x |); M.read (| y |) ]
-                      |)
-                    ]
-                  |)
-                |),
-                [
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::ops::control_flow::ControlFlow::Break",
-                          0
-                        |) in
-                      let residual := M.copy (| γ0_0 |) in
-                      M.alloc (|
-                        M.never_to_any (|
-                          M.read (|
-                            M.return_ (|
-                              M.call_closure (|
-                                M.get_trait_method (|
-                                  "core::ops::try_trait::FromResidual",
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "f64";
-                                      Ty.path
-                                        "result_chaining_with_question_mark::checked::MathError"
-                                    ],
-                                  [
-                                    Ty.apply
-                                      (Ty.path "core::result::Result")
+                      fun γ =>
+                        ltac:(M.monadic
+                          (let γ0_0 :=
+                            M.get_struct_tuple_field_or_break_match (|
+                              γ,
+                              "core::ops::control_flow::ControlFlow::Break",
+                              0
+                            |) in
+                          let residual := M.copy (| γ0_0 |) in
+                          M.alloc (|
+                            M.never_to_any (|
+                              M.read (|
+                                M.return_ (|
+                                  M.call_closure (|
+                                    M.get_trait_method (|
+                                      "core::ops::try_trait::FromResidual",
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "f64";
+                                          Ty.path
+                                            "result_chaining_with_question_mark::checked::MathError"
+                                        ],
                                       [
-                                        Ty.path "core::convert::Infallible";
-                                        Ty.path
-                                          "result_chaining_with_question_mark::checked::MathError"
-                                      ]
-                                  ],
-                                  "from_residual",
-                                  []
-                                |),
-                                [ M.read (| residual |) ]
+                                        Ty.apply
+                                          (Ty.path "core::result::Result")
+                                          [
+                                            Ty.path "core::convert::Infallible";
+                                            Ty.path
+                                              "result_chaining_with_question_mark::checked::MathError"
+                                          ]
+                                      ],
+                                      "from_residual",
+                                      []
+                                    |),
+                                    [ M.read (| residual |) ]
+                                  |)
+                                |)
                               |)
                             |)
-                          |)
-                        |)
-                      |)));
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::ops::control_flow::ControlFlow::Continue",
-                          0
-                        |) in
-                      let val := M.copy (| γ0_0 |) in
-                      val))
-                ]
-              |)
-            |) in
-          let ln :=
-            M.copy (|
-              M.match_operator (|
-                M.alloc (|
-                  M.call_closure (|
-                    M.get_trait_method (|
-                      "core::ops::try_trait::Try",
-                      Ty.apply
-                        (Ty.path "core::result::Result")
+                          |)));
+                      fun γ =>
+                        ltac:(M.monadic
+                          (let γ0_0 :=
+                            M.get_struct_tuple_field_or_break_match (|
+                              γ,
+                              "core::ops::control_flow::ControlFlow::Continue",
+                              0
+                            |) in
+                          let val := M.copy (| γ0_0 |) in
+                          val))
+                    ]
+                  |)
+                |) in
+              let ln :=
+                M.copy (|
+                  M.match_operator (|
+                    M.alloc (|
+                      M.call_closure (|
+                        M.get_trait_method (|
+                          "core::ops::try_trait::Try",
+                          Ty.apply
+                            (Ty.path "core::result::Result")
+                            [
+                              Ty.path "f64";
+                              Ty.path "result_chaining_with_question_mark::checked::MathError"
+                            ],
+                          [],
+                          "branch",
+                          []
+                        |),
                         [
-                          Ty.path "f64";
-                          Ty.path "result_chaining_with_question_mark::checked::MathError"
-                        ],
-                      [],
-                      "branch",
-                      []
+                          M.call_closure (|
+                            M.get_function (|
+                              "result_chaining_with_question_mark::checked::ln",
+                              []
+                            |),
+                            [ M.read (| ratio |) ]
+                          |)
+                        ]
+                      |)
                     |),
                     [
-                      M.call_closure (|
-                        M.get_function (| "result_chaining_with_question_mark::checked::ln", [] |),
-                        [ M.read (| ratio |) ]
-                      |)
-                    ]
-                  |)
-                |),
-                [
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::ops::control_flow::ControlFlow::Break",
-                          0
-                        |) in
-                      let residual := M.copy (| γ0_0 |) in
-                      M.alloc (|
-                        M.never_to_any (|
-                          M.read (|
-                            M.return_ (|
-                              M.call_closure (|
-                                M.get_trait_method (|
-                                  "core::ops::try_trait::FromResidual",
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "f64";
-                                      Ty.path
-                                        "result_chaining_with_question_mark::checked::MathError"
-                                    ],
-                                  [
-                                    Ty.apply
-                                      (Ty.path "core::result::Result")
+                      fun γ =>
+                        ltac:(M.monadic
+                          (let γ0_0 :=
+                            M.get_struct_tuple_field_or_break_match (|
+                              γ,
+                              "core::ops::control_flow::ControlFlow::Break",
+                              0
+                            |) in
+                          let residual := M.copy (| γ0_0 |) in
+                          M.alloc (|
+                            M.never_to_any (|
+                              M.read (|
+                                M.return_ (|
+                                  M.call_closure (|
+                                    M.get_trait_method (|
+                                      "core::ops::try_trait::FromResidual",
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "f64";
+                                          Ty.path
+                                            "result_chaining_with_question_mark::checked::MathError"
+                                        ],
                                       [
-                                        Ty.path "core::convert::Infallible";
-                                        Ty.path
-                                          "result_chaining_with_question_mark::checked::MathError"
-                                      ]
-                                  ],
-                                  "from_residual",
-                                  []
-                                |),
-                                [ M.read (| residual |) ]
+                                        Ty.apply
+                                          (Ty.path "core::result::Result")
+                                          [
+                                            Ty.path "core::convert::Infallible";
+                                            Ty.path
+                                              "result_chaining_with_question_mark::checked::MathError"
+                                          ]
+                                      ],
+                                      "from_residual",
+                                      []
+                                    |),
+                                    [ M.read (| residual |) ]
+                                  |)
+                                |)
                               |)
                             |)
-                          |)
-                        |)
-                      |)));
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::ops::control_flow::ControlFlow::Continue",
-                          0
-                        |) in
-                      let val := M.copy (| γ0_0 |) in
-                      val))
-                ]
+                          |)));
+                      fun γ =>
+                        ltac:(M.monadic
+                          (let γ0_0 :=
+                            M.get_struct_tuple_field_or_break_match (|
+                              γ,
+                              "core::ops::control_flow::ControlFlow::Continue",
+                              0
+                            |) in
+                          let val := M.copy (| γ0_0 |) in
+                          val))
+                    ]
+                  |)
+                |) in
+              M.alloc (|
+                M.call_closure (|
+                  M.get_function (| "result_chaining_with_question_mark::checked::sqrt", [] |),
+                  [ M.read (| ln |) ]
+                |)
               |)
-            |) in
-          M.alloc (|
-            M.call_closure (|
-              M.get_function (| "result_chaining_with_question_mark::checked::sqrt", [] |),
-              [ M.read (| ln |) ]
-            |)
-          |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
@@ -14,56 +14,59 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
   | [], [ filename ] =>
     ltac:(M.monadic
       (let filename := M.alloc (| filename |) in
-      M.never_to_any (|
-        M.read (|
-          let file :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (|
-                  Ty.apply
-                    (Ty.path "core::result::Result")
-                    [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
-                  "unwrap",
-                  []
-                |),
-                [
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.never_to_any (|
+            M.read (|
+              let file :=
+                M.alloc (|
                   M.call_closure (|
                     M.get_associated_function (|
-                      Ty.path "std::fs::File",
-                      "open",
-                      [ Ty.path "alloc::string::String" ]
+                      Ty.apply
+                        (Ty.path "core::result::Result")
+                        [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
+                      "unwrap",
+                      []
                     |),
-                    [ M.read (| filename |) ]
+                    [
+                      M.call_closure (|
+                        M.get_associated_function (|
+                          Ty.path "std::fs::File",
+                          "open",
+                          [ Ty.path "alloc::string::String" ]
+                        |),
+                        [ M.read (| filename |) ]
+                      |)
+                    ]
                   |)
-                ]
-              |)
-            |) in
-          M.return_ (|
-            M.call_closure (|
-              M.get_trait_method (|
-                "std::io::BufRead",
-                Ty.apply
-                  (Ty.path "std::io::buffered::bufreader::BufReader")
-                  [ Ty.path "std::fs::File" ],
-                [],
-                "lines",
-                []
-              |),
-              [
+                |) in
+              M.return_ (|
                 M.call_closure (|
-                  M.get_associated_function (|
+                  M.get_trait_method (|
+                    "std::io::BufRead",
                     Ty.apply
                       (Ty.path "std::io::buffered::bufreader::BufReader")
                       [ Ty.path "std::fs::File" ],
-                    "new",
+                    [],
+                    "lines",
                     []
                   |),
-                  [ M.read (| file |) ]
+                  [
+                    M.call_closure (|
+                      M.get_associated_function (|
+                        Ty.apply
+                          (Ty.path "std::io::buffered::bufreader::BufReader")
+                          [ Ty.path "std::fs::File" ],
+                        "new",
+                        []
+                      |),
+                      [ M.read (| file |) ]
+                    |)
+                  ]
                 |)
-              ]
+              |)
             |)
-          |)
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
@@ -15,117 +15,120 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
   | [ P ], [ filename ] =>
     ltac:(M.monadic
       (let filename := M.alloc (| filename |) in
-      M.read (|
-        let file :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
-                    [],
-                    "branch",
-                    []
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let file :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (| Ty.path "std::fs::File", "open", [ P ] |),
+                          [ M.read (| filename |) ]
+                        |)
+                      ]
+                    |)
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "std::fs::File", "open", [ P ] |),
-                      [ M.read (| filename |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
                                     Ty.apply
-                                      (Ty.path "std::io::Lines")
+                                      (Ty.path "core::result::Result")
                                       [
                                         Ty.apply
-                                          (Ty.path "std::io::buffered::bufreader::BufReader")
-                                          [ Ty.path "std::fs::File" ]
-                                      ];
-                                    Ty.path "std::io::error::Error"
-                                  ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                                          (Ty.path "std::io::Lines")
+                                          [
+                                            Ty.apply
+                                              (Ty.path "std::io::buffered::bufreader::BufReader")
+                                              [ Ty.path "std::fs::File" ]
+                                          ];
+                                        Ty.path "std::io::error::Error"
+                                      ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "std::io::error::Error"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "std::io::error::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |)
-          |) in
-        M.alloc (|
-          Value.StructTuple
-            "core::result::Result::Ok"
-            [
-              M.call_closure (|
-                M.get_trait_method (|
-                  "std::io::BufRead",
-                  Ty.apply
-                    (Ty.path "std::io::buffered::bufreader::BufReader")
-                    [ Ty.path "std::fs::File" ],
-                  [],
-                  "lines",
-                  []
-                |),
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            M.alloc (|
+              Value.StructTuple
+                "core::result::Result::Ok"
                 [
                   M.call_closure (|
-                    M.get_associated_function (|
+                    M.get_trait_method (|
+                      "std::io::BufRead",
                       Ty.apply
                         (Ty.path "std::io::buffered::bufreader::BufReader")
                         [ Ty.path "std::fs::File" ],
-                      "new",
+                      [],
+                      "lines",
                       []
                     |),
-                    [ M.read (| file |) ]
+                    [
+                      M.call_closure (|
+                        M.get_associated_function (|
+                          Ty.apply
+                            (Ty.path "std::io::buffered::bufreader::BufReader")
+                            [ Ty.path "std::fs::File" ],
+                          "new",
+                          []
+                        |),
+                        [ M.read (| file |) ]
+                      |)
+                    ]
                   |)
                 ]
-              |)
-            ]
-        |)
+            |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
@@ -16,31 +16,106 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
   | [], [ path ] =>
     ltac:(M.monadic
       (let path := M.alloc (| path |) in
-      M.read (|
-        let f :=
-          M.copy (|
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let f :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "std::fs::File",
+                            "open",
+                            [ Ty.apply (Ty.path "&") [ Ty.path "std::path::Path" ] ]
+                          |),
+                          [ M.read (| path |) ]
+                        |)
+                      ]
+                    |)
+                  |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [
+                                        Ty.path "alloc::string::String";
+                                        Ty.path "std::io::error::Error"
+                                      ],
+                                    [
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "std::io::error::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            let s :=
+              M.alloc (|
+                M.call_closure (|
+                  M.get_associated_function (| Ty.path "alloc::string::String", "new", [] |),
+                  []
+                |)
+              |) in
             M.match_operator (|
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
+                    "std::io::Read",
+                    Ty.path "std::fs::File",
                     [],
-                    "branch",
+                    "read_to_string",
                     []
                   |),
-                  [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "std::fs::File",
-                        "open",
-                        [ Ty.apply (Ty.path "&") [ Ty.path "std::path::Path" ] ]
-                      |),
-                      [ M.read (| path |) ]
-                    |)
-                  ]
+                  [ f; s ]
                 |)
               |),
               [
@@ -49,85 +124,23 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
                     (let γ0_0 :=
                       M.get_struct_tuple_field_or_break_match (|
                         γ,
-                        "core::ops::control_flow::ControlFlow::Break",
+                        "core::result::Result::Ok",
                         0
                       |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.path "alloc::string::String"; Ty.path "std::io::error::Error"
-                                  ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
-                                    [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "std::io::error::Error"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
-                            |)
-                          |)
-                        |)
-                      |)
-                    |)));
+                    M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| s |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
                       M.get_struct_tuple_field_or_break_match (|
                         γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
+                        "core::result::Result::Err",
                         0
                       |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
+                    let e := M.copy (| γ0_0 |) in
+                    M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
             |)
-          |) in
-        let s :=
-          M.alloc (|
-            M.call_closure (|
-              M.get_associated_function (| Ty.path "alloc::string::String", "new", [] |),
-              []
-            |)
-          |) in
-        M.match_operator (|
-          M.alloc (|
-            M.call_closure (|
-              M.get_trait_method (|
-                "std::io::Read",
-                Ty.path "std::fs::File",
-                [],
-                "read_to_string",
-                []
-              |),
-              [ f; s ]
-            |)
-          |),
-          [
-            fun γ =>
-              ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
-                M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| s |) ] |)));
-            fun γ =>
-              ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
-                let e := M.copy (| γ0_0 |) in
-                M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
-          ]
-        |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.
@@ -145,95 +158,104 @@ Definition echo (τ : list Ty.t) (α : list Value.t) : M :=
     ltac:(M.monadic
       (let s := M.alloc (| s |) in
       let path := M.alloc (| path |) in
-      M.read (|
-        let f :=
-          M.copy (|
-            M.match_operator (|
-              M.alloc (|
-                M.call_closure (|
-                  M.get_trait_method (|
-                    "core::ops::try_trait::Try",
-                    Ty.apply
-                      (Ty.path "core::result::Result")
-                      [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
-                    [],
-                    "branch",
-                    []
+      M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let f :=
+              M.copy (|
+                M.match_operator (|
+                  M.alloc (|
+                    M.call_closure (|
+                      M.get_trait_method (|
+                        "core::ops::try_trait::Try",
+                        Ty.apply
+                          (Ty.path "core::result::Result")
+                          [ Ty.path "std::fs::File"; Ty.path "std::io::error::Error" ],
+                        [],
+                        "branch",
+                        []
+                      |),
+                      [
+                        M.call_closure (|
+                          M.get_associated_function (|
+                            Ty.path "std::fs::File",
+                            "create",
+                            [ Ty.apply (Ty.path "&") [ Ty.path "std::path::Path" ] ]
+                          |),
+                          [ M.read (| path |) ]
+                        |)
+                      ]
+                    |)
                   |),
                   [
-                    M.call_closure (|
-                      M.get_associated_function (|
-                        Ty.path "std::fs::File",
-                        "create",
-                        [ Ty.apply (Ty.path "&") [ Ty.path "std::path::Path" ] ]
-                      |),
-                      [ M.read (| path |) ]
-                    |)
-                  ]
-                |)
-              |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Break",
-                        0
-                      |) in
-                    let residual := M.copy (| γ0_0 |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::try_trait::FromResidual",
-                                Ty.apply
-                                  (Ty.path "core::result::Result")
-                                  [ Ty.tuple []; Ty.path "std::io::error::Error" ],
-                                [
-                                  Ty.apply
-                                    (Ty.path "core::result::Result")
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Break",
+                            0
+                          |) in
+                        let residual := M.copy (| γ0_0 |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::try_trait::FromResidual",
+                                    Ty.apply
+                                      (Ty.path "core::result::Result")
+                                      [ Ty.tuple []; Ty.path "std::io::error::Error" ],
                                     [
-                                      Ty.path "core::convert::Infallible";
-                                      Ty.path "std::io::error::Error"
-                                    ]
-                                ],
-                                "from_residual",
-                                []
-                              |),
-                              [ M.read (| residual |) ]
+                                      Ty.apply
+                                        (Ty.path "core::result::Result")
+                                        [
+                                          Ty.path "core::convert::Infallible";
+                                          Ty.path "std::io::error::Error"
+                                        ]
+                                    ],
+                                    "from_residual",
+                                    []
+                                  |),
+                                  [ M.read (| residual |) ]
+                                |)
+                              |)
                             |)
                           |)
-                        |)
-                      |)
-                    |)));
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::ops::control_flow::ControlFlow::Continue",
-                        0
-                      |) in
-                    let val := M.copy (| γ0_0 |) in
-                    val))
-              ]
-            |)
-          |) in
-        M.alloc (|
-          M.call_closure (|
-            M.get_trait_method (| "std::io::Write", Ty.path "std::fs::File", [], "write_all", [] |),
-            [
-              f;
+                        |)));
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ0_0 :=
+                          M.get_struct_tuple_field_or_break_match (|
+                            γ,
+                            "core::ops::control_flow::ControlFlow::Continue",
+                            0
+                          |) in
+                        let val := M.copy (| γ0_0 |) in
+                        val))
+                  ]
+                |)
+              |) in
+            M.alloc (|
               M.call_closure (|
-                M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
-                [ M.read (| s |) ]
+                M.get_trait_method (|
+                  "std::io::Write",
+                  Ty.path "std::fs::File",
+                  [],
+                  "write_all",
+                  []
+                |),
+                [
+                  f;
+                  M.call_closure (|
+                    M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
+                    [ M.read (| s |) ]
+                  |)
+                ]
               |)
-            ]
-          |)
-        |)
+            |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
@@ -222,223 +222,86 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
   match τ, α with
   | [], [] =>
     ltac:(M.monadic
-      (M.read (|
-        let args :=
-          M.alloc (|
-            M.call_closure (|
-              M.get_trait_method (|
-                "core::iter::traits::iterator::Iterator",
-                Ty.path "std::env::Args",
-                [],
-                "collect",
-                [
-                  Ty.apply
-                    (Ty.path "alloc::vec::Vec")
-                    [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ]
-                ]
+      (M.catch_return (|
+        ltac:(M.monadic
+          (M.read (|
+            let args :=
+              M.alloc (|
+                M.call_closure (|
+                  M.get_trait_method (|
+                    "core::iter::traits::iterator::Iterator",
+                    Ty.path "std::env::Args",
+                    [],
+                    "collect",
+                    [
+                      Ty.apply
+                        (Ty.path "alloc::vec::Vec")
+                        [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ]
+                    ]
+                  |),
+                  [ M.call_closure (| M.get_function (| "std::env::args", [] |), [] |) ]
+                |)
+              |) in
+            M.match_operator (|
+              M.alloc (|
+                M.call_closure (|
+                  M.get_associated_function (|
+                    Ty.apply
+                      (Ty.path "alloc::vec::Vec")
+                      [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
+                    "len",
+                    []
+                  |),
+                  [ args ]
+                |)
               |),
-              [ M.call_closure (| M.get_function (| "std::env::args", [] |), [] |) ]
-            |)
-          |) in
-        M.match_operator (|
-          M.alloc (|
-            M.call_closure (|
-              M.get_associated_function (|
-                Ty.apply
-                  (Ty.path "alloc::vec::Vec")
-                  [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
-                "len",
-                []
-              |),
-              [ args ]
-            |)
-          |),
-          [
-            fun γ =>
-              ltac:(M.monadic
-                (let _ :=
-                  M.is_constant_or_break_match (|
-                    M.read (| γ |),
-                    Value.Integer Integer.Usize 1
-                  |) in
-                let _ :=
-                  let _ :=
-                    M.alloc (|
-                      M.call_closure (|
-                        M.get_function (| "std::io::stdio::_print", [] |),
-                        [
+              [
+                fun γ =>
+                  ltac:(M.monadic
+                    (let _ :=
+                      M.is_constant_or_break_match (|
+                        M.read (| γ |),
+                        Value.Integer Integer.Usize 1
+                      |) in
+                    let _ :=
+                      let _ :=
+                        M.alloc (|
                           M.call_closure (|
-                            M.get_associated_function (|
-                              Ty.path "core::fmt::Arguments",
-                              "new_const",
-                              []
-                            |),
+                            M.get_function (| "std::io::stdio::_print", [] |),
                             [
-                              (* Unsize *)
-                              M.pointer_coercion
-                                (M.alloc (|
-                                  Value.Array
-                                    [
-                                      M.read (|
-                                        Value.String
-                                          "My name is 'match_args'. Try passing some arguments!
+                              M.call_closure (|
+                                M.get_associated_function (|
+                                  Ty.path "core::fmt::Arguments",
+                                  "new_const",
+                                  []
+                                |),
+                                [
+                                  (* Unsize *)
+                                  M.pointer_coercion
+                                    (M.alloc (|
+                                      Value.Array
+                                        [
+                                          M.read (|
+                                            Value.String
+                                              "My name is 'match_args'. Try passing some arguments!
 "
-                                      |)
-                                    ]
-                                |))
+                                          |)
+                                        ]
+                                    |))
+                                ]
+                              |)
                             ]
                           |)
-                        ]
-                      |)
-                    |) in
-                  M.alloc (| Value.Tuple [] |) in
-                M.alloc (| Value.Tuple [] |)));
-            fun γ =>
-              ltac:(M.monadic
-                (let _ :=
-                  M.is_constant_or_break_match (|
-                    M.read (| γ |),
-                    Value.Integer Integer.Usize 2
-                  |) in
-                M.match_operator (|
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_associated_function (| Ty.path "str", "parse", [ Ty.path "i32" ] |),
-                      [
-                        M.call_closure (|
-                          M.get_trait_method (|
-                            "core::ops::deref::Deref",
-                            Ty.path "alloc::string::String",
-                            [],
-                            "deref",
-                            []
-                          |),
-                          [
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::ops::index::Index",
-                                Ty.apply
-                                  (Ty.path "alloc::vec::Vec")
-                                  [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global"
-                                  ],
-                                [ Ty.path "usize" ],
-                                "index",
-                                []
-                              |),
-                              [ args; Value.Integer Integer.Usize 1 ]
-                            |)
-                          ]
-                        |)
-                      ]
-                    |)
-                  |),
-                  [
-                    fun γ =>
-                      ltac:(M.monadic
-                        (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
-                        let _ :=
-                          M.is_constant_or_break_match (|
-                            M.read (| γ0_0 |),
-                            Value.Integer Integer.I32 42
-                          |) in
-                        let _ :=
-                          M.alloc (|
-                            M.call_closure (|
-                              M.get_function (| "std::io::stdio::_print", [] |),
-                              [
-                                M.call_closure (|
-                                  M.get_associated_function (|
-                                    Ty.path "core::fmt::Arguments",
-                                    "new_const",
-                                    []
-                                  |),
-                                  [
-                                    (* Unsize *)
-                                    M.pointer_coercion
-                                      (M.alloc (|
-                                        Value.Array
-                                          [ M.read (| Value.String "This is the answer!
-" |) ]
-                                      |))
-                                  ]
-                                |)
-                              ]
-                            |)
-                          |) in
-                        M.alloc (| Value.Tuple [] |)));
-                    fun γ =>
-                      ltac:(M.monadic
-                        (let _ :=
-                          M.alloc (|
-                            M.call_closure (|
-                              M.get_function (| "std::io::stdio::_print", [] |),
-                              [
-                                M.call_closure (|
-                                  M.get_associated_function (|
-                                    Ty.path "core::fmt::Arguments",
-                                    "new_const",
-                                    []
-                                  |),
-                                  [
-                                    (* Unsize *)
-                                    M.pointer_coercion
-                                      (M.alloc (|
-                                        Value.Array
-                                          [ M.read (| Value.String "This is not the answer.
-" |) ]
-                                      |))
-                                  ]
-                                |)
-                              ]
-                            |)
-                          |) in
-                        M.alloc (| Value.Tuple [] |)))
-                  ]
-                |)));
-            fun γ =>
-              ltac:(M.monadic
-                (let _ :=
-                  M.is_constant_or_break_match (|
-                    M.read (| γ |),
-                    Value.Integer Integer.Usize 3
-                  |) in
-                let cmd :=
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_trait_method (|
-                        "core::ops::index::Index",
-                        Ty.apply
-                          (Ty.path "alloc::vec::Vec")
-                          [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
-                        [ Ty.path "usize" ],
-                        "index",
-                        []
-                      |),
-                      [ args; Value.Integer Integer.Usize 1 ]
-                    |)
-                  |) in
-                let num :=
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_trait_method (|
-                        "core::ops::index::Index",
-                        Ty.apply
-                          (Ty.path "alloc::vec::Vec")
-                          [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
-                        [ Ty.path "usize" ],
-                        "index",
-                        []
-                      |),
-                      [ args; Value.Integer Integer.Usize 2 ]
-                    |)
-                  |) in
-                let number :=
-                  M.copy (|
+                        |) in
+                      M.alloc (| Value.Tuple [] |) in
+                    M.alloc (| Value.Tuple [] |)));
+                fun γ =>
+                  ltac:(M.monadic
+                    (let _ :=
+                      M.is_constant_or_break_match (|
+                        M.read (| γ |),
+                        Value.Integer Integer.Usize 2
+                      |) in
                     M.match_operator (|
                       M.alloc (|
                         M.call_closure (|
@@ -452,7 +315,23 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                 "deref",
                                 []
                               |),
-                              [ M.read (| num |) ]
+                              [
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::index::Index",
+                                    Ty.apply
+                                      (Ty.path "alloc::vec::Vec")
+                                      [
+                                        Ty.path "alloc::string::String";
+                                        Ty.path "alloc::alloc::Global"
+                                      ],
+                                    [ Ty.path "usize" ],
+                                    "index",
+                                    []
+                                  |),
+                                  [ args; Value.Integer Integer.Usize 1 ]
+                                |)
+                              ]
                             |)
                           ]
                         |)
@@ -466,154 +345,292 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                 "core::result::Result::Ok",
                                 0
                               |) in
-                            let n := M.copy (| γ0_0 |) in
-                            n));
+                            let _ :=
+                              M.is_constant_or_break_match (|
+                                M.read (| γ0_0 |),
+                                Value.Integer Integer.I32 42
+                              |) in
+                            let _ :=
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_function (| "std::io::stdio::_print", [] |),
+                                  [
+                                    M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "core::fmt::Arguments",
+                                        "new_const",
+                                        []
+                                      |),
+                                      [
+                                        (* Unsize *)
+                                        M.pointer_coercion
+                                          (M.alloc (|
+                                            Value.Array
+                                              [ M.read (| Value.String "This is the answer!
+" |) ]
+                                          |))
+                                      ]
+                                    |)
+                                  ]
+                                |)
+                              |) in
+                            M.alloc (| Value.Tuple [] |)));
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
-                                γ,
-                                "core::result::Result::Err",
-                                0
-                              |) in
-                            M.alloc (|
-                              M.never_to_any (|
-                                M.read (|
-                                  let _ :=
-                                    let _ :=
-                                      M.alloc (|
-                                        M.call_closure (|
-                                          M.get_function (| "std::io::stdio::_eprint", [] |),
-                                          [
-                                            M.call_closure (|
-                                              M.get_associated_function (|
-                                                Ty.path "core::fmt::Arguments",
-                                                "new_const",
-                                                []
-                                              |),
-                                              [
-                                                (* Unsize *)
-                                                M.pointer_coercion
-                                                  (M.alloc (|
-                                                    Value.Array
-                                                      [
-                                                        M.read (|
-                                                          Value.String
-                                                            "error: second argument not an integer
-"
-                                                        |)
-                                                      ]
-                                                  |))
-                                              ]
-                                            |)
-                                          ]
-                                        |)
-                                      |) in
-                                    M.alloc (| Value.Tuple [] |) in
-                                  let _ :=
-                                    M.alloc (|
-                                      M.call_closure (|
-                                        M.get_function (| "program_arguments_parsing::help", [] |),
+                            (let _ :=
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_function (| "std::io::stdio::_print", [] |),
+                                  [
+                                    M.call_closure (|
+                                      M.get_associated_function (|
+                                        Ty.path "core::fmt::Arguments",
+                                        "new_const",
                                         []
-                                      |)
-                                    |) in
-                                  M.return_ (| Value.Tuple [] |)
+                                      |),
+                                      [
+                                        (* Unsize *)
+                                        M.pointer_coercion
+                                          (M.alloc (|
+                                            Value.Array
+                                              [ M.read (| Value.String "This is not the answer.
+" |)
+                                              ]
+                                          |))
+                                      ]
+                                    |)
+                                  ]
                                 |)
-                              |)
-                            |)))
+                              |) in
+                            M.alloc (| Value.Tuple [] |)))
                       ]
-                    |)
-                  |) in
-                M.match_operator (|
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_trait_method (|
-                        "core::ops::index::Index",
-                        Ty.path "alloc::string::String",
-                        [ Ty.path "core::ops::range::RangeFull" ],
-                        "index",
-                        []
-                      |),
-                      [ M.read (| cmd |); Value.StructTuple "core::ops::range::RangeFull" [] ]
-                    |)
-                  |),
-                  [
-                    fun γ =>
-                      ltac:(M.monadic
-                        (let _ :=
-                          M.is_constant_or_break_match (|
-                            M.read (| γ |),
-                            Value.String "increase"
-                          |) in
-                        M.alloc (|
-                          M.call_closure (|
-                            M.get_function (| "program_arguments_parsing::increase", [] |),
-                            [ M.read (| number |) ]
-                          |)
-                        |)));
-                    fun γ =>
-                      ltac:(M.monadic
-                        (let _ :=
-                          M.is_constant_or_break_match (|
-                            M.read (| γ |),
-                            Value.String "decrease"
-                          |) in
-                        M.alloc (|
-                          M.call_closure (|
-                            M.get_function (| "program_arguments_parsing::decrease", [] |),
-                            [ M.read (| number |) ]
-                          |)
-                        |)));
-                    fun γ =>
-                      ltac:(M.monadic
-                        (let _ :=
-                          let _ :=
-                            M.alloc (|
-                              M.call_closure (|
-                                M.get_function (| "std::io::stdio::_eprint", [] |),
-                                [
-                                  M.call_closure (|
-                                    M.get_associated_function (|
-                                      Ty.path "core::fmt::Arguments",
-                                      "new_const",
-                                      []
-                                    |),
-                                    [
-                                      (* Unsize *)
-                                      M.pointer_coercion
-                                        (M.alloc (|
-                                          Value.Array
-                                            [ M.read (| Value.String "error: invalid command
-" |) ]
-                                        |))
-                                    ]
-                                  |)
-                                ]
-                              |)
-                            |) in
-                          M.alloc (| Value.Tuple [] |) in
-                        let _ :=
+                    |)));
+                fun γ =>
+                  ltac:(M.monadic
+                    (let _ :=
+                      M.is_constant_or_break_match (|
+                        M.read (| γ |),
+                        Value.Integer Integer.Usize 3
+                      |) in
+                    let cmd :=
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_trait_method (|
+                            "core::ops::index::Index",
+                            Ty.apply
+                              (Ty.path "alloc::vec::Vec")
+                              [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
+                            [ Ty.path "usize" ],
+                            "index",
+                            []
+                          |),
+                          [ args; Value.Integer Integer.Usize 1 ]
+                        |)
+                      |) in
+                    let num :=
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_trait_method (|
+                            "core::ops::index::Index",
+                            Ty.apply
+                              (Ty.path "alloc::vec::Vec")
+                              [ Ty.path "alloc::string::String"; Ty.path "alloc::alloc::Global" ],
+                            [ Ty.path "usize" ],
+                            "index",
+                            []
+                          |),
+                          [ args; Value.Integer Integer.Usize 2 ]
+                        |)
+                      |) in
+                    let number :=
+                      M.copy (|
+                        M.match_operator (|
                           M.alloc (|
                             M.call_closure (|
-                              M.get_function (| "program_arguments_parsing::help", [] |),
-                              []
+                              M.get_associated_function (|
+                                Ty.path "str",
+                                "parse",
+                                [ Ty.path "i32" ]
+                              |),
+                              [
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::ops::deref::Deref",
+                                    Ty.path "alloc::string::String",
+                                    [],
+                                    "deref",
+                                    []
+                                  |),
+                                  [ M.read (| num |) ]
+                                |)
+                              ]
                             |)
-                          |) in
-                        M.alloc (| Value.Tuple [] |)))
-                  ]
-                |)));
-            fun γ =>
-              ltac:(M.monadic
-                (let _ :=
-                  M.alloc (|
-                    M.call_closure (|
-                      M.get_function (| "program_arguments_parsing::help", [] |),
-                      []
-                    |)
-                  |) in
-                M.alloc (| Value.Tuple [] |)))
-          ]
-        |)
+                          |),
+                          [
+                            fun γ =>
+                              ltac:(M.monadic
+                                (let γ0_0 :=
+                                  M.get_struct_tuple_field_or_break_match (|
+                                    γ,
+                                    "core::result::Result::Ok",
+                                    0
+                                  |) in
+                                let n := M.copy (| γ0_0 |) in
+                                n));
+                            fun γ =>
+                              ltac:(M.monadic
+                                (let γ0_0 :=
+                                  M.get_struct_tuple_field_or_break_match (|
+                                    γ,
+                                    "core::result::Result::Err",
+                                    0
+                                  |) in
+                                M.alloc (|
+                                  M.never_to_any (|
+                                    M.read (|
+                                      let _ :=
+                                        let _ :=
+                                          M.alloc (|
+                                            M.call_closure (|
+                                              M.get_function (| "std::io::stdio::_eprint", [] |),
+                                              [
+                                                M.call_closure (|
+                                                  M.get_associated_function (|
+                                                    Ty.path "core::fmt::Arguments",
+                                                    "new_const",
+                                                    []
+                                                  |),
+                                                  [
+                                                    (* Unsize *)
+                                                    M.pointer_coercion
+                                                      (M.alloc (|
+                                                        Value.Array
+                                                          [
+                                                            M.read (|
+                                                              Value.String
+                                                                "error: second argument not an integer
+"
+                                                            |)
+                                                          ]
+                                                      |))
+                                                  ]
+                                                |)
+                                              ]
+                                            |)
+                                          |) in
+                                        M.alloc (| Value.Tuple [] |) in
+                                      let _ :=
+                                        M.alloc (|
+                                          M.call_closure (|
+                                            M.get_function (|
+                                              "program_arguments_parsing::help",
+                                              []
+                                            |),
+                                            []
+                                          |)
+                                        |) in
+                                      M.return_ (| Value.Tuple [] |)
+                                    |)
+                                  |)
+                                |)))
+                          ]
+                        |)
+                      |) in
+                    M.match_operator (|
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_trait_method (|
+                            "core::ops::index::Index",
+                            Ty.path "alloc::string::String",
+                            [ Ty.path "core::ops::range::RangeFull" ],
+                            "index",
+                            []
+                          |),
+                          [ M.read (| cmd |); Value.StructTuple "core::ops::range::RangeFull" [] ]
+                        |)
+                      |),
+                      [
+                        fun γ =>
+                          ltac:(M.monadic
+                            (let _ :=
+                              M.is_constant_or_break_match (|
+                                M.read (| γ |),
+                                Value.String "increase"
+                              |) in
+                            M.alloc (|
+                              M.call_closure (|
+                                M.get_function (| "program_arguments_parsing::increase", [] |),
+                                [ M.read (| number |) ]
+                              |)
+                            |)));
+                        fun γ =>
+                          ltac:(M.monadic
+                            (let _ :=
+                              M.is_constant_or_break_match (|
+                                M.read (| γ |),
+                                Value.String "decrease"
+                              |) in
+                            M.alloc (|
+                              M.call_closure (|
+                                M.get_function (| "program_arguments_parsing::decrease", [] |),
+                                [ M.read (| number |) ]
+                              |)
+                            |)));
+                        fun γ =>
+                          ltac:(M.monadic
+                            (let _ :=
+                              let _ :=
+                                M.alloc (|
+                                  M.call_closure (|
+                                    M.get_function (| "std::io::stdio::_eprint", [] |),
+                                    [
+                                      M.call_closure (|
+                                        M.get_associated_function (|
+                                          Ty.path "core::fmt::Arguments",
+                                          "new_const",
+                                          []
+                                        |),
+                                        [
+                                          (* Unsize *)
+                                          M.pointer_coercion
+                                            (M.alloc (|
+                                              Value.Array
+                                                [
+                                                  M.read (|
+                                                    Value.String "error: invalid command
+"
+                                                  |)
+                                                ]
+                                            |))
+                                        ]
+                                      |)
+                                    ]
+                                  |)
+                                |) in
+                              M.alloc (| Value.Tuple [] |) in
+                            let _ :=
+                              M.alloc (|
+                                M.call_closure (|
+                                  M.get_function (| "program_arguments_parsing::help", [] |),
+                                  []
+                                |)
+                              |) in
+                            M.alloc (| Value.Tuple [] |)))
+                      ]
+                    |)));
+                fun γ =>
+                  ltac:(M.monadic
+                    (let _ :=
+                      M.alloc (|
+                        M.call_closure (|
+                          M.get_function (| "program_arguments_parsing::help", [] |),
+                          []
+                        |)
+                      |) in
+                    M.alloc (| Value.Tuple [] |)))
+              ]
+            |)
+          |)))
       |)))
   | _, _ => M.impossible
   end.

--- a/CoqOfRust/examples/default/examples/subtle.v
+++ b/CoqOfRust/examples/default/examples/subtle.v
@@ -648,193 +648,199 @@ Module Impl_subtle_ConstantTimeEq_for_slice_T.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         let _rhs := M.alloc (| _rhs |) in
-        M.read (|
-          let len :=
-            M.alloc (|
-              M.call_closure (|
-                M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
-                [ M.read (| self |) ]
-              |)
-            |) in
-          let _ :=
-            M.match_operator (|
-              M.alloc (| Value.Tuple [] |),
-              [
-                fun γ =>
-                  ltac:(M.monadic
-                    (let γ :=
-                      M.use
-                        (M.alloc (|
-                          BinOp.Pure.ne
-                            (M.read (| len |))
-                            (M.call_closure (|
-                              M.get_associated_function (|
-                                Ty.apply (Ty.path "slice") [ T ],
-                                "len",
-                                []
-                              |),
-                              [ M.read (| _rhs |) ]
-                            |))
-                        |)) in
-                    let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                    M.alloc (|
-                      M.never_to_any (|
-                        M.read (|
-                          M.return_ (|
-                            M.call_closure (|
-                              M.get_trait_method (|
-                                "core::convert::From",
-                                Ty.path "subtle::Choice",
-                                [ Ty.path "u8" ],
-                                "from",
-                                []
-                              |),
-                              [ Value.Integer Integer.U8 0 ]
-                            |)
-                          |)
-                        |)
-                      |)
-                    |)));
-                fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
-              ]
-            |) in
-          let x := M.alloc (| Value.Integer Integer.U8 1 |) in
-          let _ :=
-            M.use
-              (M.match_operator (|
+        M.catch_return (|
+          ltac:(M.monadic
+            (M.read (|
+              let len :=
                 M.alloc (|
                   M.call_closure (|
-                    M.get_trait_method (|
-                      "core::iter::traits::collect::IntoIterator",
-                      Ty.apply
-                        (Ty.path "core::iter::adapters::zip::Zip")
-                        [
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ T ];
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ T ]
-                        ],
-                      [],
-                      "into_iter",
-                      []
-                    |),
-                    [
+                    M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
+                    [ M.read (| self |) ]
+                  |)
+                |) in
+              let _ :=
+                M.match_operator (|
+                  M.alloc (| Value.Tuple [] |),
+                  [
+                    fun γ =>
+                      ltac:(M.monadic
+                        (let γ :=
+                          M.use
+                            (M.alloc (|
+                              BinOp.Pure.ne
+                                (M.read (| len |))
+                                (M.call_closure (|
+                                  M.get_associated_function (|
+                                    Ty.apply (Ty.path "slice") [ T ],
+                                    "len",
+                                    []
+                                  |),
+                                  [ M.read (| _rhs |) ]
+                                |))
+                            |)) in
+                        let _ :=
+                          M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
+                        M.alloc (|
+                          M.never_to_any (|
+                            M.read (|
+                              M.return_ (|
+                                M.call_closure (|
+                                  M.get_trait_method (|
+                                    "core::convert::From",
+                                    Ty.path "subtle::Choice",
+                                    [ Ty.path "u8" ],
+                                    "from",
+                                    []
+                                  |),
+                                  [ Value.Integer Integer.U8 0 ]
+                                |)
+                              |)
+                            |)
+                          |)
+                        |)));
+                    fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
+                  ]
+                |) in
+              let x := M.alloc (| Value.Integer Integer.U8 1 |) in
+              let _ :=
+                M.use
+                  (M.match_operator (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_trait_method (|
-                          "core::iter::traits::iterator::Iterator",
-                          Ty.apply (Ty.path "core::slice::iter::Iter") [ T ],
+                          "core::iter::traits::collect::IntoIterator",
+                          Ty.apply
+                            (Ty.path "core::iter::adapters::zip::Zip")
+                            [
+                              Ty.apply (Ty.path "core::slice::iter::Iter") [ T ];
+                              Ty.apply (Ty.path "core::slice::iter::Iter") [ T ]
+                            ],
                           [],
-                          "zip",
-                          [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
+                          "into_iter",
+                          []
                         |),
                         [
                           M.call_closure (|
-                            M.get_associated_function (|
-                              Ty.apply (Ty.path "slice") [ T ],
-                              "iter",
-                              []
+                            M.get_trait_method (|
+                              "core::iter::traits::iterator::Iterator",
+                              Ty.apply (Ty.path "core::slice::iter::Iter") [ T ],
+                              [],
+                              "zip",
+                              [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                             |),
-                            [ M.read (| self |) ]
-                          |);
-                          M.call_closure (|
-                            M.get_associated_function (|
-                              Ty.apply (Ty.path "slice") [ T ],
-                              "iter",
-                              []
-                            |),
-                            [ M.read (| _rhs |) ]
+                            [
+                              M.call_closure (|
+                                M.get_associated_function (|
+                                  Ty.apply (Ty.path "slice") [ T ],
+                                  "iter",
+                                  []
+                                |),
+                                [ M.read (| self |) ]
+                              |);
+                              M.call_closure (|
+                                M.get_associated_function (|
+                                  Ty.apply (Ty.path "slice") [ T ],
+                                  "iter",
+                                  []
+                                |),
+                                [ M.read (| _rhs |) ]
+                              |)
+                            ]
                           |)
                         ]
                       |)
-                    ]
-                  |)
-                |),
-                [
-                  fun γ =>
-                    ltac:(M.monadic
-                      (let iter := M.copy (| γ |) in
-                      M.loop (|
+                    |),
+                    [
+                      fun γ =>
                         ltac:(M.monadic
-                          (let _ :=
-                            M.match_operator (|
-                              M.alloc (|
-                                M.call_closure (|
-                                  M.get_trait_method (|
-                                    "core::iter::traits::iterator::Iterator",
-                                    Ty.apply
-                                      (Ty.path "core::iter::adapters::zip::Zip")
-                                      [
-                                        Ty.apply (Ty.path "core::slice::iter::Iter") [ T ];
-                                        Ty.apply (Ty.path "core::slice::iter::Iter") [ T ]
-                                      ],
-                                    [],
-                                    "next",
-                                    []
+                          (let iter := M.copy (| γ |) in
+                          M.loop (|
+                            ltac:(M.monadic
+                              (let _ :=
+                                M.match_operator (|
+                                  M.alloc (|
+                                    M.call_closure (|
+                                      M.get_trait_method (|
+                                        "core::iter::traits::iterator::Iterator",
+                                        Ty.apply
+                                          (Ty.path "core::iter::adapters::zip::Zip")
+                                          [
+                                            Ty.apply (Ty.path "core::slice::iter::Iter") [ T ];
+                                            Ty.apply (Ty.path "core::slice::iter::Iter") [ T ]
+                                          ],
+                                        [],
+                                        "next",
+                                        []
+                                      |),
+                                      [ iter ]
+                                    |)
                                   |),
-                                  [ iter ]
-                                |)
-                              |),
-                              [
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (M.alloc (| M.never_to_any (| M.read (| M.break (||) |) |) |)));
-                                fun γ =>
-                                  ltac:(M.monadic
-                                    (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
-                                        γ,
-                                        "core::option::Option::Some",
-                                        0
-                                      |) in
-                                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                    let γ1_1 := M.get_tuple_field γ0_0 1 in
-                                    let ai := M.copy (| γ1_0 |) in
-                                    let bi := M.copy (| γ1_1 |) in
-                                    let _ :=
-                                      let β := x in
-                                      M.assign (|
-                                        β,
-                                        BinOp.Pure.bit_and
-                                          (M.read (| β |))
-                                          (M.call_closure (|
-                                            M.get_associated_function (|
-                                              Ty.path "subtle::Choice",
-                                              "unwrap_u8",
-                                              []
-                                            |),
-                                            [
-                                              M.alloc (|
-                                                M.call_closure (|
-                                                  M.get_trait_method (|
-                                                    "subtle::ConstantTimeEq",
-                                                    T,
-                                                    [],
-                                                    "ct_eq",
-                                                    []
-                                                  |),
-                                                  [ M.read (| ai |); M.read (| bi |) ]
-                                                |)
-                                              |)
-                                            ]
-                                          |))
-                                      |) in
-                                    M.alloc (| Value.Tuple [] |)))
-                              ]
-                            |) in
-                          M.alloc (| Value.Tuple [] |)))
-                      |)))
-                ]
-              |)) in
-          M.alloc (|
-            M.call_closure (|
-              M.get_trait_method (|
-                "core::convert::Into",
-                Ty.path "u8",
-                [ Ty.path "subtle::Choice" ],
-                "into",
-                []
-              |),
-              [ M.read (| x |) ]
-            |)
-          |)
+                                  [
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (M.alloc (|
+                                          M.never_to_any (| M.read (| M.break (||) |) |)
+                                        |)));
+                                    fun γ =>
+                                      ltac:(M.monadic
+                                        (let γ0_0 :=
+                                          M.get_struct_tuple_field_or_break_match (|
+                                            γ,
+                                            "core::option::Option::Some",
+                                            0
+                                          |) in
+                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
+                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let ai := M.copy (| γ1_0 |) in
+                                        let bi := M.copy (| γ1_1 |) in
+                                        let _ :=
+                                          let β := x in
+                                          M.assign (|
+                                            β,
+                                            BinOp.Pure.bit_and
+                                              (M.read (| β |))
+                                              (M.call_closure (|
+                                                M.get_associated_function (|
+                                                  Ty.path "subtle::Choice",
+                                                  "unwrap_u8",
+                                                  []
+                                                |),
+                                                [
+                                                  M.alloc (|
+                                                    M.call_closure (|
+                                                      M.get_trait_method (|
+                                                        "subtle::ConstantTimeEq",
+                                                        T,
+                                                        [],
+                                                        "ct_eq",
+                                                        []
+                                                      |),
+                                                      [ M.read (| ai |); M.read (| bi |) ]
+                                                    |)
+                                                  |)
+                                                ]
+                                              |))
+                                          |) in
+                                        M.alloc (| Value.Tuple [] |)))
+                                  ]
+                                |) in
+                              M.alloc (| Value.Tuple [] |)))
+                          |)))
+                    ]
+                  |)) in
+              M.alloc (|
+                M.call_closure (|
+                  M.get_trait_method (|
+                    "core::convert::Into",
+                    Ty.path "u8",
+                    [ Ty.path "subtle::Choice" ],
+                    "into",
+                    []
+                  |),
+                  [ M.read (| x |) ]
+                |)
+              |)
+            |)))
         |)))
     | _, _ => M.impossible
     end.

--- a/lib/src/thir_expression.rs
+++ b/lib/src/thir_expression.rs
@@ -165,6 +165,7 @@ fn build_inner_match(
                                     .iter()
                                     .map(|pattern| {
                                         Rc::new(Expr::Lambda {
+                                            is_for_match: true,
                                             is_internal: true,
                                             args: vec![("γ".to_string(), None)],
                                             body: build_inner_match(
@@ -182,6 +183,7 @@ fn build_inner_match(
                                     .collect(),
                             }),
                             Rc::new(Expr::Lambda {
+                                is_for_match: true,
                                 is_internal: false,
                                 args: free_vars.iter().map(|name| (name.clone(), None)).collect(),
                                 body,
@@ -345,6 +347,7 @@ pub(crate) fn build_match(scrutinee: Rc<Expr>, arms: Vec<MatchArm>) -> Rc<Expr> 
                         });
 
                     Rc::new(Expr::Lambda {
+                        is_for_match: true,
                         is_internal: true,
                         args: vec![("γ".to_string(), None)],
                         body: build_inner_match(vec![("γ".to_string(), pattern)], body, 0),
@@ -874,6 +877,7 @@ pub(crate) fn compile_expr<'a>(
                 Rc::new(Expr::Lambda {
                     args,
                     body,
+                    is_for_match: false,
                     is_internal: false,
                 })
                 .alloc()

--- a/lib/src/top_level.rs
+++ b/lib/src/top_level.rs
@@ -730,6 +730,20 @@ fn compile_function_body(
         return None;
     }
 
+    let body_without_bindings = if body_without_bindings.has_return() {
+        Rc::new(Expr::Call {
+            func: Expr::local_var("M.catch_return"),
+            args: vec![Rc::new(Expr::Lambda {
+                args: vec![],
+                body: body_without_bindings,
+                is_for_match: false,
+                is_internal: true,
+            })],
+            kind: CallKind::Effectful,
+        })
+    } else {
+        body_without_bindings
+    };
     let body_with_patterns = args.iter().rfold(
         body_without_bindings,
         |body, (name, _, pattern)| match pattern {


### PR DESCRIPTION
The `M.catch_return` call was forgotten in the last changes for the untyped mode. This PR fixes that.