### PR TITLE
Split crate in files

### DIFF
--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/dns.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/dns.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_dns_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_dns_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "dns::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_dns_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_dns_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_dns_Mapping_K_V.
 
 Module Impl_dns_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "dns::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc1155.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc1155.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc1155_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc1155_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc1155::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_erc1155_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc1155_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc1155_Mapping_K_V.
 
 Module Impl_erc1155_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc1155::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc20.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc20.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc20_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc20::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_erc20_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc20_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc20_Mapping_K_V.
 
 Module Impl_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc20::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc721.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/erc721.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc721_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc721_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc721::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_erc721_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc721_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc721_Mapping_K_V.
 
 Module Impl_erc721_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc721::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/mapping_integration_tests.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/mapping_integration_tests.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mapping_integration_tests_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "mapping_integration_tests::Mapping") [ K; V ].
   
@@ -25,7 +25,7 @@ Module Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mapping_integration_tests_Mapping_K_V.
 
 Module Impl_mapping_integration_tests_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t :=

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/mother.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/mother.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_mother_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mother_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "mother::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_mother_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_mother_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mother_Mapping_K_V.
 
 Module Impl_mother_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "mother::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/multisig.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/multisig.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_multisig_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_multisig_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "multisig::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_multisig_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_multisig_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_multisig_Mapping_K_V.
 
 Module Impl_multisig_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "multisig::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/ink_contracts/trait_erc20.v
+++ b/CoqOfRust/examples/axiomatized/examples/ink_contracts/trait_erc20.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_trait_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "trait_erc20::Mapping") [ K; V ].
   
   Parameter default : forall (K V : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -24,7 +24,7 @@ Module Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_trait_erc20_Mapping_K_V.
 
 Module Impl_trait_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "trait_erc20::Mapping") [ K; V ].

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_phantom_type.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_phantom_type.v
@@ -21,7 +21,7 @@ Module Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomTup
       (* Instance *) [].
 End Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomTuple_A_B.
 
-Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
+Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomTuple_A_B.
   Definition Self (A B : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type::PhantomTuple") [ A; B ].
   
@@ -34,7 +34,7 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
       (Self A B)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("eq", InstanceField.Method (eq A B)) ].
-End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
+End Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomTuple_A_B.
 
 (* StructRecord
   {
@@ -56,7 +56,7 @@ Module Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomStr
       (* Instance *) [].
 End Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomStruct_A_B.
 
-Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
+Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomStruct_A_B.
   Definition Self (A B : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type::PhantomStruct") [ A; B ].
   
@@ -69,6 +69,6 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
       (Self A B)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("eq", InstanceField.Method (eq A B)) ].
-End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
+End Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomStruct_A_B.
 
 Parameter main : (list Ty.t) -> (list Value.t) -> M.

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -90,7 +90,7 @@ End Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification
     fields := [ Ty.path "f64"; Ty.apply (Ty.path "core::marker::PhantomData") [ Unit ] ];
   } *)
 
-Module Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -103,9 +103,9 @@ Module Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarificatio
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt Unit)) ].
-End Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
-Module Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -118,9 +118,9 @@ Module Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarificat
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("clone", InstanceField.Method (clone Unit)) ].
-End Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
-Module Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_marker_Copy_where_core_marker_Copy_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -131,7 +131,7 @@ Module Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarificat
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [].
-End Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_marker_Copy_where_core_marker_Copy_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
 Module Impl_core_ops_arith_Add_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_where_clauses.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/generics/generics_where_clauses.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 (* Trait *)
 (* Empty module 'PrintInOption' *)
 
-Module Impl_generics_where_clauses_PrintInOption_for_T.
+Module Impl_generics_where_clauses_PrintInOption_where_core_fmt_Debug_core_option_Option_T_for_T.
   Definition Self (T : Ty.t) : Ty.t := T.
   
   Parameter print_in_option : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -16,6 +16,6 @@ Module Impl_generics_where_clauses_PrintInOption_for_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("print_in_option", InstanceField.Method (print_in_option T)) ].
-End Impl_generics_where_clauses_PrintInOption_for_T.
+End Impl_generics_where_clauses_PrintInOption_where_core_fmt_Debug_core_option_Option_T_for_T.
 
 Parameter main : (list Ty.t) -> (list Value.t) -> M.

--- a/CoqOfRust/examples/axiomatized/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/axiomatized/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -8,7 +8,7 @@ Require Import CoqOfRust.CoqOfRust.
     fields := [ Ty.apply (Ty.path "&") [ T ] ];
   } *)
 
-Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bounds_Ref_T.
   Definition Self (T : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "scoping_rules_lifetimes_bounds::Ref") [ T ].
   
@@ -21,7 +21,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt T)) ].
-End Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bounds_Ref_T.
 
 Parameter print : (list Ty.t) -> (list Value.t) -> M.
 

--- a/CoqOfRust/examples/axiomatized/examples/subtle.v
+++ b/CoqOfRust/examples/axiomatized/examples/subtle.v
@@ -186,7 +186,7 @@ Module ConstantTimeEq.
   Axiom ProvidedMethod_ct_ne : M.IsProvidedMethod "subtle::ConstantTimeEq" "ct_ne" ct_ne.
 End ConstantTimeEq.
 
-Module Impl_subtle_ConstantTimeEq_for_slice_T.
+Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "slice") [ T ].
   
   Parameter ct_eq : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -198,7 +198,7 @@ Module Impl_subtle_ConstantTimeEq_for_slice_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("ct_eq", InstanceField.Method (ct_eq T)) ].
-End Impl_subtle_ConstantTimeEq_for_slice_T.
+End Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
 
 Module Impl_subtle_ConstantTimeEq_for_subtle_Choice.
   Definition Self : Ty.t := Ty.path "subtle::Choice".
@@ -547,7 +547,7 @@ End Impl_subtle_ConditionallySelectable_for_subtle_Choice.
 (* Trait *)
 (* Empty module 'ConditionallyNegatable' *)
 
-Module Impl_subtle_ConditionallyNegatable_for_T.
+Module Impl_subtle_ConditionallyNegatable_where_subtle_ConditionallySelectable_T_where_core_ops_arith_Neg_ref__T_for_T.
   Definition Self (T : Ty.t) : Ty.t := T.
   
   Parameter conditional_negate : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -559,7 +559,7 @@ Module Impl_subtle_ConditionallyNegatable_for_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("conditional_negate", InstanceField.Method (conditional_negate T)) ].
-End Impl_subtle_ConditionallyNegatable_for_T.
+End Impl_subtle_ConditionallyNegatable_where_subtle_ConditionallySelectable_T_where_core_ops_arith_Neg_ref__T_for_T.
 
 (* StructRecord
   {
@@ -568,7 +568,7 @@ End Impl_subtle_ConditionallyNegatable_for_T.
     fields := [ ("value", T); ("is_some", Ty.path "subtle::Choice") ];
   } *)
 
-Module Impl_core_clone_Clone_for_subtle_CtOption_T.
+Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Parameter clone : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -580,9 +580,9 @@ Module Impl_core_clone_Clone_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("clone", InstanceField.Method (clone T)) ].
-End Impl_core_clone_Clone_for_subtle_CtOption_T.
+End Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
 
-Module Impl_core_marker_Copy_for_subtle_CtOption_T.
+Module Impl_core_marker_Copy_where_core_marker_Copy_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Axiom Implements :
@@ -592,9 +592,9 @@ Module Impl_core_marker_Copy_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [].
-End Impl_core_marker_Copy_for_subtle_CtOption_T.
+End Impl_core_marker_Copy_where_core_marker_Copy_T_for_subtle_CtOption_T.
 
-Module Impl_core_fmt_Debug_for_subtle_CtOption_T.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Parameter fmt : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -606,7 +606,7 @@ Module Impl_core_fmt_Debug_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt T)) ].
-End Impl_core_fmt_Debug_for_subtle_CtOption_T.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
 
 Module Impl_core_convert_From_subtle_CtOption_T_for_core_option_Option_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "core::option::Option") [ T ].
@@ -682,7 +682,7 @@ Module Impl_subtle_CtOption_T.
     M.IsAssociatedFunction (Self T) "or_else" (or_else T).
 End Impl_subtle_CtOption_T.
 
-Module Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
+Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Parameter conditional_select : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -694,9 +694,9 @@ Module Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("conditional_select", InstanceField.Method (conditional_select T)) ].
-End Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
+End Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_T_for_subtle_CtOption_T.
 
-Module Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
+Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Parameter ct_eq : forall (T : Ty.t), (list Ty.t) -> (list Value.t) -> M.
@@ -708,7 +708,7 @@ Module Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("ct_eq", InstanceField.Method (ct_eq T)) ].
-End Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
+End Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOption_T.
 
 (* Trait *)
 (* Empty module 'ConstantTimeGreater' *)

--- a/CoqOfRust/examples/default/examples/ink_contracts/dns.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/dns.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_dns_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_dns_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "dns::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_dns_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_dns_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_dns_Mapping_K_V.
 
 Module Impl_dns_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "dns::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc1155_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc1155_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc1155::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_erc1155_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc1155_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc1155_Mapping_K_V.
 
 Module Impl_erc1155_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc1155::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc20_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc20::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_erc20_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc20_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc20_Mapping_K_V.
 
 Module Impl_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc20::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_erc721_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc721_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc721::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_erc721_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_erc721_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_erc721_Mapping_K_V.
 
 Module Impl_erc721_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "erc721::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mapping_integration_tests_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "mapping_integration_tests::Mapping") [ K; V ].
   
@@ -58,7 +58,7 @@ Module Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_mapping_integration_tests_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mapping_integration_tests_Mapping_K_V.
 
 Module Impl_mapping_integration_tests_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t :=

--- a/CoqOfRust/examples/default/examples/ink_contracts/mother.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mother.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_mother_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mother_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "mother::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_mother_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_mother_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_mother_Mapping_K_V.
 
 Module Impl_mother_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "mother::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_multisig_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_multisig_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "multisig::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_multisig_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_multisig_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_multisig_Mapping_K_V.
 
 Module Impl_multisig_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "multisig::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
@@ -12,7 +12,7 @@ Require Import CoqOfRust.CoqOfRust.
       ];
   } *)
 
-Module Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
+Module Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_trait_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "trait_erc20::Mapping") [ K; V ].
   
   (* Default *)
@@ -57,7 +57,7 @@ Module Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
       (Self K V)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("default", InstanceField.Method (default K V)) ].
-End Impl_core_default_Default_for_trait_erc20_Mapping_K_V.
+End Impl_core_default_Default_where_core_default_Default_K_where_core_default_Default_V_for_trait_erc20_Mapping_K_V.
 
 Module Impl_trait_erc20_Mapping_K_V.
   Definition Self (K V : Ty.t) : Ty.t := Ty.apply (Ty.path "trait_erc20::Mapping") [ K; V ].

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
@@ -21,7 +21,7 @@ Module Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomTup
       (* Instance *) [].
 End Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomTuple_A_B.
 
-Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
+Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomTuple_A_B.
   Definition Self (A B : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type::PhantomTuple") [ A; B ].
   
@@ -72,7 +72,7 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
       (Self A B)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("eq", InstanceField.Method (eq A B)) ].
-End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomTuple_A_B.
+End Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomTuple_A_B.
 
 (* StructRecord
   {
@@ -94,7 +94,7 @@ Module Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomStr
       (* Instance *) [].
 End Impl_core_marker_StructuralPartialEq_for_generics_phantom_type_PhantomStruct_A_B.
 
-Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
+Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomStruct_A_B.
   Definition Self (A B : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type::PhantomStruct") [ A; B ].
   
@@ -151,7 +151,7 @@ Module Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
       (Self A B)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("eq", InstanceField.Method (eq A B)) ].
-End Impl_core_cmp_PartialEq_for_generics_phantom_type_PhantomStruct_A_B.
+End Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_PartialEq_B_for_generics_phantom_type_PhantomStruct_A_B.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -124,7 +124,7 @@ End Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification
     fields := [ Ty.path "f64"; Ty.apply (Ty.path "core::marker::PhantomData") [ Unit ] ];
   } *)
 
-Module Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -171,9 +171,9 @@ Module Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarificatio
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt Unit)) ].
-End Impl_core_fmt_Debug_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
-Module Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -222,9 +222,9 @@ Module Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarificat
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("clone", InstanceField.Method (clone Unit)) ].
-End Impl_core_clone_Clone_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
-Module Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+Module Impl_core_marker_Copy_where_core_marker_Copy_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "generics_phantom_type_test_case_unit_clarification::Length") [ Unit ].
   
@@ -235,7 +235,7 @@ Module Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarificat
       (Self Unit)
       (* Trait polymorphic types *) []
       (* Instance *) [].
-End Impl_core_marker_Copy_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
+End Impl_core_marker_Copy_where_core_marker_Copy_Unit_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
 
 Module Impl_core_ops_arith_Add_for_generics_phantom_type_test_case_unit_clarification_Length_Unit.
   Definition Self (Unit : Ty.t) : Ty.t :=

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_where_clauses.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_where_clauses.v
@@ -4,7 +4,7 @@ Require Import CoqOfRust.CoqOfRust.
 (* Trait *)
 (* Empty module 'PrintInOption' *)
 
-Module Impl_generics_where_clauses_PrintInOption_for_T.
+Module Impl_generics_where_clauses_PrintInOption_where_core_fmt_Debug_core_option_Option_T_for_T.
   Definition Self (T : Ty.t) : Ty.t := T.
   
   (*
@@ -74,7 +74,7 @@ Module Impl_generics_where_clauses_PrintInOption_for_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("print_in_option", InstanceField.Method (print_in_option T)) ].
-End Impl_generics_where_clauses_PrintInOption_for_T.
+End Impl_generics_where_clauses_PrintInOption_where_core_fmt_Debug_core_option_Option_T_for_T.
 
 (*
 fn main() {

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -8,7 +8,7 @@ Require Import CoqOfRust.CoqOfRust.
     fields := [ Ty.apply (Ty.path "&") [ T ] ];
   } *)
 
-Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bounds_Ref_T.
   Definition Self (T : Ty.t) : Ty.t :=
     Ty.apply (Ty.path "scoping_rules_lifetimes_bounds::Ref") [ T ].
   
@@ -46,7 +46,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt T)) ].
-End Impl_core_fmt_Debug_for_scoping_rules_lifetimes_bounds_Ref_T.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bounds_Ref_T.
 
 (*
 fn print<T>(t: T)

--- a/CoqOfRust/examples/default/examples/subtle.v
+++ b/CoqOfRust/examples/default/examples/subtle.v
@@ -617,7 +617,7 @@ Module ConstantTimeEq.
   Axiom ProvidedMethod_ct_ne : M.IsProvidedMethod "subtle::ConstantTimeEq" "ct_ne" ct_ne.
 End ConstantTimeEq.
 
-Module Impl_subtle_ConstantTimeEq_for_slice_T.
+Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "slice") [ T ].
   
   (*
@@ -852,7 +852,7 @@ Module Impl_subtle_ConstantTimeEq_for_slice_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("ct_eq", InstanceField.Method (ct_eq T)) ].
-End Impl_subtle_ConstantTimeEq_for_slice_T.
+End Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
 
 Module Impl_subtle_ConstantTimeEq_for_subtle_Choice.
   Definition Self : Ty.t := Ty.path "subtle::Choice".
@@ -2907,7 +2907,7 @@ End Impl_subtle_ConditionallySelectable_for_subtle_Choice.
 (* Trait *)
 (* Empty module 'ConditionallyNegatable' *)
 
-Module Impl_subtle_ConditionallyNegatable_for_T.
+Module Impl_subtle_ConditionallyNegatable_where_subtle_ConditionallySelectable_T_where_core_ops_arith_Neg_ref__T_for_T.
   Definition Self (T : Ty.t) : Ty.t := T.
   
   (*
@@ -2963,7 +2963,7 @@ Module Impl_subtle_ConditionallyNegatable_for_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("conditional_negate", InstanceField.Method (conditional_negate T)) ].
-End Impl_subtle_ConditionallyNegatable_for_T.
+End Impl_subtle_ConditionallyNegatable_where_subtle_ConditionallySelectable_T_where_core_ops_arith_Neg_ref__T_for_T.
 
 (* StructRecord
   {
@@ -2972,7 +2972,7 @@ End Impl_subtle_ConditionallyNegatable_for_T.
     fields := [ ("value", T); ("is_some", Ty.path "subtle::Choice") ];
   } *)
 
-Module Impl_core_clone_Clone_for_subtle_CtOption_T.
+Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   (* Clone *)
@@ -3012,9 +3012,9 @@ Module Impl_core_clone_Clone_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("clone", InstanceField.Method (clone T)) ].
-End Impl_core_clone_Clone_for_subtle_CtOption_T.
+End Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
 
-Module Impl_core_marker_Copy_for_subtle_CtOption_T.
+Module Impl_core_marker_Copy_where_core_marker_Copy_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   Axiom Implements :
@@ -3024,9 +3024,9 @@ Module Impl_core_marker_Copy_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [].
-End Impl_core_marker_Copy_for_subtle_CtOption_T.
+End Impl_core_marker_Copy_where_core_marker_Copy_T_for_subtle_CtOption_T.
 
-Module Impl_core_fmt_Debug_for_subtle_CtOption_T.
+Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   (* Debug *)
@@ -3068,7 +3068,7 @@ Module Impl_core_fmt_Debug_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("fmt", InstanceField.Method (fmt T)) ].
-End Impl_core_fmt_Debug_for_subtle_CtOption_T.
+End Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
 
 Module Impl_core_convert_From_subtle_CtOption_T_for_core_option_Option_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "core::option::Option") [ T ].
@@ -3732,7 +3732,7 @@ Module Impl_subtle_CtOption_T.
     M.IsAssociatedFunction (Self T) "or_else" (or_else T).
 End Impl_subtle_CtOption_T.
 
-Module Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
+Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   (*
@@ -3794,9 +3794,9 @@ Module Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("conditional_select", InstanceField.Method (conditional_select T)) ].
-End Impl_subtle_ConditionallySelectable_for_subtle_CtOption_T.
+End Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_T_for_subtle_CtOption_T.
 
-Module Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
+Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOption_T.
   Definition Self (T : Ty.t) : Ty.t := Ty.apply (Ty.path "subtle::CtOption") [ T ].
   
   (*
@@ -3920,7 +3920,7 @@ Module Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
       (Self T)
       (* Trait polymorphic types *) []
       (* Instance *) [ ("ct_eq", InstanceField.Method (ct_eq T)) ].
-End Impl_subtle_ConstantTimeEq_for_subtle_CtOption_T.
+End Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOption_T.
 
 (* Trait *)
 (* Empty module 'ConstantTimeGreater' *)

--- a/lib/src/callbacks.rs
+++ b/lib/src/callbacks.rs
@@ -28,7 +28,7 @@ impl Callbacks for ToCoq {
             let current_crate_name = ctxt.crate_name(rustc_hir::def_id::LOCAL_CRATE);
             let current_crate_name_string = current_crate_name.to_string();
 
-            eprintln!("Compiling create {current_crate_name_string:}");
+            eprintln!("Compiling crate {current_crate_name_string:}");
 
             (
                 current_crate_name_string.clone(),

--- a/lib/src/callbacks.rs
+++ b/lib/src/callbacks.rs
@@ -22,9 +22,10 @@ impl Callbacks for ToCoq {
         queries: &'tcx Queries<'tcx>,
     ) -> Compilation {
         let axiomatize = self.opts.axiomatize;
+
         queries.global_ctxt().unwrap();
 
-        let (crate_name, coq_output) = queries.global_ctxt().unwrap().enter(|ctxt| {
+        let (_crate_name, coq_output) = queries.global_ctxt().unwrap().enter(|ctxt| {
             let current_crate_name = ctxt.crate_name(rustc_hir::def_id::LOCAL_CRATE);
             let current_crate_name_string = current_crate_name.to_string();
 
@@ -35,8 +36,13 @@ impl Callbacks for ToCoq {
                 top_level_to_coq(&ctxt, TopLevelOptions { axiomatize }),
             )
         });
-        let mut file = File::create(format!("{crate_name}.v")).unwrap();
-        file.write_all(coq_output.as_bytes()).unwrap();
+
+        for (file_name, coq_output) in coq_output {
+            let coq_file_name = file_name.replace(".rs", ".v");
+            let mut file = File::create(coq_file_name).unwrap();
+
+            file.write_all(coq_output.as_bytes()).unwrap();
+        }
 
         compiler.sess.abort_if_errors();
 

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -131,7 +131,9 @@ fn create_translation_to_coq(opts: &CliOptions) -> String {
         hash_untracked_state: None,
         using_internal_features: Arc::new(AtomicBool::new(false)),
     };
+
     println!("Starting to translate {filename:?}...");
+
     let now = std::time::Instant::now();
     let result = rustc_interface::run_compiler(config, |compiler| {
         compiler.enter(|queries| {
@@ -145,10 +147,19 @@ fn create_translation_to_coq(opts: &CliOptions) -> String {
             })
         })
     });
+
     println!(
         "{} ms have passed to translate: {:?}",
         now.elapsed().as_millis(),
         filename
     );
-    result
+
+    match &result.iter().next() {
+        Some((_, result)) => result.to_string(),
+        None => {
+            eprintln!("No result from the compiler");
+
+            "".to_string()
+        }
+    }
 }

--- a/lib/src/env.rs
+++ b/lib/src/env.rs
@@ -18,6 +18,7 @@ pub(crate) fn emit_warning_with_note(
         .tcx
         .sess
         .struct_span_warn(*span, warning_msg.to_string());
+
     match note_msg {
         Some(note) => warn.note(note.to_string()).emit(),
         None => warn.emit(),


### PR DESCRIPTION
The goal is to translate a crate to a folder of files, instead of a single big `Crate.v` file. This should help to translate the core library for example, as we would be able to discard individual files that we cannot translate.