### PR TITLE
Single layer simulation

### DIFF
--- a/CoqOfRust/M.v
+++ b/CoqOfRust/M.v
@@ -115,11 +115,36 @@ Module Pointer.
     Definition t : Set := list Index.t.
   End Path.
 
+  Module Mutable.
+    Inductive t (Value : Set) : Set :=
+    | Make {Address Big_A A : Set}
+      (address : Address)
+      (path : Path.t)
+      (big_to_value : Big_A -> Value)
+      (projection : Big_A -> option A)
+      (injection : Big_A -> A -> option Big_A)
+      (to_value : A -> Value).
+    Arguments Make {_ _ _ _}.
+  End Mutable.
+
   Inductive t (Value : Set) : Set :=
   | Immediate (value : Value)
-  | Mutable {Address : Set} (address : Address) (path : Path.t).
+  | Mutable (mutable : Mutable.t Value).
   Arguments Immediate {_}.
-  Arguments Mutable {_ _}.
+  Arguments Mutable {_}.
+
+  Definition mutable {Value Address A : Set}
+      (address : Address)
+      (to_value : A -> Value) :
+      t Value :=
+    Mutable (Mutable.Make
+      address
+      []
+      to_value
+      (fun x => Some x)
+      (fun x _ => Some x)
+      to_value
+    ).
 End Pointer.
 
 Module Value.
@@ -305,8 +330,9 @@ End Value.
 Module Primitive.
   Inductive t : Set :=
   | StateAlloc (value : Value.t)
-  | StateRead {Address : Set} (address : Address)
-  | StateWrite {Address : Set} (address : Address) (value : Value.t)
+  | StateRead (mutable : Pointer.Mutable.t Value.t)
+  | StateWrite (mutable : Pointer.Mutable.t Value.t) (value : Value.t)
+  | GetSubPointer (mutable : Pointer.Mutable.t Value.t) (index : Pointer.Index.t)
   | EnvRead
   | GetFunction (path : string) (generic_tys : list Ty.t)
   | GetAssociatedFunction (ty : Ty.t) (name : string) (generic_tys : list Ty.t)
@@ -511,6 +537,9 @@ Definition panic (message : string) : M :=
 Definition call_closure (f : Value.t) (args : list Value.t) : M :=
   LowM.CallClosure f args LowM.Pure.
 
+Definition impossible : M :=
+  LowM.Impossible.
+
 Definition call_primitive (primitive : Primitive.t) : M :=
   LowM.CallPrimitive primitive (fun result =>
   LowM.Pure (inl result)).
@@ -521,36 +550,39 @@ Definition alloc (v : Value.t) : M :=
 Definition read (r : Value.t) : M :=
   match r with
   | Value.Pointer (Pointer.Immediate v) => LowM.Pure (inl v)
-  | Value.Pointer (Pointer.Mutable address path) =>
-    let* v := call_primitive (Primitive.StateRead address) in
-    match Value.read_path v path with
-    | Some v => LowM.Pure (inl v)
-    | None => LowM.Impossible
-    end
-  | _ => LowM.Impossible
+  | Value.Pointer (Pointer.Mutable mutable) =>
+    call_primitive (Primitive.StateRead mutable)
+  | _ => impossible
   end.
 
 Definition write (r : Value.t) (update : Value.t) : M :=
   match r with
-  | Value.Pointer (Pointer.Immediate _) => LowM.Impossible
-  | Value.Pointer (Pointer.Mutable address path) =>
-    let* value := call_primitive (Primitive.StateRead address) in
-    match Value.write_value value path update with
-    | Some value => call_primitive (Primitive.StateWrite address value)
-    | None => LowM.Impossible
-    end
-  | _ => LowM.Impossible
+  | Value.Pointer (Pointer.Immediate _) => impossible
+  | Value.Pointer (Pointer.Mutable mutable) =>
+    call_primitive (Primitive.StateWrite mutable update)
+  | _ => impossible
   end.
 
 Definition copy (r : Value.t) : M :=
   let* v := read r in
   alloc v.
 
+(** If we cannot get the sub-pointer, due to a field that does not exist or to an out-of bound
+    access in an array, we do a [break_match]. *)
+Definition get_sub_pointer (r : Value.t) (index : Pointer.Index.t) : M :=
+  match r with
+  | Value.Pointer (Pointer.Immediate v) =>
+    match Value.read_path v [index] with
+    | Some v => alloc v
+    | None => break_match
+    end
+  | Value.Pointer (Pointer.Mutable mutable) =>
+    call_primitive (Primitive.GetSubPointer mutable index)
+  | _ => impossible
+  end.
+
 Definition read_env : M :=
   call_primitive Primitive.EnvRead.
-
-Definition impossible : M :=
-  LowM.Impossible.
 
 Parameter get_constant : string -> M.
 
@@ -672,180 +704,31 @@ Definition never_to_any (x : Value.t) : M :=
 Definition use (x : Value.t) : Value.t :=
   x.
 
-(** An error should not occur as we statically know the number of fields in a
-    tuple, but the code for the error branch is still there for typing and
-    debugging reasons. *)
-Definition get_tuple_field (value : Value.t) (index : Z) : Value.t :=
-  match value with
-  | Value.Pointer pointer =>
-    match pointer with
-    | Pointer.Immediate value =>
-      match value with
-      | Value.Tuple fields =>
-        match List.nth_error fields (Z.to_nat index) with
-        | Some field => Value.Pointer (Pointer.Immediate field)
-        | None => Value.Error "invalid tuple index"
-        end
-      | _ => Value.Error "expected a tuple"
-      end
-    | Pointer.Mutable address path =>
-      let new_path := path ++ [Pointer.Index.Tuple index] in
-      Value.Pointer (Pointer.Mutable address new_path)
-    end
-  | _ => Value.Error "expected an address"
-  end.
+Definition get_tuple_field (value : Value.t) (index : Z) : M :=
+  get_sub_pointer value (Pointer.Index.Tuple index).
 
-(** This function might fail, in case the [index] is out of range. *)
 Definition get_array_field (value : Value.t) (index : Value.t) : M :=
-  let* index := read index in
   match index with
   | Value.Integer Integer.Usize index =>
-    match value with
-    | Value.Pointer pointer =>
-      match pointer with
-      | Pointer.Immediate value =>
-        match value with
-        | Value.Array fields =>
-          (* As this is in `usize`, the index is necessarily positive. *)
-          match List.nth_error fields (Z.to_nat index) with
-          | Some field => pure (Value.Pointer (Pointer.Immediate field))
-          | None => panic "invalid array index"
-          end
-        | _ => pure (Value.Error "expected an array")
-        end
-      | Pointer.Mutable address path =>
-        let new_path := path ++ [Pointer.Index.Array index] in
-        pure (Value.Pointer (Pointer.Mutable address new_path))
-      end
-    | _ => pure (Value.Error "expected an address")
-    end
-  | _ => pure (Value.Error "Expected a usize as an array index")
+    get_sub_pointer value (Pointer.Index.Array index)
+  | _ => impossible
   end.
 
-(** Same as for [get_tuple_field], an error should not occur. *)
-Definition get_struct_tuple_field
-    (value : Value.t) (constructor : string) (index : Z) :
-    Value.t :=
-  match value with
-  | Value.Pointer pointer =>
-    match pointer with
-    | Pointer.Immediate value =>
-      match value with
-      | Value.StructTuple current_constructor fields =>
-        if String.eqb current_constructor constructor then
-          match List.nth_error fields (Z.to_nat index) with
-          | Some value => Value.Pointer (Pointer.Immediate value)
-          | None => Value.Error "field not found"
-          end
-        else
-          Value.Error "different values of constructor"
-      | _ => Value.Error "not a struct tuple"
-      end
-    | Pointer.Mutable address path =>
-      let new_path := path ++ [Pointer.Index.StructTuple constructor index] in
-      Value.Pointer (Pointer.Mutable address new_path)
-    end
-  | _ => Value.Error "expected an address"
-  end.
+Definition get_struct_tuple_field (value : Value.t) (constructor : string) (index : Z) : M :=
+  get_sub_pointer value (Pointer.Index.StructTuple constructor index).
 
-(** Same as for [get_tuple_field], an error should not occur. *)
-Definition get_struct_record_field
-    (value : Value.t) (constructor field : string) :
-    Value.t :=
-  match value with
-  | Value.Pointer (Pointer.Immediate value) =>
-    match value with
-    | Value.StructRecord current_constructor fields =>
-      if String.eqb current_constructor constructor then
-        match List.assoc fields field with
-        | Some value => Value.Pointer (Pointer.Immediate value)
-        | None => Value.Error "field not found"
-        end
-      else
-        Value.Error "different values of constructor"
-    | _ => Value.Error "not a struct record"
-    end
-  | Value.Pointer (Pointer.Mutable address path) =>
-    let new_path := path ++ [Pointer.Index.StructRecord constructor field] in
-    Value.Pointer (Pointer.Mutable address new_path)
-  | _ => Value.Error "expected an address"
-  end.
+Definition get_struct_record_field (value : Value.t) (constructor field : string) : M :=
+  get_sub_pointer value (Pointer.Index.StructRecord constructor field).
 
-Parameter pointer_coercion : Value.t -> Value.t.
+(** Get an element of a slice by index. *)
+Parameter get_slice_index : Value.t -> Z -> M.
 
-Definition get_struct_tuple_field_or_break_match
-    (value : Value.t) (constructor : string) (index : Z) :
-    M :=
-  match value with
-  | Value.Pointer pointer =>
-    match pointer with
-    | Pointer.Immediate value =>
-      match value with
-      | Value.StructTuple current_constructor fields =>
-        if String.eqb current_constructor constructor then
-          match List.nth_error fields (Z.to_nat index) with
-          | Some value => pure (Value.Pointer (Pointer.Immediate value))
-          | None => M.impossible
-          end
-        else
-          break_match
-      | _ => M.impossible
-      end
-    | Pointer.Mutable address path =>
-      match Value.read_path value path with
-      | None => M.impossible
-      | Some value =>
-        match value with
-        | Value.StructTuple current_constructor fields =>
-          if String.eqb current_constructor constructor then
-            let new_path :=
-              path ++ [Pointer.Index.StructTuple constructor index] in
-            pure (Value.Pointer (Pointer.Mutable address new_path))
-          else
-            break_match
-        | _ => M.impossible
-        end
-      end
-    end
-  | _ => M.impossible
-  end.
+(** Get an element of a slice by index counting from the end. *)
+Parameter get_slice_rev_index : Value.t -> Z -> M.
 
-Definition get_struct_record_field_or_break_match
-    (value : Value.t) (constructor field : string) :
-    M :=
-  match value with
-  | Value.Pointer pointer =>
-    match pointer with
-    | Pointer.Immediate value =>
-      match value with
-      | Value.StructRecord current_constructor fields =>
-        if String.eqb current_constructor constructor then
-          match List.assoc fields field with
-          | Some value => pure (Value.Pointer (Pointer.Immediate value))
-          | None => M.impossible
-          end
-        else
-          break_match
-      | _ => M.impossible
-      end
-    | Pointer.Mutable address path =>
-      match Value.read_path value path with
-      | None => M.impossible
-      | Some value =>
-        match value with
-        | Value.StructRecord current_constructor fields =>
-          if String.eqb current_constructor constructor then
-            let new_path :=
-              path ++ [Pointer.Index.StructRecord constructor field] in
-            pure (Value.Pointer (Pointer.Mutable address new_path))
-          else
-            break_match
-        | _ => M.impossible
-        end
-      end
-    end
-  | _ => M.impossible
-  end.
+(** For two indices n and k, get all elements of a slice without
+    the first n elements and without the last k elements. *)
+Parameter get_slice_rest : Value.t -> Z -> Z -> M.
 
 Definition is_constant_or_break_match (value expected_value : Value.t) : M :=
   if Value.eqb value expected_value then
@@ -853,18 +736,7 @@ Definition is_constant_or_break_match (value expected_value : Value.t) : M :=
   else
     break_match.
 
-(** Get an element of a slice by index. *)
-Parameter get_slice_index_or_break_match :
-  Value.t -> Z -> M.
-
-(** Get an element of a slice by index counting from the end. *)
-Parameter get_slice_rev_index_or_break_match :
-  Value.t -> Z -> M.
-
-(** For two indices n and k, get all elements of a slice without
-    the first n elements and without the last k elements. *)
-Parameter get_slice_rest_or_break_match :
-  Value.t -> Z -> Z -> M.
+Parameter pointer_coercion : Value.t -> Value.t.
 
 (** This function is explicitely called in the Rust AST, and should take two
     types that are actually different but convertible, like different kinds of

--- a/CoqOfRust/M.v
+++ b/CoqOfRust/M.v
@@ -740,31 +740,33 @@ Definition never_to_any (x : Value.t) : M :=
 Definition use (x : Value.t) : Value.t :=
   x.
 
-Definition get_tuple_field (value : Value.t) (index : Z) : M :=
-  get_sub_pointer value (Pointer.Index.Tuple index).
+Module SubPointer.
+  Definition get_tuple_field (value : Value.t) (index : Z) : M :=
+    get_sub_pointer value (Pointer.Index.Tuple index).
 
-Definition get_array_field (value : Value.t) (index : Value.t) : M :=
-  match index with
-  | Value.Integer Integer.Usize index =>
-    get_sub_pointer value (Pointer.Index.Array index)
-  | _ => impossible
-  end.
+  Definition get_array_field (value : Value.t) (index : Value.t) : M :=
+    match index with
+    | Value.Integer Integer.Usize index =>
+      get_sub_pointer value (Pointer.Index.Array index)
+    | _ => impossible
+    end.
 
-Definition get_struct_tuple_field (value : Value.t) (constructor : string) (index : Z) : M :=
-  get_sub_pointer value (Pointer.Index.StructTuple constructor index).
+  Definition get_struct_tuple_field (value : Value.t) (constructor : string) (index : Z) : M :=
+    get_sub_pointer value (Pointer.Index.StructTuple constructor index).
 
-Definition get_struct_record_field (value : Value.t) (constructor field : string) : M :=
-  get_sub_pointer value (Pointer.Index.StructRecord constructor field).
+  Definition get_struct_record_field (value : Value.t) (constructor field : string) : M :=
+    get_sub_pointer value (Pointer.Index.StructRecord constructor field).
 
-(** Get an element of a slice by index. *)
-Parameter get_slice_index : Value.t -> Z -> M.
+  (** Get an element of a slice by index. *)
+  Parameter get_slice_index : Value.t -> Z -> M.
 
-(** Get an element of a slice by index counting from the end. *)
-Parameter get_slice_rev_index : Value.t -> Z -> M.
+  (** Get an element of a slice by index counting from the end. *)
+  Parameter get_slice_rev_index : Value.t -> Z -> M.
 
-(** For two indices n and k, get all elements of a slice without
-    the first n elements and without the last k elements. *)
-Parameter get_slice_rest : Value.t -> Z -> Z -> M.
+  (** For two indices n and k, get all elements of a slice without
+      the first n elements and without the last k elements. *)
+  Parameter get_slice_rest : Value.t -> Z -> Z -> M.
+End SubPointer.
 
 Definition is_constant_or_break_match (value expected_value : Value.t) : M :=
   if Value.eqb value expected_value then

--- a/CoqOfRust/M.v
+++ b/CoqOfRust/M.v
@@ -125,6 +125,36 @@ Module Pointer.
       (injection : Big_A -> A -> option Big_A)
       (to_value : A -> Value).
     Arguments Make {_ _ _ _}.
+
+    (* Definition get_sub {Value Address Big_A A Sub_A : Set}
+        (mutable : t Value)
+        (index : Index.t)
+        (sub_projection : A -> option Sub_A)
+        (sub_injection : A -> Sub_A -> option A)
+        (sub_to_value : Sub_A -> Value) :
+        t Value :=
+      let 'Make address path big_to_value projection injection to_value := mutable in
+      Make
+        address
+        (path ++ [index])
+        big_to_value
+        (fun big_a =>
+          match projection big_a with
+          | Some a => sub_projection a
+          | None => None
+          end
+        )
+        (fun big_a new_sub_a =>
+          match projection big_a with
+          | Some a =>
+            match sub_injection a new_sub_a with
+            | Some new_a => injection big_a new_a
+            | None => None
+            end
+          | None => None
+          end
+        )
+        sub_to_value. *)
   End Mutable.
 
   Inductive t (Value : Set) : Set :=
@@ -437,6 +467,12 @@ Parameter IsProvidedMethod :
   Prop.
 
 Module Option.
+  Definition map {A B : Set} (x : option A) (f : A -> B) : option B :=
+    match x with
+    | Some x => Some (f x)
+    | None => None
+    end.
+
   Definition bind {A B : Set} (x : option A) (f : A -> option B) : option B :=
     match x with
     | Some x => f x

--- a/CoqOfRust/alloc/alloc.v
+++ b/CoqOfRust/alloc/alloc.v
@@ -375,7 +375,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -417,7 +417,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -744,7 +744,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -786,7 +786,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -895,7 +895,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -937,7 +937,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1476,7 +1476,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1518,7 +1518,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1584,7 +1584,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1626,7 +1626,7 @@ Module alloc.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1753,11 +1753,7 @@ Module alloc.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let ptr := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.call_closure (|
@@ -1774,11 +1770,7 @@ Module alloc.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|

--- a/CoqOfRust/alloc/borrow.v
+++ b/CoqOfRust/alloc/borrow.v
@@ -174,7 +174,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -186,11 +186,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let o := M.alloc (| γ0_0 |) in
                     let b :=
                       M.alloc (|
@@ -248,11 +244,11 @@ Module borrow.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "alloc::borrow::Cow::Owned",
                         0
@@ -260,7 +256,7 @@ Module borrow.
                     let dest := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "alloc::borrow::Cow::Owned",
                         0
@@ -286,8 +282,8 @@ Module borrow.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let t := M.copy (| γ0_0 |) in
                     let s := M.copy (| γ0_1 |) in
                     M.write (|
@@ -346,7 +342,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -355,11 +351,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     M.alloc (| Value.Bool false |)))
               ]
             |)
@@ -425,7 +417,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -474,7 +466,7 @@ Module borrow.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "alloc::borrow::Cow::Owned",
                                         0
@@ -490,11 +482,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let owned := M.alloc (| γ0_0 |) in
                     M.alloc (| M.read (| owned |) |)))
               ]
@@ -528,7 +516,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -543,11 +531,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let owned := M.copy (| γ0_0 |) in
                     owned))
               ]
@@ -588,7 +572,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -598,11 +582,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let owned := M.alloc (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -821,7 +801,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -842,11 +822,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let o := M.alloc (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -894,7 +870,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -915,11 +891,7 @@ Module borrow.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let o := M.alloc (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -1224,7 +1196,7 @@ Module borrow.
                                     ltac:(M.monadic
                                       (let γ := M.read (| self |) in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::borrow::Cow::Borrowed",
                                           0
@@ -1410,7 +1382,7 @@ Module borrow.
                                     ltac:(M.monadic
                                       (let γ := M.read (| self |) in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::borrow::Cow::Borrowed",
                                           0

--- a/CoqOfRust/alloc/boxed.v
+++ b/CoqOfRust/alloc/boxed.v
@@ -362,7 +362,7 @@ Module boxed.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -401,7 +401,7 @@ Module boxed.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -500,21 +500,13 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let m := M.copy (| γ0_0 |) in
                     m));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (|
                       M.never_to_any (|
                         M.call_closure (|
@@ -648,7 +640,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -695,7 +687,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -795,21 +787,13 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let m := M.copy (| γ0_0 |) in
                     m));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (|
                       M.never_to_any (|
                         M.call_closure (|
@@ -943,7 +927,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -990,7 +974,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -1109,8 +1093,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -1200,8 +1184,8 @@ Module boxed.
         ltac:(M.monadic
           (let b := M.alloc (| b |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "alloc::boxed::Box") [ T; A ],
@@ -1210,8 +1194,9 @@ Module boxed.
                   |),
                   [ M.read (| b |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -1247,8 +1232,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let leaked := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -1297,7 +1282,7 @@ Module boxed.
               M.alloc (|
                 M.call_closure (|
                   M.get_function (| "core::ptr::read", [ A ] |),
-                  [ M.get_struct_tuple_field b "alloc::boxed::Box" 1 ]
+                  [ M.SubPointer.get_struct_tuple_field (| b, "alloc::boxed::Box", 1 |) ]
                 |)
               |) in
             M.alloc (|
@@ -1344,7 +1329,7 @@ Module boxed.
       | [], [ b ] =>
         ltac:(M.monadic
           (let b := M.alloc (| b |) in
-          M.get_struct_tuple_field (M.read (| b |)) "alloc::boxed::Box" 1))
+          M.SubPointer.get_struct_tuple_field (| M.read (| b |), "alloc::boxed::Box", 1 |)))
       | _, _ => M.impossible
       end.
     
@@ -1374,8 +1359,8 @@ Module boxed.
             |),
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.call_closure (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.call_closure (|
                     M.get_trait_method (|
                       "core::ops::deref::Deref",
                       Ty.apply
@@ -1399,9 +1384,10 @@ Module boxed.
                         |)
                       |)
                     ]
-                  |))
-                  "alloc::boxed::Box"
+                  |),
+                  "alloc::boxed::Box",
                   0
+                |)
               |)
             ]
           |)))
@@ -1603,7 +1589,7 @@ Module boxed.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -1613,7 +1599,7 @@ Module boxed.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -1683,7 +1669,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -1734,7 +1720,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -1876,7 +1862,7 @@ Module boxed.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -1886,7 +1872,7 @@ Module boxed.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -1956,7 +1942,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2007,7 +1993,7 @@ Module boxed.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2186,8 +2172,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -2303,8 +2289,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -2357,7 +2343,9 @@ Module boxed.
           (let self := M.alloc (| self |) in
           M.read (|
             let ptr :=
-              M.copy (| M.get_struct_tuple_field (M.read (| self |)) "alloc::boxed::Box" 0 |) in
+              M.copy (|
+                M.SubPointer.get_struct_tuple_field (| M.read (| self |), "alloc::boxed::Box", 0 |)
+              |) in
             let layout :=
               M.alloc (|
                 M.call_closure (|
@@ -2411,7 +2399,11 @@ Module boxed.
                             []
                           |),
                           [
-                            M.get_struct_tuple_field (M.read (| self |)) "alloc::boxed::Box" 1;
+                            M.SubPointer.get_struct_tuple_field (|
+                              M.read (| self |),
+                              "alloc::boxed::Box",
+                              1
+                            |);
                             M.call_closure (|
                               M.get_trait_method (|
                                 "core::convert::From",
@@ -2649,7 +2641,13 @@ Module boxed.
                   [
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                      [ M.get_struct_tuple_field (M.read (| self |)) "alloc::boxed::Box" 1 ]
+                      [
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::boxed::Box",
+                          1
+                        |)
+                      ]
                     |)
                   ]
                 |)
@@ -3670,7 +3668,7 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -3693,11 +3691,7 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let slice := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -3804,7 +3798,7 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -3827,11 +3821,7 @@ Module boxed.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let s := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -3893,8 +3883,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4013,8 +4003,8 @@ Module boxed.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let left_val := M.copy (| γ0_0 |) in
                               let right_val := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -4084,8 +4074,8 @@ Module boxed.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let ptr := M.copy (| γ0_0 |) in
                   let alloc := M.copy (| γ0_1 |) in
                   M.alloc (|
@@ -4438,8 +4428,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4604,8 +4594,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4771,8 +4761,8 @@ Module boxed.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let raw := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|

--- a/CoqOfRust/alloc/boxed/thin.v
+++ b/CoqOfRust/alloc/boxed/thin.v
@@ -178,10 +178,11 @@ Module boxed.
               (M.read (|
                 M.use
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::boxed::thin::ThinBox"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::boxed::thin::ThinBox",
                       "ptr"
+                    |)
                   |))
               |))))
         | _, _ => M.impossible
@@ -577,7 +578,15 @@ Module boxed.
               M.alloc (|
                 Value.StructTuple
                   "alloc::boxed::thin::WithOpaqueHeader"
-                  [ M.read (| M.get_struct_tuple_field ptr "alloc::boxed::thin::WithHeader" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        ptr,
+                        "alloc::boxed::thin::WithHeader",
+                        0
+                      |)
+                    |)
+                  ]
               |)
             |)))
         | _, _ => M.impossible
@@ -666,13 +675,13 @@ Module boxed.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let layout := M.copy (| γ1_0 |) in
                       let value_offset := M.copy (| γ1_1 |) in
                       let ptr :=
@@ -972,10 +981,11 @@ Module boxed.
                     [
                       ("ptr",
                         M.read (|
-                          M.get_struct_tuple_field
-                            (M.read (| self |))
-                            "alloc::boxed::thin::WithHeader"
+                          M.SubPointer.get_struct_tuple_field (|
+                            M.read (| self |),
+                            "alloc::boxed::thin::WithHeader",
                             0
+                          |)
                         |));
                       ("value_layout",
                         M.call_closure (|
@@ -1044,10 +1054,11 @@ Module boxed.
                           |),
                           [
                             M.read (|
-                              M.get_struct_tuple_field
-                                (M.read (| self |))
-                                "alloc::boxed::thin::WithHeader"
+                              M.SubPointer.get_struct_tuple_field (|
+                                M.read (| self |),
+                                "alloc::boxed::thin::WithHeader",
                                 0
+                              |)
                             |)
                           ]
                         |);
@@ -1142,7 +1153,11 @@ Module boxed.
               |),
               [
                 M.read (|
-                  M.get_struct_tuple_field (M.read (| self |)) "alloc::boxed::thin::WithHeader" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "alloc::boxed::thin::WithHeader",
+                    0
+                  |)
                 |)
               ]
             |)))

--- a/CoqOfRust/alloc/collections/binary_heap/mod.v
+++ b/CoqOfRust/alloc/collections/binary_heap/mod.v
@@ -78,15 +78,17 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::binary_heap::PeekMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::binary_heap::PeekMut",
                                 "heap"
-                            |))
-                            "alloc::collections::binary_heap::BinaryHeap"
-                            "data";
+                              |)
+                            |),
+                            "alloc::collections::binary_heap::BinaryHeap",
+                            "data"
+                          |);
                           Value.Integer Integer.Usize 0
                         ]
                       |))
@@ -138,12 +140,13 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::binary_heap::PeekMut"
-                          "original_len" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::binary_heap::PeekMut",
+                          "original_len"
+                        |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -158,15 +161,17 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::binary_heap::PeekMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::binary_heap::PeekMut",
                                     "heap"
-                                |))
-                                "alloc::collections::binary_heap::BinaryHeap"
-                                "data";
+                                  |)
+                                |),
+                                "alloc::collections::binary_heap::BinaryHeap",
+                                "data"
+                              |);
                               M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.path "core::num::nonzero::NonZeroUsize",
@@ -190,10 +195,11 @@ Module collections.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::binary_heap::PeekMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::binary_heap::PeekMut",
                                   "heap"
+                                |)
                               |);
                               Value.Integer Integer.Usize 0
                             ]
@@ -268,10 +274,11 @@ Module collections.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::binary_heap::PeekMut"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::binary_heap::PeekMut",
                                                     "heap"
+                                                  |)
                                                 |)
                                               ]
                                             |)))
@@ -317,15 +324,17 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::PeekMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::PeekMut",
                               "heap"
-                          |))
-                          "alloc::collections::binary_heap::BinaryHeap"
+                            |)
+                          |),
+                          "alloc::collections::binary_heap::BinaryHeap",
                           "data"
+                        |)
                       ]
                     |);
                     Value.Integer Integer.Usize 0
@@ -416,10 +425,11 @@ Module collections.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::binary_heap::PeekMut"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::binary_heap::PeekMut",
                                                     "heap"
+                                                  |)
                                                 |)
                                               ]
                                             |)))
@@ -458,10 +468,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::binary_heap::PeekMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::binary_heap::PeekMut",
                           "heap"
+                        |)
                       |)
                     ]
                   |)
@@ -481,10 +492,11 @@ Module collections.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::PeekMut"
-                              "original_len",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::PeekMut",
+                              "original_len"
+                            |),
                             Value.StructTuple
                               "core::option::Option::Some"
                               [
@@ -507,15 +519,17 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::binary_heap::PeekMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::binary_heap::PeekMut",
                                       "heap"
-                                  |))
-                                  "alloc::collections::binary_heap::BinaryHeap"
-                                  "data";
+                                    |)
+                                  |),
+                                  "alloc::collections::binary_heap::BinaryHeap",
+                                  "data"
+                                |);
                                 Value.Integer Integer.Usize 1
                               ]
                             |)
@@ -541,15 +555,17 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::PeekMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::PeekMut",
                               "heap"
-                          |))
-                          "alloc::collections::binary_heap::BinaryHeap"
+                            |)
+                          |),
+                          "alloc::collections::binary_heap::BinaryHeap",
                           "data"
+                        |)
                       ]
                     |);
                     Value.Integer Integer.Usize 0
@@ -611,15 +627,16 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  this
-                                  "alloc::collections::binary_heap::PeekMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  this,
+                                  "alloc::collections::binary_heap::PeekMut",
                                   "original_len"
+                                |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -634,15 +651,17 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (|
-                                    M.get_struct_record_field
-                                      this
-                                      "alloc::collections::binary_heap::PeekMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      this,
+                                      "alloc::collections::binary_heap::PeekMut",
                                       "heap"
-                                  |))
-                                  "alloc::collections::binary_heap::BinaryHeap"
-                                  "data";
+                                    |)
+                                  |),
+                                  "alloc::collections::binary_heap::BinaryHeap",
+                                  "data"
+                                |);
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.path "core::num::nonzero::NonZeroUsize",
@@ -674,10 +693,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            this
-                            "alloc::collections::binary_heap::PeekMut"
+                          M.SubPointer.get_struct_record_field (|
+                            this,
+                            "alloc::collections::binary_heap::PeekMut",
                             "heap"
+                          |)
                         |)
                       ]
                     |)
@@ -721,10 +741,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
                         "data"
+                      |)
                     ]
                   |))
               ]))
@@ -755,14 +776,16 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
-                      M.get_struct_record_field
-                        (M.read (| source |))
-                        "alloc::collections::binary_heap::BinaryHeap"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
                         "data"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| source |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |)
                     ]
                   |)
                 |) in
@@ -929,16 +952,18 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::binary_heap::RebuildOnDrop"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::binary_heap::RebuildOnDrop",
                           "heap"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::binary_heap::RebuildOnDrop"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::binary_heap::RebuildOnDrop",
                           "rebuild_from"
+                        |)
                       |)
                     ]
                   |)
@@ -1181,10 +1206,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::binary_heap::BinaryHeap"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::binary_heap::BinaryHeap",
                       "data"
+                    |)
                   ]
                 |);
                 M.closure
@@ -1243,10 +1269,11 @@ Module collections.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::binary_heap::BinaryHeap"
-                                                          "data";
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::binary_heap::BinaryHeap",
+                                                          "data"
+                                                        |);
                                                         Value.Integer Integer.Usize 0
                                                       ]
                                                     |)
@@ -1324,10 +1351,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       M.read (| item |)
                     ]
                   |)
@@ -1422,10 +1450,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::binary_heap::BinaryHeap"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::binary_heap::BinaryHeap",
                                         "data"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -1544,10 +1573,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::BinaryHeap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::BinaryHeap",
                             "data"
+                          |)
                         ]
                       |);
                       M.read (| pos |)
@@ -1770,10 +1800,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::binary_heap::BinaryHeap"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::binary_heap::BinaryHeap",
                                 "data"
+                              |)
                             ]
                           |);
                           M.read (| pos |)
@@ -2187,10 +2218,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::BinaryHeap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::BinaryHeap",
                             "data"
+                          |)
                         ]
                       |);
                       M.read (| pos |)
@@ -2696,7 +2728,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -2908,10 +2940,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
                         "data"
+                      |)
                     ]
                   |)
                 |) in
@@ -2924,14 +2957,16 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "alloc::collections::binary_heap::BinaryHeap"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
                         "data"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |)
                     ]
                   |)
                 |) in
@@ -3033,15 +3068,17 @@ Module collections.
                       [ Ty.function [ Ty.tuple [ Ty.apply (Ty.path "&") [ T ] ] ] (Ty.path "bool") ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            guard
-                            "alloc::collections::binary_heap::RebuildOnDrop"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            guard,
+                            "alloc::collections::binary_heap::RebuildOnDrop",
                             "heap"
-                        |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                          |)
+                        |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -3082,10 +3119,11 @@ Module collections.
                                                             (BinOp.Pure.lt
                                                               (M.read (| i |))
                                                               (M.read (|
-                                                                M.get_struct_record_field
-                                                                  guard
-                                                                  "alloc::collections::binary_heap::RebuildOnDrop"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  guard,
+                                                                  "alloc::collections::binary_heap::RebuildOnDrop",
                                                                   "rebuild_from"
+                                                                |)
                                                               |))))
                                                         |)
                                                       |)) in
@@ -3096,10 +3134,11 @@ Module collections.
                                                     |) in
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_struct_record_field
-                                                        guard
-                                                        "alloc::collections::binary_heap::RebuildOnDrop"
-                                                        "rebuild_from",
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        guard,
+                                                        "alloc::collections::binary_heap::RebuildOnDrop",
+                                                        "rebuild_from"
+                                                      |),
                                                       M.read (| i |)
                                                     |) in
                                                   M.alloc (| Value.Tuple [] |)));
@@ -3160,10 +3199,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::BinaryHeap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::BinaryHeap",
                             "data"
+                          |)
                         ]
                       |)
                     ]
@@ -3224,10 +3264,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::binary_heap::BinaryHeap"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::binary_heap::BinaryHeap",
                       "data"
+                    |)
                   ]
                 |);
                 Value.Integer Integer.Usize 0
@@ -3258,10 +3299,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
                   "data"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3293,10 +3335,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       M.read (| additional |)
                     ]
                   |)
@@ -3332,10 +3375,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       M.read (| additional |)
                     ]
                   |)
@@ -3368,10 +3412,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
-                  "data";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
+                  "data"
+                |);
                 M.read (| additional |)
               ]
             |)))
@@ -3401,10 +3446,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
-                  "data";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
+                  "data"
+                |);
                 M.read (| additional |)
               ]
             |)))
@@ -3436,10 +3482,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
                         "data"
+                      |)
                     ]
                   |)
                 |) in
@@ -3471,10 +3518,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
-                  "data";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
+                  "data"
+                |);
                 M.read (| min_capacity |)
               ]
             |)))
@@ -3503,10 +3551,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
                   "data"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3562,10 +3611,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
                   "data"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3593,10 +3643,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::BinaryHeap"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::BinaryHeap",
                   "data"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3656,10 +3707,11 @@ Module collections.
                       [ Ty.path "core::ops::range::RangeFull" ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       Value.StructTuple "core::ops::range::RangeFull" []
                     ]
                   |))
@@ -3844,10 +3896,11 @@ Module collections.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::binary_heap::Hole"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::binary_heap::Hole",
                 "pos"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3876,10 +3929,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Hole"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Hole",
                   "elt"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3926,10 +3980,11 @@ Module collections.
                                           (BinOp.Pure.ne
                                             (M.read (| index |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::binary_heap::Hole"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::binary_heap::Hole",
                                                 "pos"
+                                              |)
                                             |)))
                                       |)) in
                                   let _ :=
@@ -3985,10 +4040,11 @@ Module collections.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::binary_heap::Hole"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::binary_heap::Hole",
                                                     "data"
+                                                  |)
                                                 |)
                                               ]
                                             |)))
@@ -4026,10 +4082,11 @@ Module collections.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::Hole"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::Hole",
                         "data"
+                      |)
                     |);
                     M.read (| index |)
                   ]
@@ -4086,10 +4143,11 @@ Module collections.
                                           (BinOp.Pure.ne
                                             (M.read (| index |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::binary_heap::Hole"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::binary_heap::Hole",
                                                 "pos"
+                                              |)
                                             |)))
                                       |)) in
                                   let _ :=
@@ -4145,10 +4203,11 @@ Module collections.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::binary_heap::Hole"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::binary_heap::Hole",
                                                     "data"
+                                                  |)
                                                 |)
                                               ]
                                             |)))
@@ -4188,10 +4247,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::Hole"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::Hole",
                             "data"
+                          |)
                         |)
                       ]
                     |)
@@ -4212,10 +4272,11 @@ Module collections.
                       [
                         M.read (| ptr |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::Hole"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::Hole",
                             "pos"
+                          |)
                         |)
                       ]
                     |)
@@ -4231,10 +4292,11 @@ Module collections.
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::binary_heap::Hole"
-                    "pos",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::binary_heap::Hole",
+                    "pos"
+                  |),
                   M.read (| index |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -4269,10 +4331,11 @@ Module collections.
             M.read (|
               let pos :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::binary_heap::Hole"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::binary_heap::Hole",
                     "pos"
+                  |)
                 |) in
               let _ :=
                 M.alloc (|
@@ -4288,10 +4351,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::binary_heap::Hole"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::binary_heap::Hole",
                             "elt"
+                          |)
                         ]
                       |);
                       M.call_closure (|
@@ -4302,10 +4366,11 @@ Module collections.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::Hole"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::Hole",
                               "data"
+                            |)
                           |);
                           M.read (| pos |)
                         ]
@@ -4385,10 +4450,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::Iter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::Iter",
                               "iter"
+                            |)
                           ]
                         |)
                       |))
@@ -4436,10 +4502,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::Iter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::Iter",
                         "iter"
+                      |)
                     ]
                   |))
               ]))
@@ -4482,10 +4549,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Iter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Iter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4511,10 +4579,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Iter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Iter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4541,7 +4610,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "alloc::collections::binary_heap::Iter" "iter"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "alloc::collections::binary_heap::Iter",
+                    "iter"
+                  |)
                 |)
               ]
             |)))
@@ -4587,10 +4660,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Iter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Iter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4629,10 +4703,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Iter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Iter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4691,10 +4766,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::IntoIter",
                         "iter"
+                      |)
                     ]
                   |))
               ]))
@@ -4732,10 +4808,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4796,10 +4873,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::binary_heap::IntoIter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::binary_heap::IntoIter",
                               "iter"
+                            |)
                           ]
                         |)
                       |))
@@ -4846,10 +4924,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4875,10 +4954,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4922,10 +5002,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4964,10 +5045,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5160,10 +5242,11 @@ Module collections.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "alloc::collections::binary_heap::IntoIter"
-              "iter"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "alloc::collections::binary_heap::IntoIter",
+              "iter"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -5212,10 +5295,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::IntoIterSorted"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::IntoIterSorted",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -5256,10 +5340,11 @@ Module collections.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::binary_heap::IntoIterSorted"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::binary_heap::IntoIterSorted",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -5297,10 +5382,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIterSorted"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIterSorted",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5336,10 +5422,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::IntoIterSorted"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::IntoIterSorted",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5367,10 +5454,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::binary_heap::IntoIterSorted"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::binary_heap::IntoIterSorted",
                         "inner"
+                      |)
                     ]
                   |)
                 |) in
@@ -5470,10 +5558,11 @@ Module collections.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::binary_heap::Drain"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::binary_heap::Drain",
                       "iter"
+                    |)
                   |))
               ]
             |)))
@@ -5511,10 +5600,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Drain"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Drain",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5552,10 +5642,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Drain"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Drain",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5581,10 +5672,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Drain"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Drain",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5628,10 +5720,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Drain"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Drain",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5670,10 +5763,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::binary_heap::Drain"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::binary_heap::Drain",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5739,10 +5833,11 @@ Module collections.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::binary_heap::DrainSorted"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::binary_heap::DrainSorted",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -5781,10 +5876,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::binary_heap::DrainSorted"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::binary_heap::DrainSorted",
                     "inner"
+                  |)
                 |)
               ]
             |)))
@@ -5843,16 +5939,17 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::binary_heap::DrainSorted"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::binary_heap::DrainSorted",
                                       "inner"
+                                    |)
                                   |)
                                 ]
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -5939,10 +6036,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::binary_heap::DrainSorted"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::binary_heap::DrainSorted",
                     "inner"
+                  |)
                 |)
               ]
             |)))
@@ -5972,10 +6070,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::binary_heap::DrainSorted"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::binary_heap::DrainSorted",
                           "inner"
+                        |)
                       |)
                     ]
                   |)
@@ -6149,7 +6248,11 @@ Module collections.
           ltac:(M.monadic
             (let heap := M.alloc (| heap |) in
             M.read (|
-              M.get_struct_record_field heap "alloc::collections::binary_heap::BinaryHeap" "data"
+              M.SubPointer.get_struct_record_field (|
+                heap,
+                "alloc::collections::binary_heap::BinaryHeap",
+                "data"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -6263,10 +6366,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::binary_heap::BinaryHeap"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::binary_heap::BinaryHeap",
                           "data"
+                        |)
                       |)
                     ]
                   |))
@@ -6385,15 +6489,17 @@ Module collections.
                       [ I ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            guard
-                            "alloc::collections::binary_heap::RebuildOnDrop"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            guard,
+                            "alloc::collections::binary_heap::RebuildOnDrop",
                             "heap"
-                        |))
-                        "alloc::collections::binary_heap::BinaryHeap"
-                        "data";
+                          |)
+                        |),
+                        "alloc::collections::binary_heap::BinaryHeap",
+                        "data"
+                      |);
                       M.read (| iter |)
                     ]
                   |)

--- a/CoqOfRust/alloc/collections/btree/append.v
+++ b/CoqOfRust/alloc/collections/btree/append.v
@@ -260,13 +260,13 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
-                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let key := M.copy (| γ1_0 |) in
                                           let value := M.copy (| γ1_1 |) in
                                           let _ :=
@@ -387,7 +387,7 @@ Module collections.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::result::Result::Ok",
                                                                       0
@@ -509,7 +509,7 @@ Module collections.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::result::Result::Err",
                                                                       0
@@ -679,7 +679,7 @@ Module collections.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::option::Option::Some",
                                                                                   0
@@ -915,10 +915,11 @@ Module collections.
                         ]
                       |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::append::MergeIter"
-                          0;
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::append::MergeIter",
+                          0
+                        |);
                         M.closure
                           (fun γ =>
                             ltac:(M.monadic
@@ -945,8 +946,14 @@ Module collections.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| a |)) 0;
-                                                    M.get_tuple_field (M.read (| b |)) 0
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| a |),
+                                                      0
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| b |),
+                                                      0
+                                                    |)
                                                   ]
                                                 |)))
                                           ]
@@ -961,8 +968,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_next := M.copy (| γ0_0 |) in
                         let b_next := M.copy (| γ0_1 |) in
                         M.alloc (|

--- a/CoqOfRust/alloc/collections/btree/borrow.v
+++ b/CoqOfRust/alloc/collections/btree/borrow.v
@@ -126,10 +126,11 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "alloc::collections::btree::borrow::DormantMutRef"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::borrow::DormantMutRef",
                       "ptr"
+                    |)
                   |)
                 ]
               |)))
@@ -160,10 +161,11 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::borrow::DormantMutRef"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::borrow::DormantMutRef",
                       "ptr"
+                    |)
                   |)
                 ]
               |)))
@@ -194,10 +196,11 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::borrow::DormantMutRef"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::borrow::DormantMutRef",
                       "ptr"
+                    |)
                   |)
                 ]
               |)))

--- a/CoqOfRust/alloc/collections/btree/dedup_sorted_iter.v
+++ b/CoqOfRust/alloc/collections/btree/dedup_sorted_iter.v
@@ -107,10 +107,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::dedup_sorted_iter::DedupSortedIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::dedup_sorted_iter::DedupSortedIter",
                                         "iter"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -118,7 +119,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -152,10 +153,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::dedup_sorted_iter::DedupSortedIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::dedup_sorted_iter::DedupSortedIter",
                                         "iter"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -163,7 +165,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -203,8 +205,11 @@ Module collections.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field next 0;
-                                            M.get_tuple_field (M.read (| peeked |)) 0
+                                            M.SubPointer.get_tuple_field (| next, 0 |);
+                                            M.SubPointer.get_tuple_field (|
+                                              M.read (| peeked |),
+                                              0
+                                            |)
                                           ]
                                         |)
                                       |)) in

--- a/CoqOfRust/alloc/collections/btree/fix.v
+++ b/CoqOfRust/alloc/collections/btree/fix.v
@@ -126,13 +126,13 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "alloc::collections::btree::node::LeftOrRight::Left",
                                     0
@@ -222,13 +222,13 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "alloc::collections::btree::node::LeftOrRight::Right",
                                     0
@@ -318,7 +318,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -429,13 +429,13 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Ok",
                                       0
                                     |) in
                                   let γ1_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ0_0,
                                       "core::option::Option::Some",
                                       0
@@ -463,7 +463,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Ok",
                                       0
@@ -476,7 +476,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Err",
                                       0
@@ -1040,7 +1040,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::ForceResult::Internal",
                                 0
@@ -1330,7 +1330,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::ForceResult::Internal",
                                 0
@@ -1598,7 +1598,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::ForceResult::Internal",
                                 0

--- a/CoqOfRust/alloc/collections/btree/map.v
+++ b/CoqOfRust/alloc/collections/btree/map.v
@@ -251,10 +251,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::BTreeMap"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::BTreeMap",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -327,10 +328,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -351,10 +353,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::BTreeMap"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::BTreeMap",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -472,10 +475,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -485,7 +489,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -518,7 +522,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -553,7 +557,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::Found",
                                 0
@@ -564,8 +568,8 @@ Module collections.
                                 "core::option::Option::Some"
                                 [
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -591,15 +595,16 @@ Module collections.
                                           |),
                                           [ M.read (| handle |) ]
                                         |)
-                                      |))
+                                      |),
                                       0
+                                    |)
                                   |)
                                 ]
                             |)));
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::GoDown",
                                 0
@@ -661,8 +666,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let map := M.copy (| γ0_0 |) in
                             let dormant_map := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -735,10 +740,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| map |))
-                                                    "alloc::collections::btree::map::BTreeMap"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| map |),
+                                                    "alloc::collections::btree::map::BTreeMap",
                                                     "root"
+                                                  |)
                                                 ]
                                               |)
                                             ]
@@ -748,7 +754,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -782,7 +788,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -818,7 +824,7 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "alloc::collections::btree::search::SearchResult::Found",
                                         0
@@ -829,8 +835,8 @@ Module collections.
                                         "core::option::Option::Some"
                                         [
                                           M.read (|
-                                            M.get_tuple_field
-                                              (M.alloc (|
+                                            M.SubPointer.get_tuple_field (|
+                                              M.alloc (|
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
@@ -873,10 +879,11 @@ Module collections.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| map |))
-                                                                    "alloc::collections::btree::map::BTreeMap"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| map |),
+                                                                    "alloc::collections::btree::map::BTreeMap",
                                                                     "alloc"
+                                                                  |)
                                                                 ]
                                                               |)
                                                             ]
@@ -888,15 +895,16 @@ Module collections.
                                                       ]
                                                   ]
                                                 |)
-                                              |))
+                                              |),
                                               0
+                                            |)
                                           |)
                                         ]
                                     |)));
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "alloc::collections::btree::search::SearchResult::GoDown",
                                         0
@@ -962,8 +970,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let map := M.copy (| γ0_0 |) in
                         let dormant_map := M.copy (| γ0_1 |) in
                         let root_node :=
@@ -1016,10 +1024,11 @@ Module collections.
                                     ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| map |))
-                                      "alloc::collections::btree::map::BTreeMap"
-                                      "root";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| map |),
+                                      "alloc::collections::btree::map::BTreeMap",
+                                      "root"
+                                    |);
                                     M.closure
                                       (fun γ =>
                                         ltac:(M.monadic
@@ -1069,10 +1078,11 @@ Module collections.
                                                                 []
                                                               |),
                                                               [
-                                                                M.get_struct_record_field
-                                                                  (M.read (| map |))
-                                                                  "alloc::collections::btree::map::BTreeMap"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| map |),
+                                                                  "alloc::collections::btree::map::BTreeMap",
                                                                   "alloc"
+                                                                |)
                                                               ]
                                                             |)
                                                           ]
@@ -1111,7 +1121,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::SearchResult::Found",
                                     0
@@ -1157,7 +1167,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::SearchResult::GoDown",
                                     0
@@ -1210,10 +1220,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| map |))
-                                                        "alloc::collections::btree::map::BTreeMap"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| map |),
+                                                        "alloc::collections::btree::map::BTreeMap",
                                                         "alloc"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -1436,18 +1447,20 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::IterMut",
                                 "range"
+                              |)
                             ]
                           |));
                         ("length",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::IterMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::IterMut",
                               "length"
+                            |)
                           |))
                       ]
                   |) in
@@ -1586,18 +1599,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::IntoIter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::IntoIter",
                           "range"
+                        |)
                       ]
                     |));
                   ("length",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IntoIter",
                         "length"
+                      |)
                     |))
                 ]))
           | _, _ => M.impossible
@@ -1636,10 +1651,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IntoIter",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -1657,17 +1673,19 @@ Module collections.
                                 [ A ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::IntoIter"
-                                  "range";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::IntoIter",
+                                  "range"
+                                |);
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::IntoIter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::IntoIter",
                                       "alloc"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1678,10 +1696,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::IntoIter"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::IntoIter",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1700,10 +1719,11 @@ Module collections.
                                   [ A ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IntoIter"
-                                    "range";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IntoIter",
+                                    "range"
+                                  |);
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::clone::Clone",
@@ -1713,10 +1733,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::IntoIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::IntoIter",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -1763,10 +1784,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IntoIter",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -1784,17 +1806,19 @@ Module collections.
                                 [ A ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::IntoIter"
-                                  "range";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::IntoIter",
+                                  "range"
+                                |);
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::IntoIter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::IntoIter",
                                       "alloc"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1805,10 +1829,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::IntoIter"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::IntoIter",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1827,10 +1852,11 @@ Module collections.
                                   [ A ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IntoIter"
-                                    "range";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IntoIter",
+                                    "range"
+                                  |);
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::clone::Clone",
@@ -1840,10 +1866,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::IntoIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::IntoIter",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -2222,10 +2249,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::ValuesMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::ValuesMut",
                                 "inner"
+                              |)
                             ]
                           |);
                           M.closure
@@ -2238,8 +2266,8 @@ Module collections.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let val := M.copy (| γ0_1 |) in
                                           M.read (| val |)))
                                     ]
@@ -2358,10 +2386,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::IntoKeys"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::IntoKeys",
                                 "inner"
+                              |)
                             ]
                           |);
                           M.closure
@@ -2374,8 +2403,8 @@ Module collections.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let key := M.copy (| γ0_0 |) in
                                           M.read (| key |)))
                                     ]
@@ -2494,10 +2523,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::IntoValues"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::IntoValues",
                                 "inner"
+                              |)
                             ]
                           |);
                           M.closure
@@ -2510,8 +2540,8 @@ Module collections.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let val := M.copy (| γ0_1 |) in
                                           M.read (| val |)))
                                     ]
@@ -2668,10 +2698,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::RangeMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::RangeMut",
                                 "inner"
+                              |)
                             ]
                           |))
                       ]
@@ -2821,10 +2852,11 @@ Module collections.
                                   ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
-                                    "root";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
+                                    "root"
+                                  |);
                                   Value.StructTuple "core::option::Option::None" []
                                 ]
                               |));
@@ -2832,10 +2864,11 @@ Module collections.
                               M.call_closure (|
                                 M.get_function (| "core::mem::replace", [ Ty.path "usize" ] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
-                                    "length";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
+                                    "length"
+                                  |);
                                   Value.Integer Integer.Usize 0
                                 ]
                               |));
@@ -2849,10 +2882,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
                                     "alloc"
+                                  |)
                                 ]
                               |));
                             ("_marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -2990,10 +3024,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -3003,7 +3038,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -3036,7 +3071,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -3071,7 +3106,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::Found",
                                 0
@@ -3082,8 +3117,8 @@ Module collections.
                                 "core::option::Option::Some"
                                 [
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -3108,15 +3143,16 @@ Module collections.
                                           |),
                                           [ M.read (| handle |) ]
                                         |)
-                                      |))
+                                      |),
                                       1
+                                    |)
                                   |)
                                 ]
                             |)));
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::GoDown",
                                 0
@@ -3221,10 +3257,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -3234,7 +3271,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -3273,7 +3310,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -3308,7 +3345,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::Found",
                                 0
@@ -3345,7 +3382,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::GoDown",
                                 0
@@ -3445,10 +3482,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -3458,7 +3496,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -3497,7 +3535,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -3703,8 +3741,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let map := M.copy (| γ0_0 |) in
                             let dormant_map := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -3775,10 +3813,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| map |))
-                                                    "alloc::collections::btree::map::BTreeMap"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| map |),
+                                                    "alloc::collections::btree::map::BTreeMap",
                                                     "root"
+                                                  |)
                                                 ]
                                               |)
                                             ]
@@ -3788,7 +3827,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -3827,7 +3866,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -3972,7 +4011,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -4010,7 +4049,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -4074,10 +4113,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| map |))
-                                                  "alloc::collections::btree::map::BTreeMap"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| map |),
+                                                  "alloc::collections::btree::map::BTreeMap",
                                                   "alloc"
+                                                |)
                                               ]
                                             |)
                                           ]
@@ -4262,10 +4302,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -4275,7 +4316,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -4314,7 +4355,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -4520,8 +4561,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let map := M.copy (| γ0_0 |) in
                             let dormant_map := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -4592,10 +4633,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| map |))
-                                                    "alloc::collections::btree::map::BTreeMap"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| map |),
+                                                    "alloc::collections::btree::map::BTreeMap",
                                                     "root"
+                                                  |)
                                                 ]
                                               |)
                                             ]
@@ -4605,7 +4647,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -4644,7 +4686,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -4789,7 +4831,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -4827,7 +4869,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -4891,10 +4933,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| map |))
-                                                  "alloc::collections::btree::map::BTreeMap"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| map |),
+                                                  "alloc::collections::btree::map::BTreeMap",
                                                   "alloc"
+                                                |)
                                               ]
                                             |)
                                           ]
@@ -5126,10 +5169,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::BTreeMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::BTreeMap",
                                             "root"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -5139,7 +5183,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -5172,7 +5216,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -5207,7 +5251,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::Found",
                                 0
@@ -5244,7 +5288,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::search::SearchResult::GoDown",
                                 0
@@ -5299,7 +5343,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::map::entry::Entry::Occupied",
                             0
@@ -5324,7 +5368,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::map::entry::Entry::Vacant",
                             0
@@ -5389,7 +5433,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::map::entry::Entry::Occupied",
                             0
@@ -5407,7 +5451,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::map::entry::Entry::Vacant",
                             0
@@ -5480,8 +5524,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -5549,8 +5593,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let map := M.copy (| γ0_0 |) in
                             let dormant_map := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -5621,10 +5665,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| map |))
-                                                    "alloc::collections::btree::map::BTreeMap"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| map |),
+                                                    "alloc::collections::btree::map::BTreeMap",
                                                     "root"
+                                                  |)
                                                 ]
                                               |)
                                             ]
@@ -5634,7 +5679,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -5668,7 +5713,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -5704,7 +5749,7 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "alloc::collections::btree::search::SearchResult::Found",
                                         0
@@ -5751,10 +5796,11 @@ Module collections.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_struct_record_field
-                                                              (M.read (| map |))
-                                                              "alloc::collections::btree::map::BTreeMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| map |),
+                                                              "alloc::collections::btree::map::BTreeMap",
                                                               "alloc"
+                                                            |)
                                                           ]
                                                         |)
                                                       ]
@@ -5771,7 +5817,7 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "alloc::collections::btree::search::SearchResult::GoDown",
                                         0
@@ -6080,10 +6126,11 @@ Module collections.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::btree::map::BTreeMap"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::btree::map::BTreeMap",
                                               "alloc"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -6148,10 +6195,11 @@ Module collections.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::btree::map::BTreeMap"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::btree::map::BTreeMap",
                                               "alloc"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -6196,10 +6244,11 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
-                              "root";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
+                              "root"
+                            |);
                             M.closure
                               (fun γ =>
                                 ltac:(M.monadic
@@ -6248,10 +6297,11 @@ Module collections.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::btree::map::BTreeMap"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::btree::map::BTreeMap",
                                                           "alloc"
+                                                        |)
                                                       ]
                                                     |)
                                                   ]
@@ -6288,10 +6338,11 @@ Module collections.
                           M.read (| root |);
                           M.read (| self_iter |);
                           M.read (| other_iter |);
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::BTreeMap"
-                            "length";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::BTreeMap",
+                            "length"
+                          |);
                           M.call_closure (|
                             M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                             [
@@ -6304,10 +6355,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
                                     "alloc"
+                                  |)
                                 ]
                               |)
                             ]
@@ -6353,14 +6405,15 @@ Module collections.
                       ltac:(M.monadic
                         (let γ :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           |) in
                         let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -6470,14 +6523,15 @@ Module collections.
                       ltac:(M.monadic
                         (let γ :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           |) in
                         let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -6620,15 +6674,16 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let map := M.copy (| γ0_0 |) in
                         let dormant_map := M.copy (| γ0_1 |) in
                         M.match_operator (|
-                          M.get_struct_record_field
-                            (M.read (| map |))
-                            "alloc::collections::btree::map::BTreeMap"
-                            "root",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| map |),
+                            "alloc::collections::btree::map::BTreeMap",
+                            "root"
+                          |),
                           [
                             fun γ =>
                               ltac:(M.monadic
@@ -6665,10 +6720,11 @@ Module collections.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| map |))
-                                                      "alloc::collections::btree::map::BTreeMap"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| map |),
+                                                      "alloc::collections::btree::map::BTreeMap",
                                                       "alloc"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -6681,7 +6737,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -6729,7 +6785,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "alloc::collections::btree::search::SearchResult::Found",
                                             0
@@ -6766,10 +6822,11 @@ Module collections.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_struct_record_field
-                                                              (M.read (| map |))
-                                                              "alloc::collections::btree::map::BTreeMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| map |),
+                                                              "alloc::collections::btree::map::BTreeMap",
                                                               "alloc"
+                                                            |)
                                                           ]
                                                         |)
                                                       ]
@@ -6784,7 +6841,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "alloc::collections::btree::search::SearchResult::GoDown",
                                             0
@@ -6825,10 +6882,11 @@ Module collections.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_struct_record_field
-                                                              (M.read (| map |))
-                                                              "alloc::collections::btree::map::BTreeMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| map |),
+                                                              "alloc::collections::btree::map::BTreeMap",
                                                               "alloc"
+                                                            |)
                                                           ]
                                                         |)
                                                       ]
@@ -6949,10 +7007,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::btree::map::BTreeMap"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::btree::map::BTreeMap",
                                                     "alloc"
+                                                  |)
                                                 ]
                                               |)
                                             ]
@@ -7023,10 +7082,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |)
                           ]
@@ -7064,10 +7124,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::BTreeMap"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::BTreeMap",
                                       "alloc"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -7096,16 +7157,17 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let new_left_len := M.copy (| γ0_0 |) in
                             let right_len := M.copy (| γ0_1 |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
-                                  "length",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
+                                  "length"
+                                |),
                                 M.read (| new_left_len |)
                               |) in
                             M.alloc (|
@@ -7129,10 +7191,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::BTreeMap"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::BTreeMap",
                                           "alloc"
+                                        |)
                                       ]
                                     |));
                                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -7181,8 +7244,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let inner := M.copy (| γ0_0 |) in
                         let alloc := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -7265,15 +7328,16 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -7305,8 +7369,8 @@ Module collections.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let root := M.copy (| γ0_0 |) in
                                 let dormant_root := M.copy (| γ0_1 |) in
                                 let front :=
@@ -7353,10 +7417,11 @@ Module collections.
                                         "alloc::collections::btree::map::ExtractIfInner"
                                         [
                                           ("length",
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::btree::map::BTreeMap"
-                                              "length");
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::btree::map::BTreeMap",
+                                              "length"
+                                            |));
                                           ("dormant_root",
                                             Value.StructTuple
                                               "core::option::Option::Some"
@@ -7386,10 +7451,11 @@ Module collections.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::btree::map::BTreeMap"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::btree::map::BTreeMap",
                                                 "alloc"
+                                              |)
                                             ]
                                           |)
                                         ]
@@ -7407,10 +7473,11 @@ Module collections.
                                 "alloc::collections::btree::map::ExtractIfInner"
                                 [
                                   ("length",
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::BTreeMap"
-                                      "length");
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::BTreeMap",
+                                      "length"
+                                    |));
                                   ("dormant_root",
                                     Value.StructTuple "core::option::Option::None" []);
                                   ("cur_leaf_edge",
@@ -7430,10 +7497,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::BTreeMap"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::BTreeMap",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -7671,14 +7739,15 @@ Module collections.
                       ltac:(M.monadic
                         (let γ :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           |) in
                         let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -7727,10 +7796,11 @@ Module collections.
                               ("range", M.read (| full_range |));
                               ("length",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
                                     "length"
+                                  |)
                                 |))
                             ]
                         |)));
@@ -7793,14 +7863,15 @@ Module collections.
                       ltac:(M.monadic
                         (let γ :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           |) in
                         let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -7849,10 +7920,11 @@ Module collections.
                               ("range", M.read (| full_range |));
                               ("length",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::BTreeMap"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::BTreeMap",
                                     "length"
+                                  |)
                                 |));
                               ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                             ]
@@ -7997,10 +8069,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::map::BTreeMap"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::map::BTreeMap",
                   "length"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -8084,10 +8157,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |)
                           |),
@@ -8113,7 +8187,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -8252,10 +8326,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |))
                         ]
@@ -8331,18 +8406,19 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           ]
                         |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let root := M.copy (| γ0_0 |) in
                             let dormant_root := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -8387,10 +8463,11 @@ Module collections.
                                                         []);
                                                     ("root", M.read (| dormant_root |));
                                                     ("length",
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::btree::map::BTreeMap"
-                                                        "length");
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::btree::map::BTreeMap",
+                                                        "length"
+                                                      |));
                                                     ("alloc",
                                                       M.call_closure (|
                                                         M.get_trait_method (|
@@ -8404,10 +8481,11 @@ Module collections.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "alloc::collections::btree::map::BTreeMap"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "alloc::collections::btree::map::BTreeMap",
                                                             "alloc"
+                                                          |)
                                                         ]
                                                       |))
                                                   ]
@@ -8418,7 +8496,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -8547,10 +8625,11 @@ Module collections.
                                     |));
                                   ("root", M.read (| dormant_root |));
                                   ("length",
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::BTreeMap"
-                                      "length");
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::BTreeMap",
+                                      "length"
+                                    |));
                                   ("alloc",
                                     M.call_closure (|
                                       M.get_trait_method (|
@@ -8563,10 +8642,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::BTreeMap"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::BTreeMap",
                                           "alloc"
+                                        |)
                                       ]
                                     |))
                                 ]
@@ -8629,10 +8709,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |)
                           |),
@@ -8658,7 +8739,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -8797,10 +8878,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |))
                         ]
@@ -8876,18 +8958,19 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::BTreeMap"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::BTreeMap",
                               "root"
+                            |)
                           ]
                         |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let root := M.copy (| γ0_0 |) in
                             let dormant_root := M.copy (| γ0_1 |) in
                             let root_node :=
@@ -8932,10 +9015,11 @@ Module collections.
                                                         []);
                                                     ("root", M.read (| dormant_root |));
                                                     ("length",
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::btree::map::BTreeMap"
-                                                        "length");
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::btree::map::BTreeMap",
+                                                        "length"
+                                                      |));
                                                     ("alloc",
                                                       M.call_closure (|
                                                         M.get_trait_method (|
@@ -8949,10 +9033,11 @@ Module collections.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "alloc::collections::btree::map::BTreeMap"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "alloc::collections::btree::map::BTreeMap",
                                                             "alloc"
+                                                          |)
                                                         ]
                                                       |))
                                                   ]
@@ -8963,7 +9048,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -9092,10 +9177,11 @@ Module collections.
                                     |));
                                   ("root", M.read (| dormant_root |));
                                   ("length",
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::BTreeMap"
-                                      "length");
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::BTreeMap",
+                                      "length"
+                                    |));
                                   ("alloc",
                                     M.call_closure (|
                                       M.get_trait_method (|
@@ -9108,10 +9194,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::BTreeMap"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::BTreeMap",
                                           "alloc"
+                                        |)
                                       ]
                                     |))
                                 ]
@@ -9214,10 +9301,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Iter",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -9228,10 +9316,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Iter"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Iter",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9250,10 +9339,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Iter",
                                     "range"
+                                  |)
                                 ]
                               |)
                             ]
@@ -9278,19 +9368,21 @@ Module collections.
               Value.Tuple
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::map::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::map::Iter",
                       "length"
+                    |)
                   |);
                   Value.StructTuple
                     "core::option::Option::Some"
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Iter",
                           "length"
+                        |)
                       |)
                     ]
                 ]))
@@ -9436,10 +9528,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Iter",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -9450,10 +9543,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Iter"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Iter",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9472,10 +9566,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Iter",
                                     "range"
+                                  |)
                                 ]
                               |)
                             ]
@@ -9511,10 +9606,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::map::Iter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::map::Iter",
                   "length"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -9558,18 +9654,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Iter",
                           "range"
+                        |)
                       ]
                     |));
                   ("length",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Iter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Iter",
                         "length"
+                      |)
                     |))
                 ]))
           | _, _ => M.impossible
@@ -9669,10 +9767,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IterMut",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -9683,10 +9782,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::IterMut"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::IterMut",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9708,10 +9808,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IterMut",
                                     "range"
+                                  |)
                                 ]
                               |)
                             ]
@@ -9736,19 +9837,21 @@ Module collections.
               Value.Tuple
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::map::IterMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::map::IterMut",
                       "length"
+                    |)
                   |);
                   Value.StructTuple
                     "core::option::Option::Some"
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::IterMut",
                           "length"
+                        |)
                       |)
                     ]
                 ]))
@@ -9881,10 +9984,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IterMut",
                                     "length"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -9895,10 +9999,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::IterMut"
-                              "length" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::IterMut",
+                              "length"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9920,10 +10025,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::IterMut",
                                     "range"
+                                  |)
                                 ]
                               |)
                             ]
@@ -9959,10 +10065,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::map::IterMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::map::IterMut",
                   "length"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -10017,18 +10124,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::IterMut",
                           "range"
+                        |)
                       ]
                     |));
                   ("length",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IterMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IterMut",
                         "length"
+                      |)
                     |))
                 ]))
           | _, _ => M.impossible
@@ -10120,8 +10229,8 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::deref::DerefMut",
                                       Ty.apply
@@ -10136,14 +10245,15 @@ Module collections.
                                       []
                                     |),
                                     [ me ]
-                                  |))
-                                  "alloc::collections::btree::map::BTreeMap"
+                                  |),
+                                  "alloc::collections::btree::map::BTreeMap",
                                   "root"
+                                |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -10192,8 +10302,8 @@ Module collections.
                               ("range", M.read (| full_range |));
                               ("length",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.call_closure (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.call_closure (|
                                       M.get_trait_method (|
                                         "core::ops::deref::Deref",
                                         Ty.apply
@@ -10208,9 +10318,10 @@ Module collections.
                                         []
                                       |),
                                       [ me ]
-                                    |))
-                                    "alloc::collections::btree::map::BTreeMap"
+                                    |),
+                                    "alloc::collections::btree::map::BTreeMap",
                                     "length"
+                                  |)
                                 |));
                               ("alloc",
                                 M.call_closure (|
@@ -10222,8 +10333,8 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_trait_method (|
                                           "core::ops::deref::DerefMut",
                                           Ty.apply
@@ -10238,9 +10349,10 @@ Module collections.
                                           []
                                         |),
                                         [ me ]
-                                      |))
-                                      "alloc::collections::btree::map::BTreeMap"
+                                      |),
+                                      "alloc::collections::btree::map::BTreeMap",
                                       "alloc"
+                                    |)
                                   ]
                                 |))
                             ]
@@ -10277,8 +10389,8 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_trait_method (|
                                           "core::ops::deref::DerefMut",
                                           Ty.apply
@@ -10293,9 +10405,10 @@ Module collections.
                                           []
                                         |),
                                         [ me ]
-                                      |))
-                                      "alloc::collections::btree::map::BTreeMap"
+                                      |),
+                                      "alloc::collections::btree::map::BTreeMap",
                                       "alloc"
+                                    |)
                                   ]
                                 |))
                             ]
@@ -10375,7 +10488,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -10584,19 +10697,21 @@ Module collections.
               Value.Tuple
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::map::IntoIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::map::IntoIter",
                       "length"
+                    |)
                   |);
                   Value.StructTuple
                     "core::option::Option::Some"
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::IntoIter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::IntoIter",
                           "length"
+                        |)
                       |)
                     ]
                 ]))
@@ -10754,10 +10869,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::map::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::map::IntoIter",
                   "length"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -10829,10 +10945,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Keys"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Keys",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -10845,8 +10962,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -10878,10 +10995,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Keys"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Keys",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11024,10 +11142,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Keys"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Keys",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -11040,8 +11159,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -11086,10 +11205,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Keys"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Keys",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11145,10 +11265,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Keys"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Keys",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -11250,10 +11371,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Values"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Values",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -11266,8 +11388,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -11299,10 +11421,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Values"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Values",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11389,10 +11512,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Values"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Values",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -11405,8 +11529,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -11451,10 +11575,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Values"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Values",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11510,10 +11635,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Values"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Values",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -11682,10 +11808,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::ExtractIf"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::ExtractIf",
                                 "inner"
+                              |)
                             ]
                           |)
                         |))
@@ -11730,21 +11857,24 @@ Module collections.
                   [ F; A ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::ExtractIf"
-                    "inner";
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::ExtractIf"
-                    "pred";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::ExtractIf",
+                    "inner"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::ExtractIf",
+                    "pred"
+                  |);
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::ExtractIf"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::ExtractIf",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -11770,10 +11900,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::ExtractIf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::ExtractIf",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11872,10 +12003,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::ExtractIfInner"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::ExtractIfInner",
                                       "cur_leaf_edge"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -11885,7 +12017,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -11924,7 +12056,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -12219,10 +12351,11 @@ Module collections.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::btree::map::ExtractIfInner"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::btree::map::ExtractIfInner",
                                                           "cur_leaf_edge"
+                                                        |)
                                                       ]
                                                     |)
                                                   ]
@@ -12232,7 +12365,7 @@ Module collections.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -12268,7 +12401,7 @@ Module collections.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -12282,7 +12415,7 @@ Module collections.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Ok",
                                       0
@@ -12316,8 +12449,8 @@ Module collections.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let k := M.copy (| γ0_0 |) in
                                           let v := M.copy (| γ0_1 |) in
                                           let _ :=
@@ -12361,10 +12494,11 @@ Module collections.
                                                           let _ :=
                                                             let β :=
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "alloc::collections::btree::map::ExtractIfInner"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "alloc::collections::btree::map::ExtractIfInner",
                                                                   "length"
+                                                                |)
                                                               |) in
                                                             M.write (|
                                                               β,
@@ -12494,12 +12628,13 @@ Module collections.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_struct_record_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_struct_record_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      "alloc::collections::btree::map::ExtractIfInner"
+                                                                                                      |),
+                                                                                                      "alloc::collections::btree::map::ExtractIfInner",
                                                                                                       "dormant_root"
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               ]
@@ -12546,18 +12681,19 @@ Module collections.
                                                                                       |) in
                                                                                     let _ :=
                                                                                       M.write (|
-                                                                                        M.get_struct_record_field
-                                                                                          (M.read (|
+                                                                                        M.SubPointer.get_struct_record_field (|
+                                                                                          M.read (|
                                                                                             self
-                                                                                          |))
-                                                                                          "alloc::collections::btree::map::ExtractIfInner"
-                                                                                          "dormant_root",
+                                                                                          |),
+                                                                                          "alloc::collections::btree::map::ExtractIfInner",
+                                                                                          "dormant_root"
+                                                                                        |),
                                                                                         Value.StructTuple
                                                                                           "core::option::Option::Some"
                                                                                           [
                                                                                             M.read (|
-                                                                                              M.get_tuple_field
-                                                                                                (M.alloc (|
+                                                                                              M.SubPointer.get_tuple_field (|
+                                                                                                M.alloc (|
                                                                                                   M.call_closure (|
                                                                                                     M.get_associated_function (|
                                                                                                       Ty.apply
@@ -12585,8 +12721,9 @@ Module collections.
                                                                                                       |)
                                                                                                     ]
                                                                                                   |)
-                                                                                                |))
+                                                                                                |),
                                                                                                 1
+                                                                                              |)
                                                                                             |)
                                                                                           ]
                                                                                       |) in
@@ -12615,17 +12752,24 @@ Module collections.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let kv := M.copy (| γ0_0 |) in
                                                                   let pos := M.copy (| γ0_1 |) in
                                                                   let _ :=
                                                                     M.write (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "alloc::collections::btree::map::ExtractIfInner"
-                                                                        "cur_leaf_edge",
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "alloc::collections::btree::map::ExtractIfInner",
+                                                                        "cur_leaf_edge"
+                                                                      |),
                                                                       Value.StructTuple
                                                                         "core::option::Option::Some"
                                                                         [ M.read (| pos |) ]
@@ -12646,10 +12790,11 @@ Module collections.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::btree::map::ExtractIfInner"
-                                                "cur_leaf_edge",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::btree::map::ExtractIfInner",
+                                                "cur_leaf_edge"
+                                              |),
                                               Value.StructTuple
                                                 "core::option::Option::Some"
                                                 [
@@ -12732,10 +12877,11 @@ Module collections.
                     [
                       M.read (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::ExtractIfInner"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::ExtractIfInner",
                             "length"
+                          |)
                         |)
                       |)
                     ]
@@ -12791,10 +12937,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Range"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Range",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -12984,10 +13131,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::ValuesMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::ValuesMut",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13000,8 +13148,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -13033,10 +13181,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::ValuesMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::ValuesMut",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13125,10 +13274,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::ValuesMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::ValuesMut",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13141,8 +13291,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -13187,10 +13337,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::ValuesMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::ValuesMut",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13252,10 +13403,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IntoKeys"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IntoKeys",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13268,8 +13420,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -13301,10 +13453,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::IntoKeys"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::IntoKeys",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13436,10 +13589,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IntoKeys"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IntoKeys",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13452,8 +13606,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -13498,10 +13652,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::IntoKeys"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::IntoKeys",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13604,10 +13759,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IntoValues"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IntoValues",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13620,8 +13776,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -13653,10 +13809,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::IntoValues"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::IntoValues",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13732,10 +13889,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::IntoValues"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::IntoValues",
                         "inner"
+                      |)
                     ]
                   |);
                   M.closure
@@ -13748,8 +13906,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let v := M.copy (| γ0_1 |) in
                                   M.read (| v |)))
                             ]
@@ -13794,10 +13952,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::IntoValues"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::IntoValues",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13890,10 +14049,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::Range"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::Range",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -13951,10 +14111,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Range",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -13998,10 +14159,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::RangeMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::RangeMut",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -14125,10 +14287,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::map::RangeMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::map::RangeMut",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -14315,8 +14478,14 @@ Module collections.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_tuple_field (M.read (| a |)) 0;
-                                                        M.get_tuple_field (M.read (| b |)) 0
+                                                        M.SubPointer.get_tuple_field (|
+                                                          M.read (| a |),
+                                                          0
+                                                        |);
+                                                        M.SubPointer.get_tuple_field (|
+                                                          M.read (| b |),
+                                                          0
+                                                        |)
                                                       ]
                                                     |)))
                                               ]
@@ -14408,8 +14577,8 @@ Module collections.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let k := M.copy (| γ0_0 |) in
                                         let v := M.copy (| γ0_1 |) in
                                         M.read (|
@@ -14459,8 +14628,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let k := M.copy (| γ0_0 |) in
                       let v := M.copy (| γ0_1 |) in
                       M.read (|
@@ -14583,8 +14752,8 @@ Module collections.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let γ0_0 := M.read (| γ0_0 |) in
                                             let key := M.copy (| γ0_0 |) in
                                             let γ0_1 := M.read (| γ0_1 |) in
@@ -14621,8 +14790,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let k := M.copy (| γ0_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
@@ -14758,7 +14927,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -14946,8 +15115,8 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let a := M.copy (| γ0_0 |) in
                                       let b := M.copy (| γ0_1 |) in
                                       M.call_closure (|
@@ -15346,8 +15515,14 @@ Module collections.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_tuple_field (M.read (| a |)) 0;
-                                                        M.get_tuple_field (M.read (| b |)) 0
+                                                        M.SubPointer.get_tuple_field (|
+                                                          M.read (| a |),
+                                                          0
+                                                        |);
+                                                        M.SubPointer.get_tuple_field (|
+                                                          M.read (| b |),
+                                                          0
+                                                        |)
                                                       ]
                                                     |)))
                                               ]
@@ -15454,13 +15629,13 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::map::Cursor",
                             "current"
                           |) in
                         let γ0_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::map::Cursor",
                             "root"
@@ -15722,10 +15897,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Cursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Cursor",
                           "current"
+                        |)
                       ]
                     |)
                   |),
@@ -15734,10 +15910,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Cursor"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Cursor",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -15817,10 +15994,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Cursor"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Cursor",
                                     "root"
+                                  |)
                                 |);
                                 M.closure
                                   (fun γ =>
@@ -15981,7 +16159,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -15989,10 +16167,11 @@ Module collections.
                         let current := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Cursor"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Cursor",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -16132,10 +16311,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::Cursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::Cursor",
                           "current"
+                        |)
                       ]
                     |)
                   |),
@@ -16144,10 +16324,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Cursor"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Cursor",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -16227,10 +16408,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::Cursor"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::Cursor",
                                     "root"
+                                  |)
                                 |);
                                 M.closure
                                   (fun γ =>
@@ -16391,7 +16573,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -16399,10 +16581,11 @@ Module collections.
                         let current := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::Cursor"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::Cursor",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -16583,10 +16766,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Cursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Cursor",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -16601,8 +16785,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -16627,8 +16811,9 @@ Module collections.
                                           |),
                                           [ M.read (| M.read (| current |) |) ]
                                         |)
-                                      |))
+                                      |),
                                       0
+                                    |)
                                   |)))
                             ]
                           |)
@@ -16731,10 +16916,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Cursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Cursor",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -16749,8 +16935,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -16775,8 +16961,9 @@ Module collections.
                                           |),
                                           [ M.read (| M.read (| current |) |) ]
                                         |)
-                                      |))
+                                      |),
                                       1
+                                    |)
                                   |)))
                             ]
                           |)
@@ -16879,10 +17066,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::Cursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::Cursor",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -17050,10 +17238,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            next
-                            "alloc::collections::btree::map::Cursor"
+                          M.SubPointer.get_struct_record_field (|
+                            next,
+                            "alloc::collections::btree::map::Cursor",
                             "current"
+                          |)
                         ]
                       |);
                       M.closure
@@ -17223,10 +17412,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            prev
-                            "alloc::collections::btree::map::Cursor"
+                          M.SubPointer.get_struct_record_field (|
+                            prev,
+                            "alloc::collections::btree::map::Cursor",
                             "current"
+                          |)
                         ]
                       |);
                       M.closure
@@ -17330,10 +17520,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::CursorMut",
                           "current"
+                        |)
                       ]
                     |)
                   |),
@@ -17342,10 +17533,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -17470,10 +17662,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::CursorMut",
                                           "root"
+                                        |)
                                       ]
                                     |)
                                   ]
@@ -17637,7 +17830,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -17645,10 +17838,11 @@ Module collections.
                         let current := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -17787,10 +17981,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::CursorMut",
                           "current"
+                        |)
                       ]
                     |)
                   |),
@@ -17799,10 +17994,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -17927,10 +18123,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::CursorMut",
                                           "root"
+                                        |)
                                       ]
                                     |)
                                   ]
@@ -18094,7 +18291,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -18102,10 +18299,11 @@ Module collections.
                         let current := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
-                              "current",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
+                              "current"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -18284,10 +18482,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -18302,8 +18501,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -18354,8 +18553,9 @@ Module collections.
                                             |)
                                           ]
                                         |)
-                                      |))
+                                      |),
                                       0
+                                    |)
                                   |)))
                             ]
                           |)
@@ -18458,10 +18658,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -18476,8 +18677,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -18528,8 +18729,9 @@ Module collections.
                                             |)
                                           ]
                                         |)
-                                      |))
+                                      |),
                                       1
+                                    |)
                                   |)))
                             ]
                           |)
@@ -18632,10 +18834,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -18795,10 +18998,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -18813,8 +19017,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -18839,8 +19043,9 @@ Module collections.
                                           |),
                                           [ M.read (| current |) ]
                                         |)
-                                      |))
+                                      |),
                                       1
+                                    |)
                                   |)))
                             ]
                           |)
@@ -18946,10 +19151,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -18994,8 +19200,8 @@ Module collections.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let k := M.copy (| γ0_0 |) in
                                             let v := M.copy (| γ0_1 |) in
                                             M.alloc (|
@@ -19105,10 +19311,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::map::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::map::CursorMut",
                         "current"
+                      |)
                     ]
                   |);
                   M.closure
@@ -19123,8 +19330,8 @@ Module collections.
                                 ltac:(M.monadic
                                   (let current := M.copy (| γ |) in
                                   M.read (|
-                                    M.get_tuple_field
-                                      (M.alloc (|
+                                    M.SubPointer.get_tuple_field (|
+                                      M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -19149,8 +19356,9 @@ Module collections.
                                           |),
                                           [ M.read (| current |) ]
                                         |)
-                                      |))
+                                      |),
                                       0
+                                    |)
                                   |)))
                             ]
                           |)
@@ -19197,10 +19405,11 @@ Module collections.
                   (M.read (|
                     M.match_operator (|
                       M.match_operator (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::CursorMut"
-                          "current",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::CursorMut",
+                          "current"
+                        |),
                         [
                           fun γ =>
                             ltac:(M.monadic
@@ -19435,12 +19644,11 @@ Module collections.
                                                                                 []
                                                                               |),
                                                                               [
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "alloc::collections::btree::map::CursorMut"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "alloc::collections::btree::map::CursorMut",
                                                                                   "root"
+                                                                                |)
                                                                               ]
                                                                             |)
                                                                           ]
@@ -19452,7 +19660,7 @@ Module collections.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_struct_tuple_field_or_break_match (|
+                                                                          M.SubPointer.get_struct_tuple_field (|
                                                                             γ,
                                                                             "core::ops::control_flow::ControlFlow::Break",
                                                                             0
@@ -19507,7 +19715,7 @@ Module collections.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_struct_tuple_field_or_break_match (|
+                                                                          M.SubPointer.get_struct_tuple_field (|
                                                                             γ,
                                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                                             0
@@ -19533,7 +19741,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -19573,7 +19781,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -19589,7 +19797,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -19774,7 +19982,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -19814,7 +20022,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -19832,8 +20040,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let k := M.copy (| γ0_0 |) in
                             let v := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -19913,10 +20121,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::CursorMut",
                                 "current"
+                              |)
                             ]
                           |)
                         |),
@@ -20154,12 +20363,11 @@ Module collections.
                                                                                 []
                                                                               |),
                                                                               [
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "alloc::collections::btree::map::CursorMut"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "alloc::collections::btree::map::CursorMut",
                                                                                   "root"
+                                                                                |)
                                                                               ]
                                                                             |)
                                                                           ]
@@ -20171,7 +20379,7 @@ Module collections.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_struct_tuple_field_or_break_match (|
+                                                                          M.SubPointer.get_struct_tuple_field (|
                                                                             γ,
                                                                             "core::ops::control_flow::ControlFlow::Break",
                                                                             0
@@ -20226,7 +20434,7 @@ Module collections.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_struct_tuple_field_or_break_match (|
+                                                                          M.SubPointer.get_struct_tuple_field (|
                                                                             γ,
                                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                                             0
@@ -20252,7 +20460,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -20292,7 +20500,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -20308,7 +20516,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -20493,7 +20701,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -20533,7 +20741,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -20551,8 +20759,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let k := M.copy (| γ0_0 |) in
                             let v := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -20631,10 +20839,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
                               "root"
+                            |)
                           ]
                         |)
                       ]
@@ -20745,10 +20954,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::map::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::map::CursorMut",
                               "current"
+                            |)
                           ]
                         |);
                         M.closure
@@ -20869,10 +21079,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::CursorMut",
                                   "current"
+                                |)
                               ]
                             |)
                           |),
@@ -20907,10 +21118,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::CursorMut",
                                           "root"
+                                        |)
                                       ]
                                     |)
                                   |),
@@ -20951,10 +21163,11 @@ Module collections.
                                                         |),
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "alloc::collections::btree::map::CursorMut"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "alloc::collections::btree::map::CursorMut",
                                                               "alloc"
+                                                            |)
                                                           |)
                                                         ]
                                                       |)
@@ -21034,10 +21247,11 @@ Module collections.
                                               let _ :=
                                                 let β :=
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::btree::map::CursorMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::btree::map::CursorMut",
                                                       "length"
+                                                    |)
                                                   |) in
                                                 M.write (|
                                                   β,
@@ -21054,7 +21268,7 @@ Module collections.
                                       ltac:(M.monadic
                                         (let γ := M.read (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -21103,7 +21317,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -21181,10 +21395,11 @@ Module collections.
                               M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "alloc"
+                                  |)
                                 |)
                               ]
                             |);
@@ -21221,10 +21436,11 @@ Module collections.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
                                                           "left"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -21303,10 +21519,11 @@ Module collections.
                                                               []
                                                             |),
                                                             [
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "alloc::collections::btree::map::CursorMut"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "alloc::collections::btree::map::CursorMut",
                                                                 "root"
+                                                              |)
                                                             ]
                                                           |)
                                                         ]
@@ -21361,10 +21578,11 @@ Module collections.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "alloc::collections::btree::map::CursorMut"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "alloc::collections::btree::map::CursorMut",
                                                                   "alloc"
+                                                                |)
                                                               |)
                                                             ]
                                                           |)
@@ -21372,26 +21590,31 @@ Module collections.
                                                       |)
                                                     |);
                                                     M.read (|
-                                                      M.get_tuple_field
-                                                        (M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
-                                                          "kv")
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
+                                                          "kv"
+                                                        |),
                                                         0
+                                                      |)
                                                     |);
                                                     M.read (|
-                                                      M.get_tuple_field
-                                                        (M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
-                                                          "kv")
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
+                                                          "kv"
+                                                        |),
                                                         1
+                                                      |)
                                                     |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        ins
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        ins,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "right"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -21406,10 +21629,11 @@ Module collections.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::CursorMut"
-                          "current",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::CursorMut",
+                          "current"
+                        |),
                         M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
@@ -21490,10 +21714,11 @@ Module collections.
                     let _ :=
                       let β :=
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::CursorMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::CursorMut",
                             "length"
+                          |)
                         |) in
                       M.write (|
                         β,
@@ -21582,10 +21807,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::CursorMut",
                                   "current"
+                                |)
                               ]
                             |)
                           |),
@@ -21620,10 +21846,11 @@ Module collections.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::map::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::map::CursorMut",
                                           "root"
+                                        |)
                                       ]
                                     |)
                                   |),
@@ -21664,10 +21891,11 @@ Module collections.
                                                         |),
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "alloc::collections::btree::map::CursorMut"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "alloc::collections::btree::map::CursorMut",
                                                               "alloc"
+                                                            |)
                                                           |)
                                                         ]
                                                       |)
@@ -21747,10 +21975,11 @@ Module collections.
                                               let _ :=
                                                 let β :=
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::btree::map::CursorMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::btree::map::CursorMut",
                                                       "length"
+                                                    |)
                                                   |) in
                                                 M.write (|
                                                   β,
@@ -21767,7 +21996,7 @@ Module collections.
                                       ltac:(M.monadic
                                         (let γ := M.read (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -21816,7 +22045,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -21894,10 +22123,11 @@ Module collections.
                               M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "alloc"
+                                  |)
                                 |)
                               ]
                             |);
@@ -21934,10 +22164,11 @@ Module collections.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
                                                           "left"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -22016,10 +22247,11 @@ Module collections.
                                                               []
                                                             |),
                                                             [
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "alloc::collections::btree::map::CursorMut"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "alloc::collections::btree::map::CursorMut",
                                                                 "root"
+                                                              |)
                                                             ]
                                                           |)
                                                         ]
@@ -22074,10 +22306,11 @@ Module collections.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "alloc::collections::btree::map::CursorMut"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "alloc::collections::btree::map::CursorMut",
                                                                   "alloc"
+                                                                |)
                                                               |)
                                                             ]
                                                           |)
@@ -22085,26 +22318,31 @@ Module collections.
                                                       |)
                                                     |);
                                                     M.read (|
-                                                      M.get_tuple_field
-                                                        (M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
-                                                          "kv")
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
+                                                          "kv"
+                                                        |),
                                                         0
+                                                      |)
                                                     |);
                                                     M.read (|
-                                                      M.get_tuple_field
-                                                        (M.get_struct_record_field
-                                                          ins
-                                                          "alloc::collections::btree::node::SplitResult"
-                                                          "kv")
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          ins,
+                                                          "alloc::collections::btree::node::SplitResult",
+                                                          "kv"
+                                                        |),
                                                         1
+                                                      |)
                                                     |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        ins
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        ins,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "right"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -22119,10 +22357,11 @@ Module collections.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::map::CursorMut"
-                          "current",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::map::CursorMut",
+                          "current"
+                        |),
                         M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
@@ -22203,10 +22442,11 @@ Module collections.
                     let _ :=
                       let β :=
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::CursorMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::CursorMut",
                             "length"
+                          |)
                         |) in
                       M.write (|
                         β,
@@ -22271,7 +22511,7 @@ Module collections.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -22356,13 +22596,13 @@ Module collections.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let next := M.copy (| γ1_0 |) in
                           M.match_operator (|
                             M.alloc (| Value.Tuple [] |),
@@ -22489,7 +22729,7 @@ Module collections.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -22574,13 +22814,13 @@ Module collections.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let prev := M.copy (| γ1_0 |) in
                           M.match_operator (|
                             M.alloc (| Value.Tuple [] |),
@@ -22742,10 +22982,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::CursorMut",
                                       "current"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -22755,7 +22996,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -22788,7 +23029,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -22843,10 +23084,11 @@ Module collections.
                               M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "alloc"
+                                  |)
                                 |)
                               ]
                             |)
@@ -22856,16 +23098,17 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let kv := M.copy (| γ0_0 |) in
                             let pos := M.copy (| γ0_1 |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::CursorMut"
-                                  "current",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::CursorMut",
+                                  "current"
+                                |),
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply
@@ -22928,10 +23171,11 @@ Module collections.
                             let _ :=
                               let β :=
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "length"
+                                  |)
                                 |) in
                               M.write (|
                                 β,
@@ -23023,10 +23267,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::btree::map::CursorMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::btree::map::CursorMut",
                                                         "root"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -23063,10 +23308,11 @@ Module collections.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::btree::map::CursorMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::btree::map::CursorMut",
                                                       "alloc"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -23176,10 +23422,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::CursorMut",
                                       "current"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -23189,7 +23436,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -23222,7 +23469,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -23277,10 +23524,11 @@ Module collections.
                               M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "alloc"
+                                  |)
                                 |)
                               ]
                             |)
@@ -23290,16 +23538,17 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let kv := M.copy (| γ0_0 |) in
                             let pos := M.copy (| γ0_1 |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::map::CursorMut"
-                                  "current",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::map::CursorMut",
+                                  "current"
+                                |),
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply
@@ -23362,10 +23611,11 @@ Module collections.
                             let _ :=
                               let β :=
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::CursorMut",
                                     "length"
+                                  |)
                                 |) in
                               M.write (|
                                 β,
@@ -23457,10 +23707,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::btree::map::CursorMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::btree::map::CursorMut",
                                                         "root"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -23497,10 +23748,11 @@ Module collections.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::btree::map::CursorMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::btree::map::CursorMut",
                                                       "alloc"
+                                                    |)
                                                   |)
                                                 ]
                                               |)

--- a/CoqOfRust/alloc/collections/btree/map/entry.v
+++ b/CoqOfRust/alloc/collections/btree/map/entry.v
@@ -63,7 +63,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -103,7 +103,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -468,10 +468,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::map::entry::OccupiedError"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::map::entry::OccupiedError",
                                         "entry"
+                                      |)
                                     ]
                                   |))
                               ]
@@ -488,10 +489,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::map::entry::OccupiedError"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::map::entry::OccupiedError",
                                     "entry"
+                                  |)
                                 ]
                               |))
                           ]
@@ -499,10 +501,11 @@ Module collections.
                         M.read (| Value.String "new_value" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::entry::OccupiedError"
-                            "value")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::entry::OccupiedError",
+                            "value"
+                          |))
                       ]
                     |)
                   ]
@@ -570,10 +573,11 @@ Module collections.
                                     [ V ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::map::entry::OccupiedError"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::map::entry::OccupiedError",
                                       "value"
+                                    |)
                                   ]
                                 |);
                                 M.call_closure (|
@@ -594,10 +598,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::entry::OccupiedError"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::entry::OccupiedError",
                                             "entry"
+                                          |)
                                         ]
                                       |)
                                     |)
@@ -621,10 +626,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::btree::map::entry::OccupiedError"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::btree::map::entry::OccupiedError",
                                             "entry"
+                                          |)
                                         ]
                                       |)
                                     |)
@@ -704,7 +710,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -725,7 +731,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -775,7 +781,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -796,7 +802,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -861,7 +867,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -882,7 +888,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -960,7 +966,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -981,7 +987,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -1037,7 +1043,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -1080,7 +1086,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -1121,7 +1127,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Occupied",
                               0
@@ -1142,7 +1148,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::map::entry::Entry::Vacant",
                               0
@@ -1199,10 +1205,11 @@ Module collections.
             | [], [ self ] =>
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::map::entry::VacantEntry"
-                  "key"))
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::map::entry::VacantEntry",
+                  "key"
+                |)))
             | _, _ => M.impossible
             end.
           
@@ -1222,10 +1229,11 @@ Module collections.
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
                 M.read (|
-                  M.get_struct_record_field
-                    self
-                    "alloc::collections::btree::map::entry::VacantEntry"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "alloc::collections::btree::map::entry::VacantEntry",
                     "key"
+                  |)
                 |)))
             | _, _ => M.impossible
             end.
@@ -1283,10 +1291,11 @@ Module collections.
                   let out_ptr :=
                     M.copy (|
                       M.match_operator (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::map::entry::VacantEntry"
-                          "handle",
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::map::entry::VacantEntry",
+                          "handle"
+                        |),
                         [
                           fun γ =>
                             ltac:(M.monadic
@@ -1306,10 +1315,11 @@ Module collections.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "alloc::collections::btree::map::entry::VacantEntry"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "alloc::collections::btree::map::entry::VacantEntry",
                                           "dormant_map"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1339,10 +1349,11 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            self
-                                            "alloc::collections::btree::map::entry::VacantEntry"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "alloc::collections::btree::map::entry::VacantEntry",
                                             "alloc"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -1389,10 +1400,11 @@ Module collections.
                                             |)
                                           |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              self
-                                              "alloc::collections::btree::map::entry::VacantEntry"
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "alloc::collections::btree::map::entry::VacantEntry",
                                               "key"
+                                            |)
                                           |);
                                           M.read (| value |)
                                         ]
@@ -1401,10 +1413,11 @@ Module collections.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| map |))
-                                    "alloc::collections::btree::map::BTreeMap"
-                                    "root",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| map |),
+                                    "alloc::collections::btree::map::BTreeMap",
+                                    "root"
+                                  |),
                                   Value.StructTuple
                                     "core::option::Option::Some"
                                     [
@@ -1429,17 +1442,18 @@ Module collections.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| map |))
-                                    "alloc::collections::btree::map::BTreeMap"
-                                    "length",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| map |),
+                                    "alloc::collections::btree::map::BTreeMap",
+                                    "length"
+                                  |),
                                   Value.Integer Integer.Usize 1
                                 |) in
                               val_ptr));
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1491,10 +1505,11 @@ Module collections.
                                         [
                                           M.read (| handle |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              self
-                                              "alloc::collections::btree::map::entry::VacantEntry"
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "alloc::collections::btree::map::entry::VacantEntry",
                                               "key"
+                                            |)
                                           |);
                                           M.read (| value |);
                                           M.call_closure (|
@@ -1506,10 +1521,11 @@ Module collections.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                self
-                                                "alloc::collections::btree::map::entry::VacantEntry"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "alloc::collections::btree::map::entry::VacantEntry",
                                                 "alloc"
+                                              |)
                                             ]
                                           |);
                                           M.closure
@@ -1545,10 +1561,11 @@ Module collections.
                                                                   |),
                                                                   [
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        ins
-                                                                        "alloc::collections::btree::node::SplitResult"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        ins,
+                                                                        "alloc::collections::btree::node::SplitResult",
                                                                         "left"
+                                                                      |)
                                                                     |)
                                                                   ]
                                                                 |)
@@ -1570,10 +1587,11 @@ Module collections.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_struct_record_field
-                                                                      self
-                                                                      "alloc::collections::btree::map::entry::VacantEntry"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      self,
+                                                                      "alloc::collections::btree::map::entry::VacantEntry",
                                                                       "dormant_map"
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -1627,10 +1645,11 @@ Module collections.
                                                                         []
                                                                       |),
                                                                       [
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| map |))
-                                                                          "alloc::collections::btree::map::BTreeMap"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| map |),
+                                                                          "alloc::collections::btree::map::BTreeMap",
                                                                           "root"
+                                                                        |)
                                                                       ]
                                                                     |)
                                                                   ]
@@ -1674,35 +1693,41 @@ Module collections.
                                                                       [
                                                                         M.read (| root |);
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            self
-                                                                            "alloc::collections::btree::map::entry::VacantEntry"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            self,
+                                                                            "alloc::collections::btree::map::entry::VacantEntry",
                                                                             "alloc"
+                                                                          |)
                                                                         |)
                                                                       ]
                                                                     |)
                                                                   |);
                                                                   M.read (|
-                                                                    M.get_tuple_field
-                                                                      (M.get_struct_record_field
-                                                                        ins
-                                                                        "alloc::collections::btree::node::SplitResult"
-                                                                        "kv")
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        ins,
+                                                                        "alloc::collections::btree::node::SplitResult",
+                                                                        "kv"
+                                                                      |),
                                                                       0
+                                                                    |)
                                                                   |);
                                                                   M.read (|
-                                                                    M.get_tuple_field
-                                                                      (M.get_struct_record_field
-                                                                        ins
-                                                                        "alloc::collections::btree::node::SplitResult"
-                                                                        "kv")
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        ins,
+                                                                        "alloc::collections::btree::node::SplitResult",
+                                                                        "kv"
+                                                                      |),
                                                                       1
+                                                                    |)
                                                                   |);
                                                                   M.read (|
-                                                                    M.get_struct_record_field
-                                                                      ins
-                                                                      "alloc::collections::btree::node::SplitResult"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      ins,
+                                                                      "alloc::collections::btree::node::SplitResult",
                                                                       "right"
+                                                                    |)
                                                                   |)
                                                                 ]
                                                               |)
@@ -1757,20 +1782,22 @@ Module collections.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              self
-                                              "alloc::collections::btree::map::entry::VacantEntry"
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "alloc::collections::btree::map::entry::VacantEntry",
                                               "dormant_map"
+                                            |)
                                           |)
                                         ]
                                       |)
                                     |) in
                                   let _ :=
                                     let β :=
-                                      M.get_struct_record_field
-                                        (M.read (| map |))
-                                        "alloc::collections::btree::map::BTreeMap"
-                                        "length" in
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| map |),
+                                        "alloc::collections::btree::map::BTreeMap",
+                                        "length"
+                                      |) in
                                     M.write (|
                                       β,
                                       BinOp.Panic.add (|
@@ -1810,8 +1837,8 @@ Module collections.
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
                 M.read (|
-                  M.get_tuple_field
-                    (M.alloc (|
+                  M.SubPointer.get_tuple_field (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
@@ -1851,16 +1878,18 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::entry::OccupiedEntry"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::entry::OccupiedEntry",
                                 "handle"
+                              |)
                             ]
                           |)
                         ]
                       |)
-                    |))
+                    |),
                     0
+                  |)
                 |)))
             | _, _ => M.impossible
             end.
@@ -1909,8 +1938,8 @@ Module collections.
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
                 M.read (|
-                  M.get_tuple_field
-                    (M.alloc (|
+                  M.SubPointer.get_tuple_field (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
@@ -1950,16 +1979,18 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::map::entry::OccupiedEntry"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::map::entry::OccupiedEntry",
                                 "handle"
+                              |)
                             ]
                           |)
                         ]
                       |)
-                    |))
+                    |),
                     1
+                  |)
                 |)))
             | _, _ => M.impossible
             end.
@@ -1980,8 +2011,8 @@ Module collections.
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
                 M.read (|
-                  M.get_tuple_field
-                    (M.alloc (|
+                  M.SubPointer.get_tuple_field (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
@@ -2001,14 +2032,16 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::map::entry::OccupiedEntry"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::map::entry::OccupiedEntry",
                             "handle"
+                          |)
                         ]
                       |)
-                    |))
+                    |),
                     1
+                  |)
                 |)))
             | _, _ => M.impossible
             end.
@@ -2048,10 +2081,11 @@ Module collections.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::map::entry::OccupiedEntry"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::map::entry::OccupiedEntry",
                         "handle"
+                      |)
                     |)
                   ]
                 |)))
@@ -2109,8 +2143,8 @@ Module collections.
               ltac:(M.monadic
                 (let self := M.alloc (| self |) in
                 M.read (|
-                  M.get_tuple_field
-                    (M.alloc (|
+                  M.SubPointer.get_tuple_field (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
@@ -2121,8 +2155,9 @@ Module collections.
                         |),
                         [ M.read (| self |) ]
                       |)
-                    |))
+                    |),
                     1
+                  |)
                 |)))
             | _, _ => M.impossible
             end.
@@ -2176,10 +2211,11 @@ Module collections.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::map::entry::OccupiedEntry"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::map::entry::OccupiedEntry",
                               "handle"
+                            |)
                           |);
                           M.closure
                             (fun γ =>
@@ -2201,10 +2237,11 @@ Module collections.
                           M.call_closure (|
                             M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                             [
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::map::entry::OccupiedEntry"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::map::entry::OccupiedEntry",
                                 "alloc"
+                              |)
                             ]
                           |)
                         ]
@@ -2213,8 +2250,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let old_kv := M.copy (| γ0_0 |) in
                           let map :=
                             M.alloc (|
@@ -2232,20 +2269,22 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::map::entry::OccupiedEntry"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::map::entry::OccupiedEntry",
                                       "dormant_map"
+                                    |)
                                   |)
                                 ]
                               |)
                             |) in
                           let _ :=
                             let β :=
-                              M.get_struct_record_field
-                                (M.read (| map |))
-                                "alloc::collections::btree::map::BTreeMap"
-                                "length" in
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| map |),
+                                "alloc::collections::btree::map::BTreeMap",
+                                "length"
+                              |) in
                             M.write (|
                               β,
                               BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2310,10 +2349,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| map |))
-                                                  "alloc::collections::btree::map::BTreeMap"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| map |),
+                                                  "alloc::collections::btree::map::BTreeMap",
                                                   "root"
+                                                |)
                                               ]
                                             |)
                                           ]
@@ -2339,10 +2379,11 @@ Module collections.
                                           [
                                             M.read (| root |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "alloc::collections::btree::map::entry::OccupiedEntry"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "alloc::collections::btree::map::entry::OccupiedEntry",
                                                 "alloc"
+                                              |)
                                             |)
                                           ]
                                         |)

--- a/CoqOfRust/alloc/collections/btree/mem.v
+++ b/CoqOfRust/alloc/collections/btree/mem.v
@@ -108,8 +108,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let new_value := M.copy (| γ0_0 |) in
                       let ret := M.copy (| γ0_1 |) in
                       let _ :=

--- a/CoqOfRust/alloc/collections/btree/merge_iter.v
+++ b/CoqOfRust/alloc/collections/btree/merge_iter.v
@@ -58,7 +58,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::merge_iter::Peeked::A",
                             0
@@ -84,7 +84,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::merge_iter::Peeked::B",
                             0
@@ -141,7 +141,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::merge_iter::Peeked::A",
                             0
@@ -165,7 +165,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::merge_iter::Peeked::B",
                             0
@@ -222,20 +222,22 @@ Module collections.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::merge_iter::MergeIterInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::merge_iter::MergeIterInner",
                           "a"
+                        |)
                       ]
                     |));
                   ("b",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::merge_iter::MergeIterInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::merge_iter::MergeIterInner",
                           "b"
+                        |)
                       ]
                     |));
                   ("peeked",
@@ -251,10 +253,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::merge_iter::MergeIterInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::merge_iter::MergeIterInner",
                           "peeked"
+                        |)
                       ]
                     |))
                 ]))
@@ -326,26 +329,29 @@ Module collections.
                               |);
                               (* Unsize *)
                               M.pointer_coercion
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::btree::merge_iter::MergeIterInner"
-                                  "a")
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::btree::merge_iter::MergeIterInner",
+                                  "a"
+                                |))
                             ]
                           |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::merge_iter::MergeIterInner"
-                              "b")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::merge_iter::MergeIterInner",
+                              "b"
+                            |))
                         ]
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::merge_iter::MergeIterInner"
-                          "peeked")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::merge_iter::MergeIterInner",
+                          "peeked"
+                        |))
                     ]
                   |)
                 ]
@@ -452,10 +458,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::merge_iter::MergeIterInner"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::merge_iter::MergeIterInner",
                             "peeked"
+                          |)
                         ]
                       |)
                     |),
@@ -463,13 +470,13 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "alloc::collections::btree::merge_iter::Peeked::A",
                               0
@@ -492,10 +499,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "b"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -503,13 +511,13 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "alloc::collections::btree::merge_iter::Peeked::B",
                               0
@@ -532,10 +540,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "a"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -554,10 +563,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "a"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -573,10 +583,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "b"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -590,11 +601,11 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ := M.alloc (| Value.Tuple [ a_next; b_next ] |) in
-                          let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "core::option::Option::Some",
                               0
@@ -602,7 +613,7 @@ Module collections.
                           let a1 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_1,
                               "core::option::Option::Some",
                               0
@@ -631,10 +642,11 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::merge_iter::MergeIterInner"
-                                      "peeked",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::merge_iter::MergeIterInner",
+                                      "peeked"
+                                    |),
                                     M.call_closure (|
                                       M.get_associated_function (|
                                         Ty.apply (Ty.path "core::option::Option") [ Ty.associated ],
@@ -671,10 +683,11 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::merge_iter::MergeIterInner"
-                                      "peeked",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::merge_iter::MergeIterInner",
+                                      "peeked"
+                                    |),
                                     M.call_closure (|
                                       M.get_associated_function (|
                                         Ty.apply (Ty.path "core::option::Option") [ Ty.associated ],
@@ -743,21 +756,22 @@ Module collections.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::merge_iter::MergeIterInner"
-                    "peeked",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::merge_iter::MergeIterInner",
+                    "peeked"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::merge_iter::Peeked::A",
                             0
@@ -776,10 +790,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::merge_iter::MergeIterInner"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::merge_iter::MergeIterInner",
                                       "a"
+                                    |)
                                   ]
                                 |)
                               |);
@@ -792,10 +807,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "b"
+                                  |)
                                 ]
                               |)
                             ]
@@ -803,13 +819,13 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::merge_iter::Peeked::B",
                             0
@@ -826,10 +842,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "a"
+                                  |)
                                 ]
                               |);
                               BinOp.Panic.add (|
@@ -843,10 +860,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::btree::merge_iter::MergeIterInner"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::btree::merge_iter::MergeIterInner",
                                       "b"
+                                    |)
                                   ]
                                 |)
                               |)
@@ -866,10 +884,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "a"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -881,10 +900,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::merge_iter::MergeIterInner"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::merge_iter::MergeIterInner",
                                     "b"
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/alloc/collections/btree/navigate.v
+++ b/CoqOfRust/alloc/collections/btree/navigate.v
@@ -95,10 +95,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::navigate::LeafRange"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::navigate::LeafRange",
                           "front"
+                        |)
                       ]
                     |));
                   ("back",
@@ -127,10 +128,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::navigate::LeafRange"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::navigate::LeafRange",
                           "back"
+                        |)
                       ]
                     |))
                 ]))
@@ -259,14 +261,16 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::navigate::LeafRange"
-                    "front";
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::navigate::LeafRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::navigate::LeafRange",
+                    "front"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::navigate::LeafRange",
                     "back"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -395,10 +399,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::navigate::LeafRange"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::navigate::LeafRange",
                               "front"
+                            |)
                           ]
                         |);
                         M.closure
@@ -543,10 +548,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::navigate::LeafRange"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::navigate::LeafRange",
                               "back"
+                            |)
                           ]
                         |);
                         M.closure
@@ -762,10 +768,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::navigate::LeafRange"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::navigate::LeafRange",
                                         "front"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -1134,10 +1141,11 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::navigate::LeafRange"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::navigate::LeafRange",
                                         "back"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -1859,7 +1867,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                             0
@@ -1874,7 +1882,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Edge",
                             0
@@ -1928,7 +1936,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                             0
@@ -1960,7 +1968,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Edge",
                             0
@@ -2096,10 +2104,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::navigate::LazyLeafRange"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::navigate::LazyLeafRange",
                           "front"
+                        |)
                       ]
                     |));
                   ("back",
@@ -2118,10 +2127,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::navigate::LazyLeafRange"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::navigate::LazyLeafRange",
                           "back"
+                        |)
                       ]
                     |))
                 ]))
@@ -2235,10 +2245,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::navigate::LazyLeafRange"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::navigate::LazyLeafRange",
                               "front"
+                            |)
                           ]
                         |);
                         M.closure
@@ -2321,10 +2332,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::navigate::LazyLeafRange"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::navigate::LazyLeafRange",
                               "back"
+                            |)
                           ]
                         |);
                         M.closure
@@ -2392,20 +2404,21 @@ Module collections.
                         ltac:(M.monadic
                           (let γ :=
                             M.alloc (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::navigate::LazyLeafRange"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::navigate::LazyLeafRange",
                                 "front"
+                              |)
                             |) in
                           let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ1_0,
                               "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                               0
@@ -2413,10 +2426,11 @@ Module collections.
                           let root := M.alloc (| γ2_0 |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::navigate::LazyLeafRange"
-                                "front",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::navigate::LazyLeafRange",
+                                "front"
+                              |),
                               Value.StructTuple
                                 "core::option::Option::Some"
                                 [
@@ -2467,10 +2481,11 @@ Module collections.
                   |) in
                 M.match_operator (|
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::navigate::LazyLeafRange"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::navigate::LazyLeafRange",
                       "front"
+                    |)
                   |),
                   [
                     fun γ =>
@@ -2481,13 +2496,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Edge",
                             0
@@ -2500,13 +2515,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                             0
@@ -2559,20 +2574,21 @@ Module collections.
                         ltac:(M.monadic
                           (let γ :=
                             M.alloc (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::navigate::LazyLeafRange"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::navigate::LazyLeafRange",
                                 "back"
+                              |)
                             |) in
                           let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ1_0,
                               "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                               0
@@ -2580,10 +2596,11 @@ Module collections.
                           let root := M.alloc (| γ2_0 |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::navigate::LazyLeafRange"
-                                "back",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::navigate::LazyLeafRange",
+                                "back"
+                              |),
                               Value.StructTuple
                                 "core::option::Option::Some"
                                 [
@@ -2634,10 +2651,11 @@ Module collections.
                   |) in
                 M.match_operator (|
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::navigate::LazyLeafRange"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::navigate::LazyLeafRange",
                       "back"
+                    |)
                   |),
                   [
                     fun γ =>
@@ -2648,13 +2666,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Edge",
                             0
@@ -2667,13 +2685,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                             0
@@ -3085,10 +3103,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::navigate::LazyLeafRange"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::navigate::LazyLeafRange",
                                     "front"
+                                  |)
                                 ]
                               |)
                             ]
@@ -3098,7 +3117,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -3149,7 +3168,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -3162,7 +3181,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::navigate::LazyLeafHandle::Root",
                                 0
@@ -3193,7 +3212,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::navigate::LazyLeafHandle::Edge",
                                 0
@@ -3273,10 +3292,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::btree::navigate::LazyLeafRange"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::btree::navigate::LazyLeafRange",
                                                   "front"
+                                                |)
                                               ]
                                             |))
                                         |)) in
@@ -3439,10 +3459,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::btree::navigate::LazyLeafRange"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::btree::navigate::LazyLeafRange",
                                                   "back"
+                                                |)
                                               ]
                                             |))
                                         |)) in
@@ -3580,7 +3601,7 @@ Module collections.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -3700,7 +3721,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -3720,16 +3741,16 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
-                            let γ1_2 := M.get_tuple_field γ0_0 2 in
-                            let γ1_3 := M.get_tuple_field γ0_0 3 in
-                            let γ1_4 := M.get_tuple_field γ0_0 4 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
+                            let γ1_2 := M.SubPointer.get_tuple_field (| γ0_0, 2 |) in
+                            let γ1_3 := M.SubPointer.get_tuple_field (| γ0_0, 3 |) in
+                            let γ1_4 := M.SubPointer.get_tuple_field (| γ0_0, 4 |) in
                             let node := M.copy (| γ1_0 |) in
                             let lower_edge_idx := M.copy (| γ1_1 |) in
                             let upper_edge_idx := M.copy (| γ1_2 |) in
@@ -3864,17 +3885,18 @@ Module collections.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_0,
                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                   0
                                                 |) in
                                               let f := M.copy (| γ1_0 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_1,
                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                   0
@@ -3902,17 +3924,18 @@ Module collections.
                                               |)));
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_0,
                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                   0
                                                 |) in
                                               let f := M.copy (| γ1_0 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_1,
                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                   0
@@ -3968,8 +3991,10 @@ Module collections.
                                                   [
                                                     fun γ =>
                                                       ltac:(M.monadic
-                                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                                        (let γ0_0 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                        let γ0_1 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                         let lhs := M.copy (| γ0_0 |) in
                                                         let lhs := M.copy (| γ0_1 |) in
                                                         let _ :=
@@ -4035,8 +4060,10 @@ Module collections.
                                                   [
                                                     fun γ =>
                                                       ltac:(M.monadic
-                                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                                        (let γ0_0 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                        let γ0_1 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                         let lhs := M.copy (| γ0_0 |) in
                                                         let lhs := M.copy (| γ0_1 |) in
                                                         let _ :=
@@ -4167,7 +4194,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::node::ForceResult::Leaf",
                                           0
@@ -4201,7 +4228,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::node::ForceResult::Internal",
                                           0
@@ -4318,7 +4345,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::node::ForceResult::Leaf",
                                           0
@@ -4352,7 +4379,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::node::ForceResult::Internal",
                                           0
@@ -4479,8 +4506,8 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let edge := M.copy (| γ0_0 |) in
                                       let new_bound := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -4513,7 +4540,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                   0
@@ -4527,7 +4554,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                   0
@@ -4641,8 +4668,8 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let edge := M.copy (| γ0_0 |) in
                                       let new_bound := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -4675,7 +4702,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                   0
@@ -4689,7 +4716,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                   0
@@ -4923,7 +4950,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::ForceResult::Leaf",
                                 0
@@ -4964,7 +4991,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::ForceResult::Internal",
                                 0
@@ -5081,7 +5108,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "alloc::collections::btree::node::ForceResult::Leaf",
                                                       0
@@ -5153,7 +5180,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::result::Result::Ok",
                                                               0
@@ -5223,7 +5250,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::result::Result::Err",
                                                               0
@@ -5240,7 +5267,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "alloc::collections::btree::node::ForceResult::Internal",
                                                       0
@@ -5385,7 +5412,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "alloc::collections::btree::navigate::Position::Leaf",
                                                       0
@@ -5419,7 +5446,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "alloc::collections::btree::navigate::Position::Internal",
                                                       0
@@ -5453,7 +5480,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "alloc::collections::btree::navigate::Position::InternalKV",
                                                       0
@@ -5743,7 +5770,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -5763,7 +5790,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Err",
                                               0
@@ -5818,7 +5845,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Ok",
                                                       0
@@ -5853,7 +5880,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Err",
                                                       0
@@ -5977,7 +6004,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -5997,7 +6024,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Err",
                                               0
@@ -6052,7 +6079,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Ok",
                                                       0
@@ -6087,7 +6114,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Err",
                                                       0
@@ -6201,7 +6228,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -6221,7 +6248,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Err",
                                               0
@@ -6276,7 +6303,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Ok",
                                                       0
@@ -6286,7 +6313,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Err",
                                                       0
@@ -6430,7 +6457,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -6507,7 +6534,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Err",
                                               0
@@ -6574,7 +6601,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -6730,7 +6757,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -6807,7 +6834,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Err",
                                               0
@@ -6874,7 +6901,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -7040,7 +7067,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -8773,7 +8800,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -8804,7 +8831,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
@@ -8936,7 +8963,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -8967,7 +8994,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0

--- a/CoqOfRust/alloc/collections/btree/node.v
+++ b/CoqOfRust/alloc/collections/btree/node.v
@@ -127,10 +127,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| this |))
-                          "alloc::collections::btree::node::LeafNode"
-                          "parent";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| this |),
+                          "alloc::collections::btree::node::LeafNode",
+                          "parent"
+                        |);
                         Value.StructTuple "core::option::Option::None" []
                       ]
                     |)
@@ -144,10 +145,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| this |))
-                          "alloc::collections::btree::node::LeafNode"
-                          "len";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| this |),
+                          "alloc::collections::btree::node::LeafNode",
+                          "len"
+                        |);
                         Value.Integer Integer.U16 0
                       ]
                     |)
@@ -320,8 +322,8 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
                                 (Ty.path "core::mem::maybe_uninit::MaybeUninit")
@@ -334,9 +336,10 @@ Module collections.
                               []
                             |),
                             [ M.read (| node |) ]
-                          |))
-                          "alloc::collections::btree::node::InternalNode"
+                          |),
+                          "alloc::collections::btree::node::InternalNode",
                           "data"
+                        |)
                       ]
                     |)
                   |) in
@@ -710,18 +713,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_array_field (|
-                          M.get_struct_record_field
-                            (M.read (| new_node |))
-                            "alloc::collections::btree::node::InternalNode"
-                            "edges",
+                        M.SubPointer.get_array_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| new_node |),
+                            "alloc::collections::btree::node::InternalNode",
+                            "edges"
+                          |),
                           M.alloc (| Value.Integer Integer.Usize 0 |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            child
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            child,
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -744,10 +749,11 @@ Module collections.
                       M.read (| new_node |);
                       BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            child
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            child,
+                            "alloc::collections::btree::node::NodeRef",
                             "height"
+                          |)
                         |),
                         Value.Integer Integer.Usize 1
                       |)
@@ -1064,10 +1070,11 @@ Module collections.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| this |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |)
                   ]
                 |))))
@@ -1096,17 +1103,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -1229,8 +1238,8 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
                               (Ty.path "alloc::collections::btree::node::NodeRef")
@@ -1244,9 +1253,10 @@ Module collections.
                             []
                           |),
                           [ M.read (| self |) ]
-                        |))
-                        "alloc::collections::btree::node::InternalNode"
+                        |),
+                        "alloc::collections::btree::node::InternalNode",
                         "edges"
+                      |)
                     ]
                   |);
                   M.read (| index |)
@@ -1321,7 +1331,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1608,17 +1618,19 @@ Module collections.
                                 UnOp.Pure.not
                                   (BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        edge
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        edge,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |))
                                     (BinOp.Panic.sub (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::btree::node::NodeRef"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::btree::node::NodeRef",
                                           "height"
+                                        |)
                                       |),
                                       Value.Integer Integer.Usize 1
                                     |)))
@@ -1821,10 +1833,11 @@ Module collections.
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            edge
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            edge,
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -1927,8 +1940,8 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
                             (Ty.path "alloc::collections::btree::node::NodeRef")
@@ -1937,9 +1950,10 @@ Module collections.
                           []
                         |),
                         [ M.read (| self |) ]
-                      |))
-                      "alloc::collections::btree::node::LeafNode"
+                      |),
+                      "alloc::collections::btree::node::LeafNode",
                       "len"
+                    |)
                   |)
                 ]
               |)))
@@ -1962,10 +1976,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::node::NodeRef"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::node::NodeRef",
                   "height"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -1990,17 +2005,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -2042,10 +2059,11 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| this |))
-                      "alloc::collections::btree::node::NodeRef"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| this |),
+                      "alloc::collections::btree::node::NodeRef",
                       "node"
+                    |)
                   |)
                 ]
               |)))
@@ -2214,10 +2232,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| leaf_ptr |))
-                                "alloc::collections::btree::node::LeafNode"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf_ptr |),
+                                "alloc::collections::btree::node::LeafNode",
                                 "parent"
+                              |)
                             ]
                           |);
                           M.closure
@@ -2254,10 +2273,11 @@ Module collections.
                                                     M.read (| M.read (| parent |) |);
                                                     BinOp.Panic.add (|
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          self
-                                                          "alloc::collections::btree::node::NodeRef"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          self,
+                                                          "alloc::collections::btree::node::NodeRef",
                                                           "height"
+                                                        |)
                                                       |),
                                                       Value.Integer Integer.Usize 1
                                                     |)
@@ -2284,10 +2304,11 @@ Module collections.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| leaf_ptr |))
-                                                            "alloc::collections::btree::node::LeafNode"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| leaf_ptr |),
+                                                            "alloc::collections::btree::node::LeafNode",
                                                             "parent_idx"
+                                                          |)
                                                         |)
                                                       ]
                                                     |)
@@ -2596,19 +2617,19 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::NodeRef",
                             "node"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::NodeRef",
                             "height"
                           |) in
                         let γ1_2 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::NodeRef",
                             "_marker"
@@ -2650,10 +2671,11 @@ Module collections.
                                         |),
                                         [
                                           M.read (| node |);
-                                          M.get_struct_record_field
-                                            (M.read (| other |))
-                                            "alloc::collections::btree::node::NodeRef"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| other |),
+                                            "alloc::collections::btree::node::NodeRef",
                                             "node"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -2680,17 +2702,20 @@ Module collections.
                                                 Value.Tuple
                                                   [
                                                     M.read (| height |);
-                                                    M.get_struct_record_field
-                                                      (M.read (| other |))
-                                                      "alloc::collections::btree::node::NodeRef"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| other |),
+                                                      "alloc::collections::btree::node::NodeRef",
                                                       "height"
+                                                    |)
                                                   ]
                                               |),
                                               [
                                                 fun γ =>
                                                   ltac:(M.monadic
-                                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                                    (let γ0_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ0_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let left_val := M.copy (| γ0_0 |) in
                                                     let right_val := M.copy (| γ0_1 |) in
                                                     M.match_operator (|
@@ -2863,10 +2888,11 @@ Module collections.
                         [
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| leaf |))
-                              "alloc::collections::btree::node::LeafNode"
-                              "keys");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| leaf |),
+                              "alloc::collections::btree::node::LeafNode",
+                              "keys"
+                            |));
                           Value.StructRecord
                             "core::ops::range::RangeTo"
                             [
@@ -2881,10 +2907,11 @@ Module collections.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| leaf |))
-                                        "alloc::collections::btree::node::LeafNode"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| leaf |),
+                                        "alloc::collections::btree::node::LeafNode",
                                         "len"
+                                      |)
                                     |)
                                   ]
                                 |))
@@ -2945,14 +2972,19 @@ Module collections.
               M.read (|
                 let height :=
                   M.copy (|
-                    M.get_struct_record_field
-                      self
-                      "alloc::collections::btree::node::NodeRef"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::NodeRef",
                       "height"
+                    |)
                   |) in
                 let node :=
                   M.copy (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::NodeRef" "node"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::NodeRef",
+                      "node"
+                    |)
                   |) in
                 let ret :=
                   M.alloc (|
@@ -3114,17 +3146,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -3223,17 +3257,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -3279,8 +3315,8 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
                               (Ty.path "alloc::collections::btree::node::NodeRef")
@@ -3290,9 +3326,10 @@ Module collections.
                             []
                           |),
                           [ M.read (| self |) ]
-                        |))
-                        "alloc::collections::btree::node::LeafNode"
+                        |),
+                        "alloc::collections::btree::node::LeafNode",
                         "keys"
+                      |)
                     ]
                   |);
                   M.read (| index |)
@@ -3341,8 +3378,8 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
                               (Ty.path "alloc::collections::btree::node::NodeRef")
@@ -3352,9 +3389,10 @@ Module collections.
                             []
                           |),
                           [ M.read (| self |) ]
-                        |))
-                        "alloc::collections::btree::node::LeafNode"
+                        |),
+                        "alloc::collections::btree::node::LeafNode",
                         "vals"
+                      |)
                     ]
                   |);
                   M.read (| index |)
@@ -3377,8 +3415,8 @@ Module collections.
           | [], [ self ] =>
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
-              M.get_struct_record_field
-                (M.call_closure (|
+              M.SubPointer.get_struct_record_field (|
+                M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
                       (Ty.path "alloc::collections::btree::node::NodeRef")
@@ -3387,9 +3425,10 @@ Module collections.
                     []
                   |),
                   [ M.read (| self |) ]
-                |))
-                "alloc::collections::btree::node::LeafNode"
-                "len"))
+                |),
+                "alloc::collections::btree::node::LeafNode",
+                "len"
+              |)))
           | _, _ => M.impossible
           end.
         
@@ -3420,17 +3459,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -3533,17 +3574,19 @@ Module collections.
                   |) in
                 let keys :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| leaf |))
-                      "alloc::collections::btree::node::LeafNode"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| leaf |),
+                      "alloc::collections::btree::node::LeafNode",
                       "keys"
+                    |)
                   |) in
                 let vals :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| leaf |))
-                      "alloc::collections::btree::node::LeafNode"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| leaf |),
+                      "alloc::collections::btree::node::LeafNode",
                       "vals"
+                    |)
                   |) in
                 let keys := M.alloc (| (* Unsize *) M.pointer_coercion (M.read (| keys |)) |) in
                 let vals := M.alloc (| (* Unsize *) M.pointer_coercion (M.read (| vals |)) |) in
@@ -3663,10 +3706,11 @@ Module collections.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| leaf |))
-                      "alloc::collections::btree::node::LeafNode"
-                      "parent",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| leaf |),
+                      "alloc::collections::btree::node::LeafNode",
+                      "parent"
+                    |),
                     Value.StructTuple "core::option::Option::Some" [ M.read (| parent |) ]
                   |) in
                 let _ :=
@@ -3678,10 +3722,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| leaf |))
-                          "alloc::collections::btree::node::LeafNode"
-                          "parent_idx";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| leaf |),
+                          "alloc::collections::btree::node::LeafNode",
+                          "parent_idx"
+                        |);
                         M.rust_cast (M.read (| parent_idx |))
                       ]
                     |)
@@ -3728,10 +3773,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.eq
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::NodeRef"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::NodeRef",
                                                   "height"
+                                                |)
                                               |))
                                               (Value.Integer Integer.Usize 0))
                                         |)) in
@@ -3765,17 +3811,19 @@ Module collections.
                     [
                       ("height",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::NodeRef",
                             "height"
+                          |)
                         |));
                       ("node",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |));
                       ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                     ]
@@ -3822,10 +3870,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.gt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::NodeRef"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::NodeRef",
                                                   "height"
+                                                |)
                                               |))
                                               (Value.Integer Integer.Usize 0))
                                         |)) in
@@ -3859,17 +3908,19 @@ Module collections.
                     [
                       ("height",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::NodeRef",
                             "height"
+                          |)
                         |));
                       ("node",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |));
                       ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                     ]
@@ -3952,7 +4003,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Ok",
                             0
@@ -3985,7 +4036,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -4088,7 +4139,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -4123,7 +4174,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -4226,7 +4277,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -4279,7 +4330,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Err",
                             0
@@ -4362,10 +4413,11 @@ Module collections.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| leaf |))
-                      "alloc::collections::btree::node::LeafNode"
-                      "parent",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| leaf |),
+                      "alloc::collections::btree::node::LeafNode",
+                      "parent"
+                    |),
                     Value.StructTuple "core::option::Option::None" []
                   |) in
                 M.alloc (| Value.Tuple [] |)
@@ -4545,17 +4597,19 @@ Module collections.
                     [
                       ("height",
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::NodeRef",
                             "height"
+                          |)
                         |));
                       ("node",
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |));
                       ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                     ]
@@ -4608,10 +4662,11 @@ Module collections.
                                 UnOp.Pure.not
                                   (BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0))
                               |)) in
@@ -4630,10 +4685,11 @@ Module collections.
                   |) in
                 let top :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::NodeRef"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::NodeRef",
                       "node"
+                    |)
                   |) in
                 let internal_self :=
                   M.alloc (|
@@ -4689,10 +4745,11 @@ Module collections.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::NodeRef"
-                      "node",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::NodeRef",
+                      "node"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (|
                         Ty.apply
@@ -4710,11 +4767,12 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_array_field (|
-                          M.get_struct_record_field
-                            (M.read (| internal_node |))
-                            "alloc::collections::btree::node::InternalNode"
-                            "edges",
+                        M.SubPointer.get_array_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| internal_node |),
+                            "alloc::collections::btree::node::InternalNode",
+                            "edges"
+                          |),
                           M.alloc (| Value.Integer Integer.Usize 0 |)
                         |)
                       ]
@@ -4722,10 +4780,11 @@ Module collections.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::NodeRef"
-                      "height" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::NodeRef",
+                      "height"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -4816,17 +4875,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -4853,17 +4914,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -4890,17 +4953,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -5109,17 +5174,19 @@ Module collections.
                 [
                   ("height",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "height"
+                      |)
                     |));
                   ("node",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::NodeRef"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::NodeRef",
                         "node"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -5177,10 +5244,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "alloc::collections::btree::node::NodeRef"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "alloc::collections::btree::node::NodeRef",
                                     "height"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -5195,17 +5263,19 @@ Module collections.
                                 [
                                   ("height",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |));
                                   ("node",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "node"
+                                      |)
                                     |));
                                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                                 ]
@@ -5222,17 +5292,19 @@ Module collections.
                                 [
                                   ("height",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |));
                                   ("node",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "node"
+                                      |)
                                     |));
                                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                                 ]
@@ -5319,7 +5391,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field self "alloc::collections::btree::node::Handle" "node"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "alloc::collections::btree::node::Handle",
+                  "node"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -5340,10 +5416,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::btree::node::Handle"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::btree::node::Handle",
                   "idx"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -5486,10 +5563,18 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "node"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "node"
+                    |)
                   |);
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |)
                 ]
               |)))
@@ -5533,11 +5618,19 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "node"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "node"
+                    |)
                   |);
                   BinOp.Panic.add (|
                     M.read (|
-                      M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::Handle",
+                        "idx"
+                      |)
                     |),
                     Value.Integer Integer.Usize 1
                   |)
@@ -5590,19 +5683,19 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "node"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "idx"
                           |) in
                         let γ1_2 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "_marker"
@@ -5622,20 +5715,22 @@ Module collections.
                               |),
                               [
                                 M.read (| node |);
-                                M.get_struct_record_field
-                                  (M.read (| other |))
-                                  "alloc::collections::btree::node::Handle"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| other |),
+                                  "alloc::collections::btree::node::Handle",
                                   "node"
+                                |)
                               ]
                             |),
                             ltac:(M.monadic
                               (BinOp.Pure.eq
                                 (M.read (| M.read (| idx |) |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| other |))
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| other |),
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |))))
                           |)
                         |)))
@@ -5694,18 +5789,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |));
                   ("idx",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::Handle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::Handle",
                         "idx"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -5763,18 +5860,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |));
                   ("idx",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::Handle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::Handle",
                         "idx"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -5817,18 +5916,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |));
                   ("idx",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::Handle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::Handle",
                         "idx"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -5884,16 +5985,21 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |));
                   ("idx",
                     M.read (|
-                      M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::Handle",
+                        "idx"
+                      |)
                     |));
                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]))
@@ -6045,10 +6151,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -6073,17 +6180,19 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "node"
+                                    |)
                                   |);
                                   BinOp.Panic.sub (|
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |),
                                     Value.Integer Integer.Usize 1
                                   |)
@@ -6139,10 +6248,11 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.lt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |))
                                 (M.call_closure (|
                                   M.get_associated_function (|
@@ -6153,10 +6263,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "node"
+                                    |)
                                   ]
                                 |))
                             |)) in
@@ -6181,16 +6292,18 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "node"
+                                    |)
                                   |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "idx"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -6480,10 +6593,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |))
                                               (M.read (|
@@ -6534,10 +6648,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         ]
                       |),
                       Value.Integer Integer.Usize 1
@@ -6567,20 +6682,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |);
                         M.read (| key |)
                       ]
@@ -6610,20 +6727,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |);
                         M.read (| val |)
                       ]
@@ -6645,10 +6764,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |),
                     M.rust_cast (M.read (| new_len |))
@@ -6674,16 +6794,18 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "idx"
+                        |)
                       |)
                     ]
                   |)
@@ -6761,10 +6883,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "node"
+                                    |)
                                   ]
                                 |))
                                 (M.read (|
@@ -6833,10 +6956,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |)
                               ]
                             |)
@@ -6844,8 +6968,8 @@ Module collections.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let middle_kv_idx := M.copy (| γ0_0 |) in
                                 let insertion := M.copy (| γ0_1 |) in
                                 let middle :=
@@ -6872,10 +6996,11 @@ Module collections.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "alloc::collections::btree::node::Handle"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "alloc::collections::btree::node::Handle",
                                             "node"
+                                          |)
                                         |);
                                         M.read (| middle_kv_idx |)
                                       ]
@@ -6914,7 +7039,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Left",
                                                 0
@@ -6962,10 +7087,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        result
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        result,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "left"
+                                                      |)
                                                     ]
                                                   |);
                                                   M.read (| insert_idx |)
@@ -6975,7 +7101,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Right",
                                                 0
@@ -7023,10 +7149,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        result
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        result,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "right"
+                                                      |)
                                                     ]
                                                   |);
                                                   M.read (| insert_idx |)
@@ -7196,8 +7323,8 @@ Module collections.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let handle := M.copy (| γ0_1 |) in
                               M.alloc (|
                                 M.never_to_any (|
@@ -7231,10 +7358,10 @@ Module collections.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::option::Option::Some",
                                   0
@@ -7266,8 +7393,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let split := M.copy (| γ0_0 |) in
                             let handle := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -7299,10 +7426,11 @@ Module collections.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        split
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        split,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "left"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -7311,7 +7439,7 @@ Module collections.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::result::Result::Ok",
                                                         0
@@ -7345,26 +7473,31 @@ Module collections.
                                                           [
                                                             M.read (| parent |);
                                                             M.read (|
-                                                              M.get_tuple_field
-                                                                (M.get_struct_record_field
-                                                                  split
-                                                                  "alloc::collections::btree::node::SplitResult"
-                                                                  "kv")
+                                                              M.SubPointer.get_tuple_field (|
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  split,
+                                                                  "alloc::collections::btree::node::SplitResult",
+                                                                  "kv"
+                                                                |),
                                                                 0
+                                                              |)
                                                             |);
                                                             M.read (|
-                                                              M.get_tuple_field
-                                                                (M.get_struct_record_field
-                                                                  split
-                                                                  "alloc::collections::btree::node::SplitResult"
-                                                                  "kv")
+                                                              M.SubPointer.get_tuple_field (|
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  split,
+                                                                  "alloc::collections::btree::node::SplitResult",
+                                                                  "kv"
+                                                                |),
                                                                 1
+                                                              |)
                                                             |);
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                split
-                                                                "alloc::collections::btree::node::SplitResult"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                split,
+                                                                "alloc::collections::btree::node::SplitResult",
                                                                 "right"
+                                                              |)
                                                             |);
                                                             M.call_closure (|
                                                               M.get_trait_method (|
@@ -7418,7 +7551,7 @@ Module collections.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -7447,7 +7580,7 @@ Module collections.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::result::Result::Err",
                                                         0
@@ -7606,10 +7739,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
                               "node"
+                            |)
                           ]
                         |)
                       ]
@@ -7617,7 +7751,11 @@ Module collections.
                   |) in
                 let idx :=
                   M.copy (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |) in
                 let child :=
                   M.alloc (|
@@ -7731,10 +7869,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |))
                                               (M.read (|
@@ -7789,20 +7928,23 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.eq
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  edge
-                                                  "alloc::collections::btree::node::NodeRef"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  edge,
+                                                  "alloc::collections::btree::node::NodeRef",
                                                   "height"
+                                                |)
                                               |))
                                               (BinOp.Panic.sub (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::btree::node::Handle"
-                                                      "node")
-                                                    "alloc::collections::btree::node::NodeRef"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::btree::node::Handle",
+                                                      "node"
+                                                    |),
+                                                    "alloc::collections::btree::node::NodeRef",
                                                     "height"
+                                                  |)
                                                 |),
                                                 Value.Integer Integer.Usize 1
                                               |)))
@@ -7849,10 +7991,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         ]
                       |),
                       Value.Integer Integer.Usize 1
@@ -7882,20 +8025,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |);
                         M.read (| key |)
                       ]
@@ -7925,20 +8070,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |);
                         M.read (| val |)
                       ]
@@ -7991,10 +8138,11 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [
@@ -8008,18 +8156,20 @@ Module collections.
                         |);
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
                               "idx"
+                            |)
                           |),
                           Value.Integer Integer.Usize 1
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            edge
-                            "alloc::collections::btree::node::NodeRef"
+                          M.SubPointer.get_struct_record_field (|
+                            edge,
+                            "alloc::collections::btree::node::NodeRef",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -8040,10 +8190,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |),
                     M.rust_cast (M.read (| new_len |))
@@ -8064,20 +8215,22 @@ Module collections.
                         [ Ty.apply (Ty.path "core::ops::range::Range") [ Ty.path "usize" ] ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
-                          "node";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
+                          "node"
+                        |);
                         Value.StructRecord
                           "core::ops::range::Range"
                           [
                             ("start",
                               BinOp.Panic.add (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |),
                                 Value.Integer Integer.Usize 1
                               |));
@@ -8152,20 +8305,23 @@ Module collections.
                                 UnOp.Pure.not
                                   (BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        edge
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        edge,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |))
                                     (BinOp.Panic.sub (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            self
-                                            "alloc::collections::btree::node::Handle"
-                                            "node")
-                                          "alloc::collections::btree::node::NodeRef"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "alloc::collections::btree::node::Handle",
+                                            "node"
+                                          |),
+                                          "alloc::collections::btree::node::NodeRef",
                                           "height"
+                                        |)
                                       |),
                                       Value.Integer Integer.Usize 1
                                     |)))
@@ -8211,10 +8367,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      self
-                                      "alloc::collections::btree::node::Handle"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "alloc::collections::btree::node::Handle",
                                       "node"
+                                    |)
                                   ]
                                 |))
                                 (M.read (|
@@ -8258,10 +8415,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "alloc::collections::btree::node::Handle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "alloc::collections::btree::node::Handle",
                                     "idx"
+                                  |)
                                 |)
                               ]
                             |)
@@ -8269,8 +8427,8 @@ Module collections.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let middle_kv_idx := M.copy (| γ0_0 |) in
                                 let insertion := M.copy (| γ0_1 |) in
                                 let middle :=
@@ -8297,10 +8455,11 @@ Module collections.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "alloc::collections::btree::node::Handle"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "alloc::collections::btree::node::Handle",
                                             "node"
+                                          |)
                                         |);
                                         M.read (| middle_kv_idx |)
                                       ]
@@ -8339,7 +8498,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Left",
                                                 0
@@ -8387,10 +8546,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        result
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        result,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "left"
+                                                      |)
                                                     ]
                                                   |);
                                                   M.read (| insert_idx |)
@@ -8400,7 +8560,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Right",
                                                 0
@@ -8448,10 +8608,11 @@ Module collections.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        result
-                                                        "alloc::collections::btree::node::SplitResult"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        result,
+                                                        "alloc::collections::btree::node::SplitResult",
                                                         "right"
+                                                      |)
                                                     ]
                                                   |);
                                                   M.read (| insert_idx |)
@@ -8565,10 +8726,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -8614,15 +8776,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| parent_ptr |))
-                                "alloc::collections::btree::node::InternalNode"
-                                "edges");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| parent_ptr |),
+                                "alloc::collections::btree::node::InternalNode",
+                                "edges"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -8637,13 +8801,15 @@ Module collections.
                       ("height",
                         BinOp.Panic.sub (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
-                                "node")
-                              "alloc::collections::btree::node::NodeRef"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
+                                "node"
+                              |),
+                              "alloc::collections::btree::node::NodeRef",
                               "height"
+                            |)
                           |),
                           Value.Integer Integer.Usize 1
                         |));
@@ -8708,15 +8874,20 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       |)
                     ]
                   |);
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |)
                 ]
               |)))
@@ -8779,10 +8950,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -8800,10 +8972,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -8845,10 +9018,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -8873,15 +9047,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "keys");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "keys"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -8908,15 +9084,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "vals");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "vals"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -8974,15 +9152,17 @@ Module collections.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::Handle"
-                        "node";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::Handle",
+                        "node"
+                      |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "idx"
+                        |)
                       |)
                     ]
                   |)
@@ -9030,10 +9210,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -9051,10 +9232,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -9096,10 +9278,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -9123,15 +9306,17 @@ Module collections.
                         [
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| leaf |))
-                              "alloc::collections::btree::node::LeafNode"
-                              "vals");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| leaf |),
+                              "alloc::collections::btree::node::LeafNode",
+                              "vals"
+                            |));
                           M.read (|
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
                               "idx"
+                            |)
                           |)
                         ]
                       |)
@@ -9183,10 +9368,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -9204,10 +9390,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -9249,10 +9436,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -9277,15 +9465,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "keys");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "keys"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9312,15 +9502,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "vals");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "vals"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9376,10 +9568,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -9397,10 +9590,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -9441,10 +9635,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -9468,15 +9663,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "keys");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "keys"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9503,15 +9700,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "vals");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "vals"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9568,8 +9767,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let key := M.copy (| γ0_0 |) in
                         let val := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -9647,10 +9846,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -9668,10 +9868,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -9712,10 +9913,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -9725,10 +9927,11 @@ Module collections.
                       BinOp.Panic.sub (|
                         M.read (| old_len |),
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |)
                       |),
                       Value.Integer Integer.Usize 1
@@ -9736,10 +9939,11 @@ Module collections.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| new_node |))
-                      "alloc::collections::btree::node::LeafNode"
-                      "len",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| new_node |),
+                      "alloc::collections::btree::node::LeafNode",
+                      "len"
+                    |),
                     M.rust_cast (M.read (| new_len |))
                   |) in
                 let k :=
@@ -9768,15 +9972,17 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9809,15 +10015,17 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -9848,20 +10056,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::Range"
                               [
                                 ("start",
                                   BinOp.Panic.add (|
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |),
                                     Value.Integer Integer.Usize 1
                                   |));
@@ -9880,10 +10090,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| new_node |))
-                              "alloc::collections::btree::node::LeafNode"
-                              "keys";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| new_node |),
+                              "alloc::collections::btree::node::LeafNode",
+                              "keys"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
@@ -9916,20 +10127,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::Range"
                               [
                                 ("start",
                                   BinOp.Panic.add (|
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |),
                                     Value.Integer Integer.Usize 1
                                   |));
@@ -9948,10 +10161,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| new_node |))
-                              "alloc::collections::btree::node::LeafNode"
-                              "vals";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| new_node |),
+                              "alloc::collections::btree::node::LeafNode",
+                              "vals"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| new_len |)) ]
@@ -9972,18 +10186,20 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |),
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::Handle",
                           "idx"
+                        |)
                       |))
                   |) in
                 M.alloc (| Value.Tuple [ M.read (| k |); M.read (| v |) ] |)
@@ -10031,10 +10247,18 @@ Module collections.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "node"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "node"
+                    |)
                   |);
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |)
                 ]
               |)))
@@ -10097,10 +10321,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -10118,10 +10343,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -10162,10 +10388,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -10189,15 +10416,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "keys");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "keys"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -10224,15 +10453,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "vals");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "vals"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -10286,10 +10517,11 @@ Module collections.
                                           UnOp.Pure.not
                                             (BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "alloc::collections::btree::node::Handle"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "alloc::collections::btree::node::Handle",
                                                   "idx"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -10307,10 +10539,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "alloc::collections::btree::node::Handle"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "alloc::collections::btree::node::Handle",
                                                     "node"
+                                                  |)
                                                 ]
                                               |)))
                                         |)) in
@@ -10351,10 +10584,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -10378,15 +10612,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "keys");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "keys"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -10413,15 +10649,17 @@ Module collections.
                           [
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| leaf |))
-                                "alloc::collections::btree::node::LeafNode"
-                                "vals");
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| leaf |),
+                                "alloc::collections::btree::node::LeafNode",
+                                "vals"
+                              |));
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "alloc::collections::btree::node::Handle"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::collections::btree::node::Handle",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
@@ -10531,10 +10769,11 @@ Module collections.
                     [
                       ("left",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |));
                       ("kv", M.read (| kv |));
                       ("right", M.read (| right |))
@@ -10584,10 +10823,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -10615,20 +10855,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| old_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |)
                       ]
                     |)
@@ -10657,20 +10899,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [ ("end_", M.read (| old_len |)) ]
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |)
                       ]
                     |)
@@ -10691,10 +10935,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |),
                     M.rust_cast
@@ -10797,10 +11042,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       ]
                     |)
                   |) in
@@ -10837,10 +11083,11 @@ Module collections.
                       |),
                       [
                         self;
-                        M.get_struct_record_field
-                          (M.read (| new_node |))
-                          "alloc::collections::btree::node::InternalNode"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| new_node |),
+                          "alloc::collections::btree::node::InternalNode",
                           "data"
+                        |)
                       ]
                     |)
                   |) in
@@ -10856,13 +11103,15 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| new_node |))
-                              "alloc::collections::btree::node::InternalNode"
-                              "data")
-                            "alloc::collections::btree::node::LeafNode"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| new_node |),
+                              "alloc::collections::btree::node::InternalNode",
+                              "data"
+                            |),
+                            "alloc::collections::btree::node::LeafNode",
                             "len"
+                          |)
                         |)
                       ]
                     |)
@@ -10914,20 +11163,22 @@ Module collections.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::Handle"
-                              "node";
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::Handle",
+                              "node"
+                            |);
                             Value.StructRecord
                               "core::ops::range::Range"
                               [
                                 ("start",
                                   BinOp.Panic.add (|
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |),
                                     Value.Integer Integer.Usize 1
                                   |));
@@ -10962,10 +11213,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| new_node |))
-                              "alloc::collections::btree::node::InternalNode"
-                              "edges";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| new_node |),
+                              "alloc::collections::btree::node::InternalNode",
+                              "edges"
+                            |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [
@@ -10982,13 +11234,15 @@ Module collections.
                   |) in
                 let height :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::Handle"
-                        "node")
-                      "alloc::collections::btree::node::NodeRef"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::Handle",
+                        "node"
+                      |),
+                      "alloc::collections::btree::node::NodeRef",
                       "height"
+                    |)
                   |) in
                 let right :=
                   M.alloc (|
@@ -11014,10 +11268,11 @@ Module collections.
                     [
                       ("left",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |));
                       ("kv", M.read (| kv |));
                       ("right", M.read (| right |))
@@ -11268,10 +11523,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::node::BalancingContext"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::node::BalancingContext",
                     "left_child"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11306,10 +11562,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::node::BalancingContext"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::node::BalancingContext",
                     "right_child"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -11331,10 +11588,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  self
-                  "alloc::collections::btree::node::BalancingContext"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "alloc::collections::btree::node::BalancingContext",
                   "left_child"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -11355,10 +11613,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  self
-                  "alloc::collections::btree::node::BalancingContext"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "alloc::collections::btree::node::BalancingContext",
                   "right_child"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -11395,10 +11654,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::node::BalancingContext"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::node::BalancingContext",
                           "left_child"
+                        |)
                       ]
                     |),
                     Value.Integer Integer.Usize 1
@@ -11417,10 +11677,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::node::BalancingContext"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::node::BalancingContext",
                         "right_child"
+                      |)
                     ]
                   |)
                 |))
@@ -11505,27 +11766,28 @@ Module collections.
               let alloc := M.alloc (| alloc |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    self
-                    "alloc::collections::btree::node::BalancingContext"
-                    "parent",
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "alloc::collections::btree::node::BalancingContext",
+                    "parent"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "node"
                           |) in
                         let γ0_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "idx"
                           |) in
                         let γ0_2 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::node::Handle",
                             "_marker"
@@ -11553,10 +11815,11 @@ Module collections.
                           |) in
                         let left_node :=
                           M.copy (|
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::BalancingContext"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::BalancingContext",
                               "left_child"
+                            |)
                           |) in
                         let old_left_len :=
                           M.alloc (|
@@ -11579,10 +11842,11 @@ Module collections.
                           |) in
                         let right_node :=
                           M.copy (|
-                            M.get_struct_record_field
-                              self
-                              "alloc::collections::btree::node::BalancingContext"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::collections::btree::node::BalancingContext",
                               "right_child"
+                            |)
                           |) in
                         let right_len :=
                           M.alloc (|
@@ -12125,10 +12389,11 @@ Module collections.
                                       (M.alloc (|
                                         BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              parent_node
-                                              "alloc::collections::btree::node::NodeRef"
+                                            M.SubPointer.get_struct_record_field (|
+                                              parent_node,
+                                              "alloc::collections::btree::node::NodeRef",
                                               "height"
+                                            |)
                                           |))
                                           (Value.Integer Integer.Usize 1)
                                       |)) in
@@ -12385,10 +12650,11 @@ Module collections.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  right_node
-                                                  "alloc::collections::btree::node::NodeRef"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  right_node,
+                                                  "alloc::collections::btree::node::NodeRef",
                                                   "node"
+                                                |)
                                               |)
                                             ]
                                           |);
@@ -12438,10 +12704,11 @@ Module collections.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  right_node
-                                                  "alloc::collections::btree::node::NodeRef"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  right_node,
+                                                  "alloc::collections::btree::node::NodeRef",
                                                   "node"
+                                                |)
                                               |)
                                             ]
                                           |);
@@ -12749,10 +13016,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::BalancingContext"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::BalancingContext",
                           "left_child"
+                        |)
                       ]
                     |)
                   |) in
@@ -12772,10 +13040,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::BalancingContext"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::BalancingContext",
                           "right_child"
+                        |)
                       ]
                     |)
                   |) in
@@ -12796,7 +13065,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Left",
                                                 0
@@ -12810,7 +13079,7 @@ Module collections.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "alloc::collections::btree::node::LeftOrRight::Right",
                                                 0
@@ -12867,7 +13136,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::LeftOrRight::Left",
                                 0
@@ -12877,7 +13146,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::node::LeftOrRight::Right",
                                 0
@@ -12979,10 +13248,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::BalancingContext"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::BalancingContext",
                           "right_child"
+                        |)
                       |);
                       BinOp.Panic.add (|
                         Value.Integer Integer.Usize 1,
@@ -13050,10 +13320,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::BalancingContext"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::BalancingContext",
                           "left_child"
+                        |)
                       |);
                       M.read (| track_left_edge_idx |)
                     ]
@@ -13167,10 +13438,11 @@ Module collections.
                   |) in
                 let left_node :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::BalancingContext"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::BalancingContext",
                       "left_child"
+                    |)
                   |) in
                 let old_left_len :=
                   M.alloc (|
@@ -13192,10 +13464,11 @@ Module collections.
                   |) in
                 let right_node :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::BalancingContext"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::BalancingContext",
                       "right_child"
+                    |)
                   |) in
                 let old_right_len :=
                   M.alloc (|
@@ -13633,10 +13906,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::BalancingContext"
-                            "parent";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::BalancingContext",
+                            "parent"
+                          |);
                           M.read (| k |);
                           M.read (| v |)
                         ]
@@ -13645,8 +13919,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let k := M.copy (| γ0_0 |) in
                           let v := M.copy (| γ0_1 |) in
                           let _ :=
@@ -13805,17 +14079,17 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
                           |) in
                         let left := M.copy (| γ1_0 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
@@ -14030,16 +14304,16 @@ Module collections.
                         M.alloc (| Value.Tuple [] |)));
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -14167,10 +14441,11 @@ Module collections.
                   |) in
                 let left_node :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::BalancingContext"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::BalancingContext",
                       "left_child"
+                    |)
                   |) in
                 let old_left_len :=
                   M.alloc (|
@@ -14192,10 +14467,11 @@ Module collections.
                   |) in
                 let right_node :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::BalancingContext"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::BalancingContext",
                       "right_child"
+                    |)
                   |) in
                 let old_right_len :=
                   M.alloc (|
@@ -14423,10 +14699,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::node::BalancingContext"
-                            "parent";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::node::BalancingContext",
+                            "parent"
+                          |);
                           M.read (| k |);
                           M.read (| v |)
                         ]
@@ -14435,8 +14712,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let k := M.copy (| γ0_0 |) in
                           let v := M.copy (| γ0_1 |) in
                           let _ :=
@@ -14847,17 +15124,17 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
                           |) in
                         let left := M.copy (| γ1_0 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
@@ -15106,16 +15383,16 @@ Module collections.
                         M.alloc (| Value.Tuple [] |)));
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -15202,15 +15479,20 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       |)
                     ]
                   |);
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |)
                 ]
               |)))
@@ -15284,15 +15566,20 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::btree::node::Handle"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::btree::node::Handle",
                           "node"
+                        |)
                       |)
                     ]
                   |);
                   M.read (|
-                    M.get_struct_record_field self "alloc::collections::btree::node::Handle" "idx"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "alloc::collections::btree::node::Handle",
+                      "idx"
+                    |)
                   |)
                 ]
               |)))
@@ -15364,10 +15651,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -15376,7 +15664,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -15392,10 +15680,11 @@ Module collections.
                                   ("node", M.read (| node |));
                                   ("idx",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |));
                                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                                 ]
@@ -15404,7 +15693,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
@@ -15420,10 +15709,11 @@ Module collections.
                                   ("node", M.read (| node |));
                                   ("idx",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "alloc::collections::btree::node::Handle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "alloc::collections::btree::node::Handle",
                                         "idx"
+                                      |)
                                     |));
                                   ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                                 ]
@@ -15492,10 +15782,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "node"
+                          |)
                         |)
                       ]
                     |)
@@ -15507,10 +15798,11 @@ Module collections.
                       ("node", M.read (| node |));
                       ("idx",
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::Handle"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::Handle",
                             "idx"
+                          |)
                         |));
                       ("_marker", Value.StructTuple "core::marker::PhantomData" [])
                     ]
@@ -15596,10 +15888,11 @@ Module collections.
               M.read (|
                 let new_left_len :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::node::Handle"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::node::Handle",
                       "idx"
+                    |)
                   |) in
                 let left_node :=
                   M.alloc (|
@@ -15744,16 +16037,18 @@ Module collections.
                                 UnOp.Pure.not
                                   (BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        left_node
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        left_node,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |))
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        right_node
-                                        "alloc::collections::btree::node::NodeRef"
+                                      M.SubPointer.get_struct_record_field (|
+                                        right_node,
+                                        "alloc::collections::btree::node::NodeRef",
                                         "height"
+                                      |)
                                     |)))
                               |)) in
                           let _ :=
@@ -16025,17 +16320,17 @@ Module collections.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "alloc::collections::btree::node::ForceResult::Internal",
                                     0
                                   |) in
                                 let left := M.copy (| γ1_0 |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_1,
                                     "alloc::collections::btree::node::ForceResult::Internal",
                                     0
@@ -16201,16 +16496,16 @@ Module collections.
                                 M.alloc (| Value.Tuple [] |)));
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "alloc::collections::btree::node::ForceResult::Leaf",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_1,
                                     "alloc::collections::btree::node::ForceResult::Leaf",
                                     0
@@ -16318,19 +16613,21 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::SplitResult"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::SplitResult",
                             "left"
+                          |)
                         |)
                       ]
                     |));
                   ("kv",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::SplitResult"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::SplitResult",
                         "kv"
+                      |)
                     |));
                   ("right",
                     M.call_closure (|
@@ -16348,10 +16645,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::SplitResult"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::SplitResult",
                             "right"
+                          |)
                         |)
                       ]
                     |))
@@ -16400,19 +16698,21 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::SplitResult"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::SplitResult",
                             "left"
+                          |)
                         |)
                       ]
                     |));
                   ("kv",
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::btree::node::SplitResult"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::btree::node::SplitResult",
                         "kv"
+                      |)
                     |));
                   ("right",
                     M.call_closure (|
@@ -16430,10 +16730,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::node::SplitResult"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::node::SplitResult",
                             "right"
+                          |)
                         |)
                       ]
                     |))

--- a/CoqOfRust/alloc/collections/btree/remove.v
+++ b/CoqOfRust/alloc/collections/btree/remove.v
@@ -68,7 +68,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Leaf",
                             0
@@ -103,7 +103,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::node::ForceResult::Internal",
                             0
@@ -249,8 +249,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let old_kv := M.copy (| γ0_0 |) in
                         let pos := M.copy (| γ0_1 |) in
                         let len :=
@@ -439,13 +439,13 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::result::Result::Ok",
                                                   0
                                                 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_0,
                                                   "alloc::collections::btree::node::LeftOrRight::Left",
                                                   0
@@ -685,13 +685,13 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::result::Result::Ok",
                                                   0
                                                 |) in
                                               let γ1_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ0_0,
                                                   "alloc::collections::btree::node::LeftOrRight::Right",
                                                   0
@@ -931,7 +931,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::result::Result::Err",
                                                   0
@@ -1073,7 +1073,7 @@ Module collections.
                                               |)
                                             |) in
                                           let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::result::Result::Ok",
                                               0
@@ -1420,8 +1420,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let left_kv := M.copy (| γ0_0 |) in
                         let left_hole := M.copy (| γ0_1 |) in
                         let internal :=
@@ -1534,8 +1534,8 @@ Module collections.
                               |),
                               [
                                 internal;
-                                M.read (| M.get_tuple_field left_kv 0 |);
-                                M.read (| M.get_tuple_field left_kv 1 |)
+                                M.read (| M.SubPointer.get_tuple_field (| left_kv, 0 |) |);
+                                M.read (| M.SubPointer.get_tuple_field (| left_kv, 1 |) |)
                               ]
                             |)
                           |) in

--- a/CoqOfRust/alloc/collections/btree/search.v
+++ b/CoqOfRust/alloc/collections/btree/search.v
@@ -60,7 +60,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Included",
                             0
@@ -74,7 +74,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Excluded",
                             0
@@ -230,7 +230,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::search::SearchResult::Found",
                                           0
@@ -250,7 +250,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "alloc::collections::btree::search::SearchResult::GoDown",
                                           0
@@ -286,7 +286,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                   0
@@ -306,7 +306,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                   0
@@ -483,8 +483,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let start := M.copy (| γ0_0 |) in
                             let end_ := M.copy (| γ0_1 |) in
                             let _ :=
@@ -493,17 +493,17 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_0,
                                           "core::ops::range::Bound::Excluded",
                                           0
                                         |) in
                                       let s := M.copy (| γ1_0 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_1,
                                           "core::ops::range::Bound::Excluded",
                                           0
@@ -608,15 +608,15 @@ Module collections.
                                       |)));
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       M.find_or_pattern (|
                                         γ0_0,
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::range::Bound::Included",
                                                   0
@@ -626,7 +626,7 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::range::Bound::Excluded",
                                                   0
@@ -645,7 +645,7 @@ Module collections.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::range::Bound::Included",
                                                             0
@@ -655,7 +655,7 @@ Module collections.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::range::Bound::Excluded",
                                                             0
@@ -829,8 +829,9 @@ Module collections.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let lower_edge_idx := M.copy (| γ0_0 |) in
                                               let lower_child_bound := M.copy (| γ0_1 |) in
                                               M.match_operator (|
@@ -860,8 +861,10 @@ Module collections.
                                                 [
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let upper_edge_idx := M.copy (| γ0_0 |) in
                                                       let upper_child_bound := M.copy (| γ0_1 |) in
                                                       let _ :=
@@ -948,9 +951,15 @@ Module collections.
                                                                       fun γ =>
                                                                         ltac:(M.monadic
                                                                           (let γ0_0 :=
-                                                                            M.get_tuple_field γ 0 in
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              γ,
+                                                                              0
+                                                                            |) in
                                                                           let γ0_1 :=
-                                                                            M.get_tuple_field γ 1 in
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              γ,
+                                                                              1
+                                                                            |) in
                                                                           let left_val :=
                                                                             M.copy (| γ0_0 |) in
                                                                           let right_val :=
@@ -1101,7 +1110,7 @@ Module collections.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                                                   0
@@ -1122,7 +1131,7 @@ Module collections.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "alloc::collections::btree::node::ForceResult::Internal",
                                                                   0
@@ -1239,8 +1248,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let edge_idx := M.copy (| γ0_0 |) in
                         let bound := M.copy (| γ0_1 |) in
                         let edge :=
@@ -1328,8 +1337,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let edge_idx := M.copy (| γ0_0 |) in
                         let bound := M.copy (| γ0_1 |) in
                         let edge :=
@@ -1416,7 +1425,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::IndexResult::KV",
                             0
@@ -1446,7 +1455,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::IndexResult::Edge",
                             0
@@ -1697,13 +1706,15 @@ Module collections.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
                                                 |) in
-                                              let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                              let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                              let γ1_0 :=
+                                                M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                              let γ1_1 :=
+                                                M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                               let offset := M.copy (| γ1_0 |) in
                                               let k := M.copy (| γ1_1 |) in
                                               M.match_operator (|
@@ -1845,7 +1856,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::SearchBound::Included",
                             0
@@ -1868,7 +1879,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::KV",
                                     0
@@ -1886,7 +1897,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::Edge",
                                     0
@@ -1898,7 +1909,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::SearchBound::Excluded",
                             0
@@ -1921,7 +1932,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::KV",
                                     0
@@ -1942,7 +1953,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::Edge",
                                     0
@@ -2038,7 +2049,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::SearchBound::Included",
                             0
@@ -2061,7 +2072,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::KV",
                                     0
@@ -2082,7 +2093,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::Edge",
                                     0
@@ -2094,7 +2105,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::search::SearchBound::Excluded",
                             0
@@ -2117,7 +2128,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::KV",
                                     0
@@ -2135,7 +2146,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "alloc::collections::btree::search::IndexResult::Edge",
                                     0

--- a/CoqOfRust/alloc/collections/btree/set.v
+++ b/CoqOfRust/alloc/collections/btree/set.v
@@ -44,10 +44,11 @@ Module collections.
                   [ H ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |);
                   M.read (| state |)
                 ]
               |)))
@@ -94,14 +95,16 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::collections::btree::set::BTreeSet"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
                     "map"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -160,14 +163,16 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::collections::btree::set::BTreeSet"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
                     "map"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -209,14 +214,16 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::collections::btree::set::BTreeSet"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
                     "map"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -261,10 +268,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
                           "map"
+                        |)
                       ]
                     |))
                 ]))
@@ -297,14 +305,16 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "alloc::collections::btree::set::BTreeSet"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
                           "map"
+                        |);
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |)
                       ]
                     |)
                   |) in
@@ -393,10 +403,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::set::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::set::Iter",
                                 "iter"
+                              |)
                             ]
                           |)
                         |))
@@ -454,10 +465,11 @@ Module collections.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::IntoIter",
                         "iter"
+                      |)
                     |))
                 ]
               |)))
@@ -511,10 +523,11 @@ Module collections.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::Range"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::Range",
                         "iter"
+                      |)
                     |))
                 ]
               |)))
@@ -619,13 +632,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::DifferenceInner::Stitch",
                             "self_iter"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::DifferenceInner::Stitch",
                             "other_iter"
@@ -679,13 +692,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::DifferenceInner::Search",
                             "self_iter"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::DifferenceInner::Search",
                             "other_set"
@@ -739,7 +752,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::set::DifferenceInner::Iterate",
                             0
@@ -833,10 +846,11 @@ Module collections.
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Difference"
-                          "inner")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Difference",
+                          "inner"
+                        |))
                     ]
                   |)
                 ]
@@ -907,10 +921,11 @@ Module collections.
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::SymmetricDifference"
-                          0)
+                        (M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::SymmetricDifference",
+                          0
+                        |))
                     ]
                   |)
                 ]
@@ -1012,13 +1027,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Stitch",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Stitch",
                             "b"
@@ -1072,13 +1087,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Search",
                             "small_iter"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Search",
                             "large_set"
@@ -1132,7 +1147,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Answer",
                             0
@@ -1226,10 +1241,11 @@ Module collections.
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Intersection"
-                          "inner")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Intersection",
+                          "inner"
+                        |))
                     ]
                   |)
                 ]
@@ -1300,10 +1316,11 @@ Module collections.
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Union"
-                          0)
+                        (M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Union",
+                          0
+                        |))
                     ]
                   |)
                 ]
@@ -1433,10 +1450,11 @@ Module collections.
                         [ K; R ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |);
                         M.read (| range |)
                       ]
                     |))
@@ -1531,17 +1549,17 @@ Module collections.
                                       |)
                                     ]
                                 |) in
-                              let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::option::Option::Some",
                                   0
                                 |) in
                               let self_min := M.copy (| γ1_0 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::option::Option::Some",
                                   0
@@ -1585,8 +1603,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let self_min := M.copy (| γ0_0 |) in
                             let self_max := M.copy (| γ0_1 |) in
                             M.match_operator (|
@@ -1623,17 +1641,17 @@ Module collections.
                                               |)
                                             ]
                                         |) in
-                                      let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_0,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let other_min := M.copy (| γ1_0 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_1,
                                           "core::option::Option::Some",
                                           0
@@ -1678,8 +1696,8 @@ Module collections.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let other_min := M.copy (| γ0_0 |) in
                                     let other_max := M.copy (| γ0_1 |) in
                                     M.alloc (|
@@ -1728,13 +1746,29 @@ Module collections.
                                                         [
                                                           fun γ =>
                                                             ltac:(M.monadic
-                                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                                              (let γ0_0 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  0
+                                                                |) in
+                                                              let γ0_1 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  1
+                                                                |) in
                                                               Value.Tuple []));
                                                           fun γ =>
                                                             ltac:(M.monadic
-                                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                                              (let γ0_0 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  0
+                                                                |) in
+                                                              let γ0_1 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  1
+                                                                |) in
                                                               Value.Tuple []))
                                                         ],
                                                         M.closure
@@ -1764,8 +1798,10 @@ Module collections.
                                                       |)));
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let self_iter :=
                                                         M.alloc (|
                                                           M.call_closure (|
@@ -1803,8 +1839,10 @@ Module collections.
                                                       |)));
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let self_iter :=
                                                         M.alloc (|
                                                           M.call_closure (|
@@ -2094,17 +2132,17 @@ Module collections.
                                       |)
                                     ]
                                 |) in
-                              let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::option::Option::Some",
                                   0
                                 |) in
                               let self_min := M.copy (| γ1_0 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::option::Option::Some",
                                   0
@@ -2136,8 +2174,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let self_min := M.copy (| γ0_0 |) in
                             let self_max := M.copy (| γ0_1 |) in
                             M.match_operator (|
@@ -2174,17 +2212,17 @@ Module collections.
                                               |)
                                             ]
                                         |) in
-                                      let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_0,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let other_min := M.copy (| γ1_0 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_1,
                                           "core::option::Option::Some",
                                           0
@@ -2221,8 +2259,8 @@ Module collections.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let other_min := M.copy (| γ0_0 |) in
                                     let other_max := M.copy (| γ0_1 |) in
                                     M.alloc (|
@@ -2271,13 +2309,29 @@ Module collections.
                                                         [
                                                           fun γ =>
                                                             ltac:(M.monadic
-                                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                                              (let γ0_0 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  0
+                                                                |) in
+                                                              let γ0_1 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  1
+                                                                |) in
                                                               Value.Tuple []));
                                                           fun γ =>
                                                             ltac:(M.monadic
-                                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                                              (let γ0_0 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  0
+                                                                |) in
+                                                              let γ0_1 :=
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  γ,
+                                                                  1
+                                                                |) in
                                                               Value.Tuple []))
                                                         ],
                                                         M.closure
@@ -2299,8 +2353,10 @@ Module collections.
                                                       |)));
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       M.alloc (|
                                                         Value.StructTuple
                                                           "alloc::collections::btree::set::IntersectionInner::Answer"
@@ -2312,8 +2368,10 @@ Module collections.
                                                       |)));
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       M.alloc (|
                                                         Value.StructTuple
                                                           "alloc::collections::btree::set::IntersectionInner::Answer"
@@ -2567,10 +2625,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
                     "map"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -2605,10 +2664,11 @@ Module collections.
                   [ Q ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |);
                   M.read (| value |)
                 ]
               |)))
@@ -2646,10 +2706,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |);
                   M.read (| value |)
                 ]
               |)))
@@ -2859,17 +2920,17 @@ Module collections.
                                       |)
                                     ]
                                 |) in
-                              let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::option::Option::Some",
                                   0
                                 |) in
                               let self_min := M.copy (| γ1_0 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::option::Option::Some",
                                   0
@@ -2888,8 +2949,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let self_min := M.copy (| γ0_0 |) in
                             let self_max := M.copy (| γ0_1 |) in
                             M.match_operator (|
@@ -2926,17 +2987,17 @@ Module collections.
                                               |)
                                             ]
                                         |) in
-                                      let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_0,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let other_min := M.copy (| γ1_0 |) in
                                       let γ1_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ0_1,
                                           "core::option::Option::Some",
                                           0
@@ -2958,8 +3019,8 @@ Module collections.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let other_min := M.copy (| γ0_0 |) in
                                     let other_max := M.copy (| γ0_1 |) in
                                     let self_iter :=
@@ -3161,7 +3222,7 @@ Module collections.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::option::Option::Some",
                                                                           0
@@ -3300,7 +3361,7 @@ Module collections.
                                                         ltac:(M.monadic
                                                           (let γ := self_next in
                                                           let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
@@ -3540,10 +3601,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::BTreeSet"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::BTreeSet",
                         "map"
+                      |)
                     ]
                   |);
                   M.closure
@@ -3556,8 +3618,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -3629,10 +3691,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::BTreeSet"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::BTreeSet",
                         "map"
+                      |)
                     ]
                   |);
                   M.closure
@@ -3645,8 +3708,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -3703,10 +3766,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::BTreeSet"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::BTreeSet",
                         "map"
+                      |)
                     ]
                   |);
                   M.closure
@@ -3720,7 +3784,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let kv := M.copy (| γ |) in
-                                  M.read (| M.get_tuple_field kv 0 |)))
+                                  M.read (| M.SubPointer.get_tuple_field (| kv, 0 |) |)))
                             ]
                           |)
                         | _ => M.impossible (||)
@@ -3775,10 +3839,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::BTreeSet"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::BTreeSet",
                         "map"
+                      |)
                     ]
                   |);
                   M.closure
@@ -3792,7 +3857,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let kv := M.copy (| γ |) in
-                                  M.read (| M.get_tuple_field kv 0 |)))
+                                  M.read (| M.SubPointer.get_tuple_field (| kv, 0 |) |)))
                             ]
                           |)
                         | _ => M.impossible (||)
@@ -3840,10 +3905,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |);
                         M.read (| value |);
                         M.call_closure (|
                           M.get_trait_method (|
@@ -3893,10 +3959,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |);
                   M.read (| value |)
                 ]
               |)))
@@ -3942,10 +4009,11 @@ Module collections.
                         [ Q ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |);
                         M.read (| value |)
                       ]
                     |)
@@ -3986,10 +4054,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
-                    "map";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
+                    "map"
+                  |);
                   M.read (| value |)
                 ]
               |)))
@@ -4117,14 +4186,16 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "alloc::collections::btree::set::BTreeSet"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
                           "map"
+                        |);
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |)
                       ]
                     |)
                   |) in
@@ -4166,10 +4237,11 @@ Module collections.
                         [ Q ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
-                          "map";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
+                          "map"
+                        |);
                         M.read (| value |)
                       ]
                     |))
@@ -4210,18 +4282,19 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
                           "map"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let inner := M.copy (| γ0_0 |) in
                         let alloc := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -4267,10 +4340,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::BTreeSet"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::BTreeSet",
                           "map"
+                        |)
                       ]
                     |))
                 ]))
@@ -4301,10 +4375,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::BTreeSet"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::BTreeSet",
                     "map"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -4841,10 +4916,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::btree::set::BTreeSet"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::btree::set::BTreeSet",
                             "map"
+                          |)
                         |)
                       ]
                     |))
@@ -5018,10 +5094,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::set::ExtractIf"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::set::ExtractIf",
                                     "inner"
+                                  |)
                                 ]
                               |);
                               M.closure
@@ -5034,8 +5111,9 @@ Module collections.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let k := M.copy (| γ0_0 |) in
                                               M.read (| k |)))
                                         ]
@@ -5084,10 +5162,11 @@ Module collections.
               M.read (|
                 let pred :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::set::ExtractIf"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::set::ExtractIf",
                       "pred"
+                    |)
                   |) in
                 let mapped_pred :=
                   M.alloc (|
@@ -5168,18 +5247,20 @@ Module collections.
                           ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::set::ExtractIf"
-                            "inner";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::set::ExtractIf",
+                            "inner"
+                          |);
                           mapped_pred;
                           M.call_closure (|
                             M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::btree::set::ExtractIf"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::btree::set::ExtractIf",
                                 "alloc"
+                              |)
                             ]
                           |)
                         ]
@@ -5194,8 +5275,8 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let k := M.copy (| γ0_0 |) in
                                       M.read (| k |)))
                                 ]
@@ -5229,10 +5310,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::ExtractIf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::ExtractIf",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -5611,13 +5693,15 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::set::BTreeSet"
-                              "map")
-                            "alloc::collections::btree::map::BTreeMap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::set::BTreeSet",
+                              "map"
+                            |),
+                            "alloc::collections::btree::map::BTreeMap",
                             "alloc"
+                          |)
                         ]
                       |)
                     ]
@@ -5720,13 +5804,15 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::set::BTreeSet"
-                              "map")
-                            "alloc::collections::btree::map::BTreeMap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::set::BTreeSet",
+                              "map"
+                            |),
+                            "alloc::collections::btree::map::BTreeMap",
                             "alloc"
+                          |)
                         ]
                       |)
                     ]
@@ -5826,13 +5912,15 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::set::BTreeSet"
-                              "map")
-                            "alloc::collections::btree::map::BTreeMap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::set::BTreeSet",
+                              "map"
+                            |),
+                            "alloc::collections::btree::map::BTreeMap",
                             "alloc"
+                          |)
                         ]
                       |)
                     ]
@@ -5932,13 +6020,15 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::btree::set::BTreeSet"
-                              "map")
-                            "alloc::collections::btree::map::BTreeMap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::btree::set::BTreeSet",
+                              "map"
+                            |),
+                            "alloc::collections::btree::map::BTreeMap",
                             "alloc"
+                          |)
                         ]
                       |)
                     ]
@@ -6064,10 +6154,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Iter",
                           "iter"
+                        |)
                       ]
                     |))
                 ]))
@@ -6112,10 +6203,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::Iter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::Iter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6143,10 +6235,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::Iter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::Iter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6273,10 +6366,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::Iter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::Iter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6317,10 +6411,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::Iter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::Iter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6395,10 +6490,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::IntoIter",
                         "iter"
+                      |)
                     ]
                   |);
                   M.closure
@@ -6411,8 +6507,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -6446,10 +6542,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::IntoIter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6556,10 +6653,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::IntoIter",
                         "iter"
+                      |)
                     ]
                   |);
                   M.closure
@@ -6572,8 +6670,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -6620,10 +6718,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::btree::set::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::btree::set::IntoIter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -6724,10 +6823,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Range",
                           "iter"
+                        |)
                       ]
                     |))
                 ]))
@@ -6805,10 +6905,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::Range"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::Range",
                         "iter"
+                      |)
                     ]
                   |);
                   M.closure
@@ -6821,8 +6922,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -6987,10 +7088,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::Range"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::Range",
                         "iter"
+                      |)
                     ]
                   |);
                   M.closure
@@ -7003,8 +7105,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let k := M.copy (| γ0_0 |) in
                                   M.read (| k |)))
                             ]
@@ -7114,23 +7216,24 @@ Module collections.
                     M.read (|
                       M.match_operator (|
                         M.alloc (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::set::Difference"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::set::Difference",
                             "inner"
+                          |)
                         |),
                         [
                           fun γ =>
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::DifferenceInner::Stitch",
                                   "self_iter"
                                 |) in
                               let γ1_1 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::DifferenceInner::Stitch",
                                   "other_iter"
@@ -7177,13 +7280,13 @@ Module collections.
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::DifferenceInner::Search",
                                   "self_iter"
                                 |) in
                               let γ1_1 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::DifferenceInner::Search",
                                   "other_set"
@@ -7214,7 +7317,7 @@ Module collections.
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "alloc::collections::btree::set::DifferenceInner::Iterate",
                                   0
@@ -7300,23 +7403,24 @@ Module collections.
                   (M.read (|
                     M.match_operator (|
                       M.alloc (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Difference"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Difference",
                           "inner"
+                        |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::DifferenceInner::Stitch",
                                 "self_iter"
                               |) in
                             let γ1_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::DifferenceInner::Stitch",
                                 "other_iter"
@@ -7357,7 +7461,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -7390,7 +7494,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -7535,7 +7639,7 @@ Module collections.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -7577,7 +7681,7 @@ Module collections.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -7644,13 +7748,13 @@ Module collections.
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::DifferenceInner::Search",
                                 "self_iter"
                               |) in
                             let γ1_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::DifferenceInner::Search",
                                 "other_set"
@@ -7697,7 +7801,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -7733,7 +7837,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -7794,7 +7898,7 @@ Module collections.
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::set::DifferenceInner::Iterate",
                                 0
@@ -7841,23 +7945,24 @@ Module collections.
                 M.match_operator (|
                   M.match_operator (|
                     M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::Difference"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::Difference",
                         "inner"
+                      |)
                     |),
                     [
                       fun γ =>
                         ltac:(M.monadic
                           (let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::btree::set::DifferenceInner::Stitch",
                               "self_iter"
                             |) in
                           let γ1_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::btree::set::DifferenceInner::Stitch",
                               "other_iter"
@@ -7899,13 +8004,13 @@ Module collections.
                         ltac:(M.monadic
                           (let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::btree::set::DifferenceInner::Search",
                               "self_iter"
                             |) in
                           let γ1_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::btree::set::DifferenceInner::Search",
                               "other_set"
@@ -7941,7 +8046,7 @@ Module collections.
                         ltac:(M.monadic
                           (let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "alloc::collections::btree::set::DifferenceInner::Iterate",
                               0
@@ -7968,8 +8073,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let self_len := M.copy (| γ0_0 |) in
                         let other_len := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -8075,10 +8180,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::SymmetricDifference"
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::SymmetricDifference",
                         0
+                      |)
                     ]
                   |)
                 ]))
@@ -8146,10 +8252,11 @@ Module collections.
                                   ]
                                 |),
                                 [
-                                  M.get_struct_tuple_field
-                                    (M.read (| self |))
-                                    "alloc::collections::btree::set::SymmetricDifference"
-                                    0;
+                                  M.SubPointer.get_struct_tuple_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::btree::set::SymmetricDifference",
+                                    0
+                                  |);
                                   M.get_trait_method (|
                                     "core::cmp::Ord",
                                     Ty.apply (Ty.path "&") [ T ],
@@ -8163,8 +8270,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let a_next := M.copy (| γ0_0 |) in
                                   let b_next := M.copy (| γ0_1 |) in
                                   M.match_operator (|
@@ -8261,18 +8368,19 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::SymmetricDifference"
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::SymmetricDifference",
                           0
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_len := M.copy (| γ0_0 |) in
                         let b_len := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -8374,23 +8482,24 @@ Module collections.
                     M.read (|
                       M.match_operator (|
                         M.alloc (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::btree::set::Intersection"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::btree::set::Intersection",
                             "inner"
+                          |)
                         |),
                         [
                           fun γ =>
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::IntersectionInner::Stitch",
                                   "a"
                                 |) in
                               let γ1_1 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::IntersectionInner::Stitch",
                                   "b"
@@ -8433,13 +8542,13 @@ Module collections.
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::IntersectionInner::Search",
                                   "small_iter"
                                 |) in
                               let γ1_1 :=
-                                M.get_struct_record_field_or_break_match (|
+                                M.SubPointer.get_struct_record_field (|
                                   γ,
                                   "alloc::collections::btree::set::IntersectionInner::Search",
                                   "large_set"
@@ -8470,7 +8579,7 @@ Module collections.
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "alloc::collections::btree::set::IntersectionInner::Answer",
                                   0
@@ -8539,23 +8648,24 @@ Module collections.
                   (M.read (|
                     M.match_operator (|
                       M.alloc (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Intersection"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Intersection",
                           "inner"
+                        |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::IntersectionInner::Stitch",
                                 "a"
                               |) in
                             let γ1_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::IntersectionInner::Stitch",
                                 "b"
@@ -8596,7 +8706,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -8629,7 +8739,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -8673,7 +8783,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -8706,7 +8816,7 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -8773,7 +8883,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -8815,7 +8925,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -8864,7 +8974,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -8906,7 +9016,7 @@ Module collections.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -8940,13 +9050,13 @@ Module collections.
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::IntersectionInner::Search",
                                 "small_iter"
                               |) in
                             let γ1_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "alloc::collections::btree::set::IntersectionInner::Search",
                                 "large_set"
@@ -8993,7 +9103,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -9029,7 +9139,7 @@ Module collections.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -9089,7 +9199,7 @@ Module collections.
                           ltac:(M.monadic
                             (let γ := M.read (| γ |) in
                             let γ1_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "alloc::collections::btree::set::IntersectionInner::Answer",
                                 0
@@ -9133,23 +9243,24 @@ Module collections.
               M.read (|
                 M.match_operator (|
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::btree::set::Intersection"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::btree::set::Intersection",
                       "inner"
+                    |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Stitch",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Stitch",
                             "b"
@@ -9199,7 +9310,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Search",
                             "small_iter"
@@ -9231,7 +9342,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Answer",
                             0
@@ -9249,13 +9360,13 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "alloc::collections::btree::set::IntersectionInner::Answer",
                             0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "core::option::Option::Some",
                             0
@@ -9356,10 +9467,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "alloc::collections::btree::set::Union"
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "alloc::collections::btree::set::Union",
                         0
+                      |)
                     ]
                   |)
                 ]))
@@ -9413,10 +9525,11 @@ Module collections.
                         ]
                       |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Union"
-                          0;
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Union",
+                          0
+                        |);
                         M.get_trait_method (|
                           "core::cmp::Ord",
                           Ty.apply (Ty.path "&") [ T ],
@@ -9430,8 +9543,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_next := M.copy (| γ0_0 |) in
                         let b_next := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -9477,18 +9590,19 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "alloc::collections::btree::set::Union"
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "alloc::collections::btree::set::Union",
                           0
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_len := M.copy (| γ0_0 |) in
                         let b_len := M.copy (| γ0_1 |) in
                         M.alloc (|

--- a/CoqOfRust/alloc/collections/btree/split.v
+++ b/CoqOfRust/alloc/collections/btree/split.v
@@ -48,8 +48,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let length_a := M.copy (| γ0_0 |) in
                         let length_b := M.copy (| γ0_1 |) in
                         let _ :=
@@ -211,8 +211,10 @@ Module collections.
                                                 [
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let left_val := M.copy (| γ0_0 |) in
                                                       let right_val := M.copy (| γ0_1 |) in
                                                       M.match_operator (|
@@ -391,8 +393,10 @@ Module collections.
                                                 [
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let left_val := M.copy (| γ0_0 |) in
                                                       let right_val := M.copy (| γ0_1 |) in
                                                       M.match_operator (|
@@ -619,7 +623,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "alloc::collections::btree::search::SearchResult::Found",
                                       0
@@ -652,7 +656,7 @@ Module collections.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "alloc::collections::btree::search::SearchResult::GoDown",
                                       0
@@ -732,17 +736,17 @@ Module collections.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "alloc::collections::btree::node::ForceResult::Internal",
                                   0
                                 |) in
                               let edge := M.copy (| γ1_0 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "alloc::collections::btree::node::ForceResult::Internal",
                                   0
@@ -821,16 +825,16 @@ Module collections.
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                   0
                                 |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "alloc::collections::btree::node::ForceResult::Leaf",
                                   0
@@ -997,7 +1001,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0

--- a/CoqOfRust/alloc/collections/linked_list.v
+++ b/CoqOfRust/alloc/collections/linked_list.v
@@ -190,24 +190,27 @@ Module collections.
                                       [
                                         ("head",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::Iter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::Iter",
                                               "head"
+                                            |)
                                           |));
                                         ("tail",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::Iter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::Iter",
                                               "tail"
+                                            |)
                                           |));
                                         ("len",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::Iter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::Iter",
                                               "len"
+                                            |)
                                           |));
                                         ("alloc", Value.StructTuple "alloc::alloc::Global" []);
                                         ("marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -221,10 +224,11 @@ Module collections.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::Iter"
-                        "len")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::Iter",
+                        "len"
+                      |))
                   ]
                 |)
               ]
@@ -395,24 +399,27 @@ Module collections.
                                       [
                                         ("head",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::IterMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::IterMut",
                                               "head"
+                                            |)
                                           |));
                                         ("tail",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::IterMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::IterMut",
                                               "tail"
+                                            |)
                                           |));
                                         ("len",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::IterMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::IterMut",
                                               "len"
+                                            |)
                                           |));
                                         ("alloc", Value.StructTuple "alloc::alloc::Global" []);
                                         ("marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -426,10 +433,11 @@ Module collections.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::IterMut"
-                        "len")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::IterMut",
+                        "len"
+                      |))
                   ]
                 |)
               ]
@@ -478,10 +486,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::IntoIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::IntoIter",
                         "list"
+                      |)
                     ]
                   |))
               ]))
@@ -539,10 +548,11 @@ Module collections.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::IntoIter"
-                        "list")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::IntoIter",
+                        "list"
+                      |))
                   ]
                 |)
               ]
@@ -600,10 +610,11 @@ Module collections.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::linked_list::Node"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::linked_list::Node",
                 "element"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -647,8 +658,8 @@ Module collections.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_associated_function (|
                         Ty.apply
                           (Ty.path "core::ptr::non_null::NonNull")
@@ -657,20 +668,22 @@ Module collections.
                         []
                       |),
                       [ M.read (| node |) ]
-                    |))
-                    "alloc::collections::linked_list::Node"
-                    "next",
+                    |),
+                    "alloc::collections::linked_list::Node",
+                    "next"
+                  |),
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_associated_function (|
                         Ty.apply
                           (Ty.path "core::ptr::non_null::NonNull")
@@ -679,9 +692,10 @@ Module collections.
                         []
                       |),
                       [ M.read (| node |) ]
-                    |))
-                    "alloc::collections::linked_list::Node"
-                    "prev",
+                    |),
+                    "alloc::collections::linked_list::Node",
+                    "prev"
+                  |),
                   Value.StructTuple "core::option::Option::None" []
                 |) in
               let node :=
@@ -690,32 +704,34 @@ Module collections.
                 |) in
               let _ :=
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "head"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |),
                           M.read (| node |)
                         |)));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let head := M.copy (| γ0_0 |) in
                         M.write (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -725,27 +741,30 @@ Module collections.
                                 []
                               |),
                               [ M.read (| head |) ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "prev",
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "prev"
+                          |),
                           M.read (| node |)
                         |)))
                   ]
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "head"
+                  |),
                   M.read (| node |)
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "len"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -820,10 +839,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
                     "head"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -868,54 +888,59 @@ Module collections.
                                             |),
                                             [ M.read (| node |) ]
                                           |);
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::LinkedList"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::LinkedList",
                                             "alloc"
+                                          |)
                                         ]
                                       |)
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "head",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "head"
+                                      |),
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| node |))
-                                          "alloc::collections::linked_list::Node"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| node |),
+                                          "alloc::collections::linked_list::Node",
                                           "next"
+                                        |)
                                       |)
                                     |) in
                                   let _ :=
                                     M.match_operator (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "head",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "head"
+                                      |),
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
                                             (M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::linked_list::LinkedList"
-                                                "tail",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::linked_list::LinkedList",
+                                                "tail"
+                                              |),
                                               Value.StructTuple "core::option::Option::None" []
                                             |)));
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
                                             let head := M.copy (| γ0_0 |) in
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.call_closure (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
                                                       (Ty.path "core::ptr::non_null::NonNull")
@@ -929,19 +954,21 @@ Module collections.
                                                     []
                                                   |),
                                                   [ M.read (| head |) ]
-                                                |))
-                                                "alloc::collections::linked_list::Node"
-                                                "prev",
+                                                |),
+                                                "alloc::collections::linked_list::Node",
+                                                "prev"
+                                              |),
                                               Value.StructTuple "core::option::Option::None" []
                                             |)))
                                       ]
                                     |) in
                                   let _ :=
                                     let β :=
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "len" in
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "len"
+                                      |) in
                                     M.write (|
                                       β,
                                       BinOp.Panic.sub (|
@@ -994,8 +1021,8 @@ Module collections.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_associated_function (|
                         Ty.apply
                           (Ty.path "core::ptr::non_null::NonNull")
@@ -1004,15 +1031,16 @@ Module collections.
                         []
                       |),
                       [ M.read (| node |) ]
-                    |))
-                    "alloc::collections::linked_list::Node"
-                    "next",
+                    |),
+                    "alloc::collections::linked_list::Node",
+                    "next"
+                  |),
                   Value.StructTuple "core::option::Option::None" []
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_associated_function (|
                         Ty.apply
                           (Ty.path "core::ptr::non_null::NonNull")
@@ -1021,14 +1049,16 @@ Module collections.
                         []
                       |),
                       [ M.read (| node |) ]
-                    |))
-                    "alloc::collections::linked_list::Node"
-                    "prev",
+                    |),
+                    "alloc::collections::linked_list::Node",
+                    "prev"
+                  |),
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   |)
                 |) in
               let node :=
@@ -1037,32 +1067,34 @@ Module collections.
                 |) in
               let _ :=
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "tail",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "tail"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |),
                           M.read (| node |)
                         |)));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let tail := M.copy (| γ0_0 |) in
                         M.write (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -1072,27 +1104,30 @@ Module collections.
                                 []
                               |),
                               [ M.read (| tail |) ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "next",
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "next"
+                          |),
                           M.read (| node |)
                         |)))
                   ]
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "tail",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "tail"
+                  |),
                   M.read (| node |)
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "len"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1167,10 +1202,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
                     "tail"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -1215,54 +1251,59 @@ Module collections.
                                             |),
                                             [ M.read (| node |) ]
                                           |);
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::LinkedList"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::LinkedList",
                                             "alloc"
+                                          |)
                                         ]
                                       |)
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "tail",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "tail"
+                                      |),
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| node |))
-                                          "alloc::collections::linked_list::Node"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| node |),
+                                          "alloc::collections::linked_list::Node",
                                           "prev"
+                                        |)
                                       |)
                                     |) in
                                   let _ :=
                                     M.match_operator (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "tail",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "tail"
+                                      |),
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
                                             (M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::linked_list::LinkedList"
-                                                "head",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::linked_list::LinkedList",
+                                                "head"
+                                              |),
                                               Value.StructTuple "core::option::Option::None" []
                                             |)));
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
                                             let tail := M.copy (| γ0_0 |) in
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.call_closure (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
                                                       (Ty.path "core::ptr::non_null::NonNull")
@@ -1276,19 +1317,21 @@ Module collections.
                                                     []
                                                   |),
                                                   [ M.read (| tail |) ]
-                                                |))
-                                                "alloc::collections::linked_list::Node"
-                                                "next",
+                                                |),
+                                                "alloc::collections::linked_list::Node",
+                                                "next"
+                                              |),
                                               Value.StructTuple "core::option::Option::None" []
                                             |)))
                                       ]
                                     |) in
                                   let _ :=
                                     let β :=
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "len" in
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "len"
+                                      |) in
                                     M.write (|
                                       β,
                                       BinOp.Panic.sub (|
@@ -1354,23 +1397,24 @@ Module collections.
                 |) in
               let _ :=
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| node |))
-                    "alloc::collections::linked_list::Node"
-                    "prev",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| node |),
+                    "alloc::collections::linked_list::Node",
+                    "prev"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let prev := M.copy (| γ0_0 |) in
                         M.write (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -1380,51 +1424,56 @@ Module collections.
                                 []
                               |),
                               [ M.read (| prev |) ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "next",
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "next"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| node |))
-                              "alloc::collections::linked_list::Node"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| node |),
+                              "alloc::collections::linked_list::Node",
                               "next"
+                            |)
                           |)
                         |)));
                     fun γ =>
                       ltac:(M.monadic
                         (M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| node |))
-                              "alloc::collections::linked_list::Node"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| node |),
+                              "alloc::collections::linked_list::Node",
                               "next"
+                            |)
                           |)
                         |)))
                   ]
                 |) in
               let _ :=
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| node |))
-                    "alloc::collections::linked_list::Node"
-                    "next",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| node |),
+                    "alloc::collections::linked_list::Node",
+                    "next"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let next := M.copy (| γ0_0 |) in
                         M.write (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -1434,38 +1483,43 @@ Module collections.
                                 []
                               |),
                               [ M.read (| next |) ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "prev",
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "prev"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| node |))
-                              "alloc::collections::linked_list::Node"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| node |),
+                              "alloc::collections::linked_list::Node",
                               "prev"
+                            |)
                           |)
                         |)));
                     fun γ =>
                       ltac:(M.monadic
                         (M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| node |))
-                              "alloc::collections::linked_list::Node"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| node |),
+                              "alloc::collections::linked_list::Node",
                               "prev"
+                            |)
                           |)
                         |)))
                   ]
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "len"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1532,7 +1586,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := existing_prev in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1540,8 +1594,8 @@ Module collections.
                         let existing_prev := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -1554,9 +1608,10 @@ Module collections.
                                   []
                                 |),
                                 [ existing_prev ]
-                              |))
-                              "alloc::collections::linked_list::Node"
-                              "next",
+                              |),
+                              "alloc::collections::linked_list::Node",
+                              "next"
+                            |),
                             Value.StructTuple
                               "core::option::Option::Some"
                               [ M.read (| splice_start |) ]
@@ -1566,10 +1621,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::LinkedList"
-                              "head",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::LinkedList",
+                              "head"
+                            |),
                             Value.StructTuple
                               "core::option::Option::Some"
                               [ M.read (| splice_start |) ]
@@ -1585,7 +1641,7 @@ Module collections.
                       ltac:(M.monadic
                         (let γ := existing_next in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1593,8 +1649,8 @@ Module collections.
                         let existing_next := M.copy (| γ0_0 |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -1607,9 +1663,10 @@ Module collections.
                                   []
                                 |),
                                 [ existing_next ]
-                              |))
-                              "alloc::collections::linked_list::Node"
-                              "prev",
+                              |),
+                              "alloc::collections::linked_list::Node",
+                              "prev"
+                            |),
                             Value.StructTuple
                               "core::option::Option::Some"
                               [ M.read (| splice_end |) ]
@@ -1619,10 +1676,11 @@ Module collections.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::LinkedList"
-                              "tail",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::LinkedList",
+                              "tail"
+                            |),
                             Value.StructTuple
                               "core::option::Option::Some"
                               [ M.read (| splice_end |) ]
@@ -1633,8 +1691,8 @@ Module collections.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
                             (Ty.path "core::ptr::non_null::NonNull")
@@ -1643,15 +1701,16 @@ Module collections.
                           []
                         |),
                         [ splice_start ]
-                      |))
-                      "alloc::collections::linked_list::Node"
-                      "prev",
+                      |),
+                      "alloc::collections::linked_list::Node",
+                      "prev"
+                    |),
                     M.read (| existing_prev |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
                             (Ty.path "core::ptr::non_null::NonNull")
@@ -1660,18 +1719,20 @@ Module collections.
                           []
                         |),
                         [ splice_end ]
-                      |))
-                      "alloc::collections::linked_list::Node"
-                      "next",
+                      |),
+                      "alloc::collections::linked_list::Node",
+                      "next"
+                    |),
                     M.read (| existing_next |)
                   |) in
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
+                    "len"
+                  |) in
                 M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| splice_length |) |) |) in
               M.alloc (| Value.Tuple [] |)
             |)))
@@ -1720,10 +1781,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::linked_list::LinkedList"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::linked_list::LinkedList",
                         "head"
+                      |)
                     ]
                   |)
                 |) in
@@ -1742,10 +1804,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::linked_list::LinkedList"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::linked_list::LinkedList",
                         "tail"
+                      |)
                     ]
                   |)
                 |) in
@@ -1754,10 +1817,11 @@ Module collections.
                   M.call_closure (|
                     M.get_function (| "core::mem::replace", [ Ty.path "usize" ] |),
                     [
-                      M.get_struct_record_field
-                        self
-                        "alloc::collections::linked_list::LinkedList"
-                        "len";
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::collections::linked_list::LinkedList",
+                        "len"
+                      |);
                       Value.Integer Integer.Usize 0
                     ]
                   |)
@@ -1769,7 +1833,7 @@ Module collections.
                     ltac:(M.monadic
                       (let γ := head in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1873,7 +1937,7 @@ Module collections.
                     ltac:(M.monadic
                       (let γ := split_node in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1902,8 +1966,8 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -1916,9 +1980,10 @@ Module collections.
                                       []
                                     |),
                                     [ split_node ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
+                                  |),
+                                  "alloc::collections::linked_list::Node",
                                   "prev"
+                                |)
                               ]
                             |)
                           |) in
@@ -1931,7 +1996,7 @@ Module collections.
                               ltac:(M.monadic
                                 (let γ := first_part_tail in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1940,8 +2005,8 @@ Module collections.
                                 let _ :=
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
                                               (Ty.path "core::ptr::non_null::NonNull")
@@ -1954,9 +2019,10 @@ Module collections.
                                             []
                                           |),
                                           [ tail ]
-                                        |))
-                                        "alloc::collections::linked_list::Node"
-                                        "next",
+                                        |),
+                                        "alloc::collections::linked_list::Node",
+                                        "next"
+                                      |),
                                       Value.StructTuple "core::option::Option::None" []
                                     |) in
                                   M.alloc (| Value.Tuple [] |) in
@@ -1964,10 +2030,11 @@ Module collections.
                                   M.write (|
                                     first_part_head,
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
                                         "head"
+                                      |)
                                     |)
                                   |) in
                                 M.alloc (| Value.Tuple [] |)));
@@ -1993,10 +2060,11 @@ Module collections.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "alloc"
+                                    |)
                                   ]
                                 |));
                               ("marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -2004,24 +2072,27 @@ Module collections.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |),
                           Value.StructTuple "core::option::Option::Some" [ M.read (| split_node |) ]
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "len",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "len"
+                          |),
                           BinOp.Panic.sub (|
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::LinkedList"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::LinkedList",
                                 "len"
+                              |)
                             |),
                             M.read (| at_ |)
                           |)
@@ -2053,10 +2124,11 @@ Module collections.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "alloc"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2134,7 +2206,7 @@ Module collections.
                     ltac:(M.monadic
                       (let γ := split_node in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2163,8 +2235,8 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -2177,9 +2249,10 @@ Module collections.
                                       []
                                     |),
                                     [ split_node ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
+                                  |),
+                                  "alloc::collections::linked_list::Node",
                                   "next"
+                                |)
                               ]
                             |)
                           |) in
@@ -2192,7 +2265,7 @@ Module collections.
                               ltac:(M.monadic
                                 (let γ := second_part_head in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2201,8 +2274,8 @@ Module collections.
                                 let _ :=
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
                                               (Ty.path "core::ptr::non_null::NonNull")
@@ -2215,9 +2288,10 @@ Module collections.
                                             []
                                           |),
                                           [ head ]
-                                        |))
-                                        "alloc::collections::linked_list::Node"
-                                        "prev",
+                                        |),
+                                        "alloc::collections::linked_list::Node",
+                                        "prev"
+                                      |),
                                       Value.StructTuple "core::option::Option::None" []
                                     |) in
                                   M.alloc (| Value.Tuple [] |) in
@@ -2225,10 +2299,11 @@ Module collections.
                                   M.write (|
                                     second_part_tail,
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::LinkedList"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::LinkedList",
                                         "tail"
+                                      |)
                                     |)
                                   |) in
                                 M.alloc (| Value.Tuple [] |)));
@@ -2252,10 +2327,11 @@ Module collections.
                               ("len",
                                 BinOp.Panic.sub (|
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "len"
+                                    |)
                                   |),
                                   M.read (| at_ |)
                                 |));
@@ -2263,10 +2339,11 @@ Module collections.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "alloc"
+                                    |)
                                   ]
                                 |));
                               ("marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -2274,18 +2351,20 @@ Module collections.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |),
                           Value.StructTuple "core::option::Option::Some" [ M.read (| split_node |) ]
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "len",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "len"
+                          |),
                           M.read (| at_ |)
                         |) in
                       second_part));
@@ -2315,10 +2394,11 @@ Module collections.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "alloc"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2378,24 +2458,27 @@ Module collections.
               [
                 ("head",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   |));
                 ("tail",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   |));
                 ("len",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "len"
+                    |)
                   |));
                 ("marker", Value.StructTuple "core::marker::PhantomData" [])
               ]))
@@ -2422,24 +2505,27 @@ Module collections.
               [
                 ("head",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   |));
                 ("tail",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   |));
                 ("len",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "len"
+                    |)
                   |));
                 ("marker", Value.StructTuple "core::marker::PhantomData" [])
               ]))
@@ -2467,10 +2553,11 @@ Module collections.
                 ("index", Value.Integer Integer.Usize 0);
                 ("current",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   |));
                 ("list", M.read (| self |))
               ]))
@@ -2498,10 +2585,11 @@ Module collections.
                 ("index", Value.Integer Integer.Usize 0);
                 ("current",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   |));
                 ("list", M.read (| self |))
               ]))
@@ -2538,10 +2626,11 @@ Module collections.
                         M.get_associated_function (| Ty.path "usize", "checked_sub", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::LinkedList"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::LinkedList",
                               "len"
+                            |)
                           |);
                           Value.Integer Integer.Usize 1
                         ]
@@ -2551,10 +2640,11 @@ Module collections.
                   |));
                 ("current",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   |));
                 ("list", M.read (| self |))
               ]))
@@ -2591,10 +2681,11 @@ Module collections.
                         M.get_associated_function (| Ty.path "usize", "checked_sub", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::LinkedList"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::LinkedList",
                               "len"
+                            |)
                           |);
                           Value.Integer Integer.Usize 1
                         ]
@@ -2604,10 +2695,11 @@ Module collections.
                   |));
                 ("current",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   |));
                 ("list", M.read (| self |))
               ]))
@@ -2642,10 +2734,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::linked_list::LinkedList"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::linked_list::LinkedList",
                   "head"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -2667,10 +2760,11 @@ Module collections.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::linked_list::LinkedList"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::linked_list::LinkedList",
                 "len"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2732,10 +2826,11 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::LinkedList"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::LinkedList",
                                   "head"
+                                |)
                               ]
                             |));
                           ("tail",
@@ -2756,27 +2851,30 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::LinkedList"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::LinkedList",
                                   "tail"
+                                |)
                               ]
                             |));
                           ("len",
                             M.call_closure (|
                               M.get_function (| "core::mem::take", [ Ty.path "usize" ] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::LinkedList"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::LinkedList",
                                   "len"
+                                |)
                               ]
                             |));
                           ("alloc",
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::LinkedList"
-                              "alloc");
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::LinkedList",
+                              "alloc"
+                            |));
                           ("marker", Value.StructTuple "core::marker::PhantomData" [])
                         ]
                     ]
@@ -2916,10 +3014,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   ]
                 |);
                 M.closure
@@ -2933,8 +3032,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let node := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -2947,9 +3046,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| node |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -3020,10 +3120,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "head"
+                    |)
                   ]
                 |);
                 M.closure
@@ -3037,8 +3138,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let node := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -3051,9 +3152,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| node |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -3124,10 +3226,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   ]
                 |);
                 M.closure
@@ -3141,8 +3244,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let node := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -3155,9 +3258,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| node |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -3228,10 +3332,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::LinkedList"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::LinkedList",
                       "tail"
+                    |)
                   ]
                 |);
                 M.closure
@@ -3245,8 +3350,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let node := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -3259,9 +3364,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| node |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -3315,10 +3421,11 @@ Module collections.
                         |),
                         [ M.read (| elt |) ]
                       |);
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::LinkedList"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::LinkedList",
                         "alloc"
+                      |)
                     ]
                   |)
                 |) in
@@ -3476,10 +3583,11 @@ Module collections.
                         |),
                         [ M.read (| elt |) ]
                       |);
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::LinkedList"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::LinkedList",
                         "alloc"
+                      |)
                     ]
                   |)
                 |) in
@@ -3746,10 +3854,11 @@ Module collections.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::linked_list::LinkedList"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::linked_list::LinkedList",
                                                   "alloc"
+                                                |)
                                               ]
                                             |)
                                           ]
@@ -3800,10 +3909,11 @@ Module collections.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::linked_list::LinkedList"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::linked_list::LinkedList",
                                                       "alloc"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -3922,7 +4032,7 @@ Module collections.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -3950,10 +4060,11 @@ Module collections.
                                           |)))
                                     ]
                                   |)) in
-                              M.get_struct_record_field
-                                iter
-                                "alloc::collections::linked_list::IterMut"
-                                "head"));
+                              M.SubPointer.get_struct_record_field (|
+                                iter,
+                                "alloc::collections::linked_list::IterMut",
+                                "head"
+                              |)));
                           fun γ =>
                             ltac:(M.monadic
                               (let iter :=
@@ -4036,7 +4147,7 @@ Module collections.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -4064,10 +4175,11 @@ Module collections.
                                           |)))
                                     ]
                                   |)) in
-                              M.get_struct_record_field
-                                iter
-                                "alloc::collections::linked_list::IterMut"
-                                "tail"))
+                              M.SubPointer.get_struct_record_field (|
+                                iter,
+                                "alloc::collections::linked_list::IterMut",
+                                "tail"
+                              |)))
                         ]
                       |)
                     |) in
@@ -4261,7 +4373,7 @@ Module collections.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -4376,7 +4488,7 @@ Module collections.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -4555,7 +4667,7 @@ Module collections.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -4672,17 +4784,19 @@ Module collections.
             M.read (|
               let it :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
                     "head"
+                  |)
                 |) in
               let old_len :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::LinkedList"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::LinkedList",
                     "len"
+                  |)
                 |) in
               M.alloc (|
                 Value.StructRecord
@@ -4803,10 +4917,11 @@ Module collections.
             let other := M.alloc (| other |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::linked_list::LinkedList"
-                  "tail",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::linked_list::LinkedList",
+                  "tail"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -4826,7 +4941,7 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -4856,15 +4971,16 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "alloc::collections::linked_list::LinkedList"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "alloc::collections::linked_list::LinkedList",
                                         "head"
+                                      |)
                                     ]
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -4873,8 +4989,8 @@ Module collections.
                               let _ :=
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -4887,17 +5003,18 @@ Module collections.
                                           []
                                         |),
                                         [ tail ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "next",
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "next"
+                                    |),
                                     Value.StructTuple
                                       "core::option::Option::Some"
                                       [ M.read (| other_head |) ]
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -4910,9 +5027,10 @@ Module collections.
                                           []
                                         |),
                                         [ other_head ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "prev",
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "prev"
+                                    |),
                                     Value.StructTuple
                                       "core::option::Option::Some"
                                       [ M.read (| tail |) ]
@@ -4920,10 +5038,11 @@ Module collections.
                                 M.alloc (| Value.Tuple [] |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::LinkedList"
-                                    "tail",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::LinkedList",
+                                    "tail"
+                                  |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
@@ -4941,19 +5060,21 @@ Module collections.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "alloc::collections::linked_list::LinkedList"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "alloc::collections::linked_list::LinkedList",
                                         "tail"
+                                      |)
                                     ]
                                   |)
                                 |) in
                               let _ :=
                                 let β :=
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::LinkedList"
-                                    "len" in
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::LinkedList",
+                                    "len"
+                                  |) in
                                 M.write (|
                                   β,
                                   BinOp.Panic.add (|
@@ -4964,10 +5085,11 @@ Module collections.
                                         [ Ty.path "usize" ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| other |))
-                                          "alloc::collections::linked_list::LinkedList"
-                                          "len";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| other |),
+                                          "alloc::collections::linked_list::LinkedList",
+                                          "len"
+                                        |);
                                         Value.Integer Integer.Usize 0
                                       ]
                                     |)
@@ -5065,10 +5187,11 @@ Module collections.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_tuple_field
-                                                guard
-                                                "alloc::collections::linked_list::drop::DropGuard"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                guard,
+                                                "alloc::collections::linked_list::drop::DropGuard",
                                                 0
+                                              |)
                                             |)
                                           ]
                                         |)
@@ -5160,10 +5283,11 @@ Module collections.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::Iter",
                                   "len"
+                                |)
                               |))
                               (Value.Integer Integer.Usize 0)
                           |)) in
@@ -5203,10 +5327,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::Iter",
                                 "head"
+                              |)
                             |);
                             M.closure
                               (fun γ =>
@@ -5240,10 +5365,11 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 let β :=
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::Iter"
-                                                    "len" in
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::Iter",
+                                                    "len"
+                                                  |) in
                                                 M.write (|
                                                   β,
                                                   BinOp.Panic.sub (|
@@ -5253,22 +5379,25 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::Iter"
-                                                    "head",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::Iter",
+                                                    "head"
+                                                  |),
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| node |))
-                                                      "alloc::collections::linked_list::Node"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| node |),
+                                                      "alloc::collections::linked_list::Node",
                                                       "next"
+                                                    |)
                                                   |)
                                                 |) in
                                               M.alloc (|
-                                                M.get_struct_record_field
-                                                  (M.read (| node |))
-                                                  "alloc::collections::linked_list::Node"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| node |),
+                                                  "alloc::collections::linked_list::Node",
                                                   "element"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -5298,19 +5427,21 @@ Module collections.
             Value.Tuple
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::Iter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::Iter",
                     "len"
+                  |)
                 |);
                 Value.StructTuple
                   "core::option::Option::Some"
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::Iter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::Iter",
                         "len"
+                      |)
                     |)
                   ]
               ]))
@@ -5392,10 +5523,11 @@ Module collections.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::Iter",
                                   "len"
+                                |)
                               |))
                               (Value.Integer Integer.Usize 0)
                           |)) in
@@ -5435,10 +5567,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::Iter",
                                 "tail"
+                              |)
                             |);
                             M.closure
                               (fun γ =>
@@ -5472,10 +5605,11 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 let β :=
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::Iter"
-                                                    "len" in
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::Iter",
+                                                    "len"
+                                                  |) in
                                                 M.write (|
                                                   β,
                                                   BinOp.Panic.sub (|
@@ -5485,22 +5619,25 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::Iter"
-                                                    "tail",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::Iter",
+                                                    "tail"
+                                                  |),
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| node |))
-                                                      "alloc::collections::linked_list::Node"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| node |),
+                                                      "alloc::collections::linked_list::Node",
                                                       "prev"
+                                                    |)
                                                   |)
                                                 |) in
                                               M.alloc (|
-                                                M.get_struct_record_field
-                                                  (M.read (| node |))
-                                                  "alloc::collections::linked_list::Node"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| node |),
+                                                  "alloc::collections::linked_list::Node",
                                                   "element"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -5640,10 +5777,11 @@ Module collections.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::IterMut",
                                   "len"
+                                |)
                               |))
                               (Value.Integer Integer.Usize 0)
                           |)) in
@@ -5683,10 +5821,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::IterMut",
                                 "head"
+                              |)
                             |);
                             M.closure
                               (fun γ =>
@@ -5720,10 +5859,11 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 let β :=
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::IterMut"
-                                                    "len" in
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::IterMut",
+                                                    "len"
+                                                  |) in
                                                 M.write (|
                                                   β,
                                                   BinOp.Panic.sub (|
@@ -5733,22 +5873,25 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::IterMut"
-                                                    "head",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::IterMut",
+                                                    "head"
+                                                  |),
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| node |))
-                                                      "alloc::collections::linked_list::Node"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| node |),
+                                                      "alloc::collections::linked_list::Node",
                                                       "next"
+                                                    |)
                                                   |)
                                                 |) in
                                               M.alloc (|
-                                                M.get_struct_record_field
-                                                  (M.read (| node |))
-                                                  "alloc::collections::linked_list::Node"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| node |),
+                                                  "alloc::collections::linked_list::Node",
                                                   "element"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -5778,19 +5921,21 @@ Module collections.
             Value.Tuple
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::IterMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::IterMut",
                     "len"
+                  |)
                 |);
                 Value.StructTuple
                   "core::option::Option::Some"
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::IterMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::IterMut",
                         "len"
+                      |)
                     |)
                   ]
               ]))
@@ -5872,10 +6017,11 @@ Module collections.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::IterMut",
                                   "len"
+                                |)
                               |))
                               (Value.Integer Integer.Usize 0)
                           |)) in
@@ -5915,10 +6061,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::IterMut",
                                 "tail"
+                              |)
                             |);
                             M.closure
                               (fun γ =>
@@ -5952,10 +6099,11 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 let β :=
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::IterMut"
-                                                    "len" in
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::IterMut",
+                                                    "len"
+                                                  |) in
                                                 M.write (|
                                                   β,
                                                   BinOp.Panic.sub (|
@@ -5965,22 +6113,25 @@ Module collections.
                                                 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::IterMut"
-                                                    "tail",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::IterMut",
+                                                    "tail"
+                                                  |),
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| node |))
-                                                      "alloc::collections::linked_list::Node"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| node |),
+                                                      "alloc::collections::linked_list::Node",
                                                       "prev"
+                                                    |)
                                                   |)
                                                 |) in
                                               M.alloc (|
-                                                M.get_struct_record_field
-                                                  (M.read (| node |))
-                                                  "alloc::collections::linked_list::Node"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| node |),
+                                                  "alloc::collections::linked_list::Node",
                                                   "element"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -6126,19 +6277,19 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "alloc::collections::linked_list::Cursor",
                           "index"
                         |) in
                       let γ0_1 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "alloc::collections::linked_list::Cursor",
                           "current"
                         |) in
                       let γ0_2 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "alloc::collections::linked_list::Cursor",
                           "list"
@@ -6219,10 +6370,11 @@ Module collections.
                         |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "list")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "list"
+                          |))
                       ]
                     |);
                     (* Unsize *)
@@ -6324,10 +6476,11 @@ Module collections.
                         |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "list")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "list"
+                          |))
                       ]
                     |);
                     (* Unsize *)
@@ -6399,10 +6552,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::Cursor"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::Cursor",
                                 "current"
+                              |)
                             |)
                           ]
                         |)
@@ -6411,7 +6565,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -6444,7 +6598,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -6461,10 +6615,11 @@ Module collections.
                               "core::option::Option::Some"
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::Cursor"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::Cursor",
                                     "index"
+                                  |)
                                 |)
                               ]
                           |)))
@@ -6518,10 +6673,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::Cursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::Cursor",
                         "current"
+                      |)
                     ]
                   |)
                 |),
@@ -6530,35 +6686,39 @@ Module collections.
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::Cursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::Cursor",
                                   "list"
-                              |))
-                              "alloc::collections::linked_list::LinkedList"
+                                |)
+                              |),
+                              "alloc::collections::linked_list::LinkedList",
                               "head"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "index"
+                          |),
                           Value.Integer Integer.Usize 0
                         |) in
                       M.alloc (| Value.Tuple [] |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -6566,13 +6726,14 @@ Module collections.
                       let current := M.copy (| γ0_0 |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -6585,17 +6746,19 @@ Module collections.
                                   []
                                 |),
                                 [ current ]
-                              |))
-                              "alloc::collections::linked_list::Node"
+                              |),
+                              "alloc::collections::linked_list::Node",
                               "next"
+                            |)
                           |)
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "index" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "index"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -6649,10 +6812,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::Cursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::Cursor",
                         "current"
+                      |)
                     ]
                   |)
                 |),
@@ -6661,28 +6825,32 @@ Module collections.
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::Cursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::Cursor",
                                   "list"
-                              |))
-                              "alloc::collections::linked_list::LinkedList"
+                                |)
+                              |),
+                              "alloc::collections::linked_list::LinkedList",
                               "tail"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "index"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::option::Option") [ Ty.path "usize" ],
@@ -6703,10 +6871,11 @@ Module collections.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::linked_list::Cursor"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::linked_list::Cursor",
                                           "list"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -6721,7 +6890,7 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -6729,13 +6898,14 @@ Module collections.
                       let current := M.copy (| γ0_0 |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -6748,17 +6918,19 @@ Module collections.
                                   []
                                 |),
                                 [ current ]
-                              |))
-                              "alloc::collections::linked_list::Node"
+                              |),
+                              "alloc::collections::linked_list::Node",
                               "prev"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::Cursor"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::Cursor",
+                            "index"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::option::Option") [ Ty.path "usize" ],
@@ -6770,10 +6942,11 @@ Module collections.
                                 M.get_associated_function (| Ty.path "usize", "checked_sub", [] |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::Cursor"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::Cursor",
                                       "index"
+                                    |)
                                   |);
                                   Value.Integer Integer.Usize 1
                                 ]
@@ -6799,10 +6972,11 @@ Module collections.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::linked_list::Cursor"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::linked_list::Cursor",
                                                       "list"
+                                                    |)
                                                   |)
                                                 ]
                                               |)))
@@ -6861,10 +7035,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::Cursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::Cursor",
                     "current"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -6877,8 +7052,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let current := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -6891,9 +7066,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| current |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -6928,33 +7104,36 @@ Module collections.
               let next :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::Cursor"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::Cursor",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::Cursor"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::Cursor",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let current := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -6964,9 +7143,10 @@ Module collections.
                                 []
                               |),
                               [ current ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "next"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "next"
+                          |)))
                     ]
                   |)
                 |) in
@@ -7008,8 +7188,8 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let next := M.copy (| γ |) in
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -7022,9 +7202,10 @@ Module collections.
                                           []
                                         |),
                                         [ M.read (| next |) ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "element"))
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "element"
+                                    |)))
                               ]
                             |)
                           | _ => M.impossible (||)
@@ -7061,33 +7242,36 @@ Module collections.
               let prev :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::Cursor"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::Cursor",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::Cursor"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::Cursor",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let current := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -7097,9 +7281,10 @@ Module collections.
                                 []
                               |),
                               [ current ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "prev"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "prev"
+                          |)))
                     ]
                   |)
                 |) in
@@ -7141,8 +7326,8 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let prev := M.copy (| γ |) in
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -7155,9 +7340,10 @@ Module collections.
                                           []
                                         |),
                                         [ M.read (| prev |) ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "element"))
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "element"
+                                    |)))
                               ]
                             |)
                           | _ => M.impossible (||)
@@ -7192,10 +7378,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::Cursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::Cursor",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -7225,10 +7412,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::Cursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::Cursor",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -7279,10 +7467,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "current"
+                              |)
                             |)
                           ]
                         |)
@@ -7291,7 +7480,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -7324,7 +7513,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -7341,10 +7530,11 @@ Module collections.
                               "core::option::Option::Some"
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "index"
+                                  |)
                                 |)
                               ]
                           |)))
@@ -7398,10 +7588,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "current"
+                      |)
                     ]
                   |)
                 |),
@@ -7410,35 +7601,39 @@ Module collections.
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "list"
-                              |))
-                              "alloc::collections::linked_list::LinkedList"
+                                |)
+                              |),
+                              "alloc::collections::linked_list::LinkedList",
                               "head"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |),
                           Value.Integer Integer.Usize 0
                         |) in
                       M.alloc (| Value.Tuple [] |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7446,13 +7641,14 @@ Module collections.
                       let current := M.copy (| γ0_0 |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -7465,17 +7661,19 @@ Module collections.
                                   []
                                 |),
                                 [ current ]
-                              |))
-                              "alloc::collections::linked_list::Node"
+                              |),
+                              "alloc::collections::linked_list::Node",
                               "next"
+                            |)
                           |)
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -7529,10 +7727,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "current"
+                      |)
                     ]
                   |)
                 |),
@@ -7541,28 +7740,32 @@ Module collections.
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "list"
-                              |))
-                              "alloc::collections::linked_list::LinkedList"
+                                |)
+                              |),
+                              "alloc::collections::linked_list::LinkedList",
                               "tail"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::option::Option") [ Ty.path "usize" ],
@@ -7583,10 +7786,11 @@ Module collections.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::linked_list::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::linked_list::CursorMut",
                                           "list"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -7601,7 +7805,7 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7609,13 +7813,14 @@ Module collections.
                       let current := M.copy (| γ0_0 |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "current",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "current"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
                                     (Ty.path "core::ptr::non_null::NonNull")
@@ -7628,17 +7833,19 @@ Module collections.
                                   []
                                 |),
                                 [ current ]
-                              |))
-                              "alloc::collections::linked_list::Node"
+                              |),
+                              "alloc::collections::linked_list::Node",
                               "prev"
+                            |)
                           |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::option::Option") [ Ty.path "usize" ],
@@ -7650,10 +7857,11 @@ Module collections.
                                 M.get_associated_function (| Ty.path "usize", "checked_sub", [] |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "index"
+                                    |)
                                   |);
                                   Value.Integer Integer.Usize 1
                                 ]
@@ -7679,10 +7887,11 @@ Module collections.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::linked_list::CursorMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::linked_list::CursorMut",
                                                       "list"
+                                                    |)
                                                   |)
                                                 ]
                                               |)))
@@ -7741,10 +7950,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "current"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -7757,8 +7967,8 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let current := M.copy (| γ |) in
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
                                         (Ty.path "core::ptr::non_null::NonNull")
@@ -7771,9 +7981,10 @@ Module collections.
                                       []
                                     |),
                                     [ M.read (| current |) ]
-                                  |))
-                                  "alloc::collections::linked_list::Node"
-                                  "element"))
+                                  |),
+                                  "alloc::collections::linked_list::Node",
+                                  "element"
+                                |)))
                           ]
                         |)
                       | _ => M.impossible (||)
@@ -7808,33 +8019,36 @@ Module collections.
               let next :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let current := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -7844,9 +8058,10 @@ Module collections.
                                 []
                               |),
                               [ current ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "next"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "next"
+                          |)))
                     ]
                   |)
                 |) in
@@ -7888,8 +8103,8 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let next := M.copy (| γ |) in
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -7902,9 +8117,10 @@ Module collections.
                                           []
                                         |),
                                         [ M.read (| next |) ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "element"))
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "element"
+                                    |)))
                               ]
                             |)
                           | _ => M.impossible (||)
@@ -7941,33 +8157,36 @@ Module collections.
               let prev :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let current := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -7977,9 +8196,10 @@ Module collections.
                                 []
                               |),
                               [ current ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "prev"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "prev"
+                          |)))
                     ]
                   |)
                 |) in
@@ -8021,8 +8241,8 @@ Module collections.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let prev := M.copy (| γ |) in
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
                                             (Ty.path "core::ptr::non_null::NonNull")
@@ -8035,9 +8255,10 @@ Module collections.
                                           []
                                         |),
                                         [ M.read (| prev |) ]
-                                      |))
-                                      "alloc::collections::linked_list::Node"
-                                      "element"))
+                                      |),
+                                      "alloc::collections::linked_list::Node",
+                                      "element"
+                                    |)))
                               ]
                             |)
                           | _ => M.impossible (||)
@@ -8069,24 +8290,27 @@ Module collections.
               [
                 ("list",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
                       "list"
+                    |)
                   |));
                 ("current",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
                       "current"
+                    |)
                   |));
                 ("index",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
                       "index"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -8168,15 +8392,17 @@ Module collections.
                                 |),
                                 [ M.read (| item |) ]
                               |);
-                              M.get_struct_record_field
-                                (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "list"
-                                |))
-                                "alloc::collections::linked_list::LinkedList"
+                                  |)
+                                |),
+                                "alloc::collections::linked_list::LinkedList",
                                 "alloc"
+                              |)
                             ]
                           |)
                         ]
@@ -8187,33 +8413,36 @@ Module collections.
               let node_next :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "head"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "head"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let node := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -8223,9 +8452,10 @@ Module collections.
                                 []
                               |),
                               [ node ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "next"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "next"
+                          |)))
                     ]
                   |)
                 |) in
@@ -8239,16 +8469,18 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "list"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "current"
+                        |)
                       |);
                       M.read (| node_next |);
                       M.read (| spliced_node |);
@@ -8282,30 +8514,34 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "current"
+                                |)
                               ]
                             |)
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "list"
-                              |))
-                              "alloc::collections::linked_list::LinkedList"
+                                |)
+                              |),
+                              "alloc::collections::linked_list::LinkedList",
                               "len"
+                            |)
                           |)
                         |) in
                       M.alloc (| Value.Tuple [] |)));
@@ -8390,15 +8626,17 @@ Module collections.
                                 |),
                                 [ M.read (| item |) ]
                               |);
-                              M.get_struct_record_field
-                                (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "list"
-                                |))
-                                "alloc::collections::linked_list::LinkedList"
+                                  |)
+                                |),
+                                "alloc::collections::linked_list::LinkedList",
                                 "alloc"
+                              |)
                             ]
                           |)
                         ]
@@ -8409,33 +8647,36 @@ Module collections.
               let node_prev :=
                 M.copy (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::CursorMut"
-                      "current",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::CursorMut",
+                      "current"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
-                            |))
-                            "alloc::collections::linked_list::LinkedList"
-                            "tail"));
+                              |)
+                            |),
+                            "alloc::collections::linked_list::LinkedList",
+                            "tail"
+                          |)));
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
                           let node := M.copy (| γ0_0 |) in
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
                                   (Ty.path "core::ptr::non_null::NonNull")
@@ -8445,9 +8686,10 @@ Module collections.
                                 []
                               |),
                               [ node ]
-                            |))
-                            "alloc::collections::linked_list::Node"
-                            "prev"))
+                            |),
+                            "alloc::collections::linked_list::Node",
+                            "prev"
+                          |)))
                     ]
                   |)
                 |) in
@@ -8461,17 +8703,19 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "list"
+                        |)
                       |);
                       M.read (| node_prev |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "current"
+                        |)
                       |);
                       M.read (| spliced_node |);
                       M.read (| spliced_node |);
@@ -8481,10 +8725,11 @@ Module collections.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
-                    "index" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
+                    "index"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -8542,10 +8787,11 @@ Module collections.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "current"
+                                |)
                               |)
                             ]
                           |)
@@ -8554,7 +8800,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -8585,7 +8831,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -8597,13 +8843,14 @@ Module collections.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
-                        "current",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
+                        "current"
+                      |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
                                 (Ty.path "core::ptr::non_null::NonNull")
@@ -8613,9 +8860,10 @@ Module collections.
                               []
                             |),
                             [ unlinked_node ]
-                          |))
-                          "alloc::collections::linked_list::Node"
+                          |),
+                          "alloc::collections::linked_list::Node",
                           "next"
+                        |)
                       |)
                     |) in
                   let _ :=
@@ -8628,10 +8876,11 @@ Module collections.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::CursorMut",
                               "list"
+                            |)
                           |);
                           M.read (| unlinked_node |)
                         ]
@@ -8670,10 +8919,11 @@ Module collections.
                       "core::option::Option::Some"
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| unlinked_node |))
-                            "alloc::collections::linked_list::Node"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| unlinked_node |),
+                            "alloc::collections::linked_list::Node",
                             "element"
+                          |)
                         |)
                       ]
                   |)
@@ -8741,10 +8991,11 @@ Module collections.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "current"
+                                |)
                               |)
                             ]
                           |)
@@ -8753,7 +9004,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -8791,7 +9042,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -8803,13 +9054,14 @@ Module collections.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
-                        "current",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
+                        "current"
+                      |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
                                 (Ty.path "core::ptr::non_null::NonNull")
@@ -8819,9 +9071,10 @@ Module collections.
                               []
                             |),
                             [ unlinked_node ]
-                          |))
-                          "alloc::collections::linked_list::Node"
+                          |),
+                          "alloc::collections::linked_list::Node",
                           "next"
+                        |)
                       |)
                     |) in
                   let _ :=
@@ -8834,10 +9087,11 @@ Module collections.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::CursorMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::CursorMut",
                               "list"
+                            |)
                           |);
                           M.read (| unlinked_node |)
                         ]
@@ -8845,8 +9099,8 @@ Module collections.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
                               (Ty.path "core::ptr::non_null::NonNull")
@@ -8855,15 +9109,16 @@ Module collections.
                             []
                           |),
                           [ unlinked_node ]
-                        |))
-                        "alloc::collections::linked_list::Node"
-                        "prev",
+                        |),
+                        "alloc::collections::linked_list::Node",
+                        "prev"
+                      |),
                       Value.StructTuple "core::option::Option::None" []
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_associated_function (|
                             Ty.apply
                               (Ty.path "core::ptr::non_null::NonNull")
@@ -8872,9 +9127,10 @@ Module collections.
                             []
                           |),
                           [ unlinked_node ]
-                        |))
-                        "alloc::collections::linked_list::Node"
-                        "next",
+                        |),
+                        "alloc::collections::linked_list::Node",
+                        "next"
+                      |),
                       Value.StructTuple "core::option::Option::None" []
                     |) in
                   M.alloc (|
@@ -8897,15 +9153,17 @@ Module collections.
                               M.call_closure (|
                                 M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::CursorMut",
                                         "list"
-                                    |))
-                                    "alloc::collections::linked_list::LinkedList"
+                                      |)
+                                    |),
+                                    "alloc::collections::linked_list::LinkedList",
                                     "alloc"
+                                  |)
                                 ]
                               |));
                             ("marker", Value.StructTuple "core::marker::PhantomData" [])
@@ -8953,21 +9211,24 @@ Module collections.
                               (M.alloc (|
                                 BinOp.Pure.eq
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "index"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::linked_list::CursorMut",
                                           "list"
-                                      |))
-                                      "alloc::collections::linked_list::LinkedList"
+                                        |)
+                                      |),
+                                      "alloc::collections::linked_list::LinkedList",
                                       "len"
+                                    |)
                                   |))
                               |)) in
                           let _ :=
@@ -8978,10 +9239,11 @@ Module collections.
                           (M.alloc (|
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
                                   "index"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -9000,31 +9262,35 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "index"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::CursorMut",
                                         "list"
-                                    |))
-                                    "alloc::collections::linked_list::LinkedList"
+                                      |)
+                                    |),
+                                    "alloc::collections::linked_list::LinkedList",
                                     "len"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::linked_list::CursorMut"
-                              "index",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::linked_list::CursorMut",
+                              "index"
+                            |),
                             Value.Integer Integer.Usize 0
                           |) in
                         M.alloc (| Value.Tuple [] |)));
@@ -9040,16 +9306,18 @@ Module collections.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "list"
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "current"
+                      |)
                     |);
                     M.read (| split_off_idx |)
                   ]
@@ -9082,17 +9350,19 @@ Module collections.
             M.read (|
               let split_off_idx :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "index"
+                  |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
-                    "index",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
+                    "index"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               M.alloc (|
@@ -9104,16 +9374,18 @@ Module collections.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "list"
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::CursorMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::CursorMut",
                         "current"
+                      |)
                     |);
                     M.read (| split_off_idx |)
                   ]
@@ -9154,10 +9426,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "list"
+                        |)
                       |);
                       M.read (| elt |)
                     ]
@@ -9165,10 +9438,11 @@ Module collections.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
-                    "index" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
+                    "index"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9213,10 +9487,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::CursorMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::CursorMut",
                           "list"
+                        |)
                       |);
                       M.read (| elt |)
                     ]
@@ -9257,10 +9532,11 @@ Module collections.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::CursorMut"
-                            "index" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::CursorMut",
+                            "index"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9323,10 +9599,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "list"
+                                  |)
                                 |)
                               ]
                             |)
@@ -9377,19 +9654,22 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::linked_list::CursorMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::linked_list::CursorMut",
                                                 "list"
-                                            |))
-                                            "alloc::collections::linked_list::LinkedList"
-                                            "head";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::CursorMut"
+                                              |)
+                                            |),
+                                            "alloc::collections::linked_list::LinkedList",
+                                            "head"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::CursorMut",
                                             "current"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -9416,10 +9696,11 @@ Module collections.
                               ltac:(M.monadic
                                 (let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
-                                      "index" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
+                                      "index"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.sub (|
@@ -9441,10 +9722,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
+                              |)
                             |)
                           ]
                         |)
@@ -9501,10 +9783,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::CursorMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::CursorMut",
                                     "list"
+                                  |)
                                 |)
                               ]
                             |)
@@ -9555,19 +9838,22 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::linked_list::CursorMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::linked_list::CursorMut",
                                                 "list"
-                                            |))
-                                            "alloc::collections::linked_list::LinkedList"
-                                            "tail";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::CursorMut"
+                                              |)
+                                            |),
+                                            "alloc::collections::linked_list::LinkedList",
+                                            "tail"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::CursorMut",
                                             "current"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -9578,10 +9864,11 @@ Module collections.
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
-                                      "current",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
+                                      "current"
+                                    |),
                                     Value.StructTuple "core::option::Option::None" []
                                   |) in
                                 M.alloc (| Value.Tuple [] |)));
@@ -9613,10 +9900,11 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::CursorMut"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::CursorMut",
                                                     "current"
+                                                  |)
                                                 ]
                                               |)
                                             |)) in
@@ -9627,21 +9915,24 @@ Module collections.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::CursorMut"
-                                              "index",
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::CursorMut",
+                                              "index"
+                                            |),
                                             BinOp.Panic.sub (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::linked_list::CursorMut"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::linked_list::CursorMut",
                                                       "list"
-                                                  |))
-                                                  "alloc::collections::linked_list::LinkedList"
+                                                    |)
+                                                  |),
+                                                  "alloc::collections::linked_list::LinkedList",
                                                   "len"
+                                                |)
                                               |),
                                               Value.Integer Integer.Usize 1
                                             |)
@@ -9663,10 +9954,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
                                 "list"
+                              |)
                             |)
                           ]
                         |)
@@ -9700,10 +9992,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -9733,10 +10026,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -9766,10 +10060,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -9799,10 +10094,11 @@ Module collections.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::linked_list::CursorMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::linked_list::CursorMut",
                     "list"
+                  |)
                 |)
               ]
             |)))
@@ -9867,7 +10163,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -9884,42 +10180,45 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let splice_head := M.copy (| γ0_0 |) in
                           let splice_tail := M.copy (| γ0_1 |) in
                           let splice_len := M.copy (| γ0_2 |) in
                           let node_next :=
                             M.copy (|
                               M.match_operator (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
-                                  "current",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
+                                  "current"
+                                |),
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (M.get_struct_record_field
-                                        (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::CursorMut"
+                                      (M.SubPointer.get_struct_record_field (|
+                                        M.read (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::CursorMut",
                                             "list"
-                                        |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "head"));
+                                          |)
+                                        |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "head"
+                                      |)));
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let node := M.copy (| γ0_0 |) in
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
                                               (Ty.path "core::ptr::non_null::NonNull")
@@ -9932,9 +10231,10 @@ Module collections.
                                             []
                                           |),
                                           [ node ]
-                                        |))
-                                        "alloc::collections::linked_list::Node"
-                                        "next"))
+                                        |),
+                                        "alloc::collections::linked_list::Node",
+                                        "next"
+                                      |)))
                                 ]
                               |)
                             |) in
@@ -9950,16 +10250,18 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "list"
+                                    |)
                                   |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "current"
+                                    |)
                                   |);
                                   M.read (| node_next |);
                                   M.read (| splice_head |);
@@ -9994,10 +10296,11 @@ Module collections.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::CursorMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::CursorMut",
                                               "current"
+                                            |)
                                           ]
                                         |)
                                       |)) in
@@ -10008,20 +10311,23 @@ Module collections.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::linked_list::CursorMut"
-                                        "index",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::linked_list::CursorMut",
+                                        "index"
+                                      |),
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::linked_list::CursorMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::linked_list::CursorMut",
                                               "list"
-                                          |))
-                                          "alloc::collections::linked_list::LinkedList"
+                                            |)
+                                          |),
+                                          "alloc::collections::linked_list::LinkedList",
                                           "len"
+                                        |)
                                       |)
                                     |) in
                                   M.alloc (| Value.Tuple [] |)));
@@ -10083,7 +10389,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -10100,42 +10406,45 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let splice_head := M.copy (| γ0_0 |) in
                           let splice_tail := M.copy (| γ0_1 |) in
                           let splice_len := M.copy (| γ0_2 |) in
                           let node_prev :=
                             M.copy (|
                               M.match_operator (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::linked_list::CursorMut"
-                                  "current",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::linked_list::CursorMut",
+                                  "current"
+                                |),
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (M.get_struct_record_field
-                                        (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::linked_list::CursorMut"
+                                      (M.SubPointer.get_struct_record_field (|
+                                        M.read (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::linked_list::CursorMut",
                                             "list"
-                                        |))
-                                        "alloc::collections::linked_list::LinkedList"
-                                        "tail"));
+                                          |)
+                                        |),
+                                        "alloc::collections::linked_list::LinkedList",
+                                        "tail"
+                                      |)));
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let node := M.copy (| γ0_0 |) in
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
                                               (Ty.path "core::ptr::non_null::NonNull")
@@ -10148,9 +10457,10 @@ Module collections.
                                             []
                                           |),
                                           [ node ]
-                                        |))
-                                        "alloc::collections::linked_list::Node"
-                                        "prev"))
+                                        |),
+                                        "alloc::collections::linked_list::Node",
+                                        "prev"
+                                      |)))
                                 ]
                               |)
                             |) in
@@ -10166,17 +10476,19 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "list"
+                                    |)
                                   |);
                                   M.read (| node_prev |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::CursorMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::CursorMut",
                                       "current"
+                                    |)
                                   |);
                                   M.read (| splice_head |);
                                   M.read (| splice_tail |);
@@ -10186,10 +10498,11 @@ Module collections.
                             |) in
                           let _ :=
                             let β :=
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::linked_list::CursorMut"
-                                "index" in
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::linked_list::CursorMut",
+                                "index"
+                              |) in
                             M.write (|
                               β,
                               BinOp.Panic.add (| M.read (| β |), M.read (| splice_len |) |)
@@ -10275,12 +10588,13 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ :=
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::linked_list::ExtractIf"
-                                    "it" in
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::linked_list::ExtractIf",
+                                    "it"
+                                  |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -10288,13 +10602,14 @@ Module collections.
                                 let node := M.copy (| γ0_0 |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::ExtractIf"
-                                      "it",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::ExtractIf",
+                                      "it"
+                                    |),
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
                                               (Ty.path "core::ptr::non_null::NonNull")
@@ -10307,17 +10622,19 @@ Module collections.
                                             []
                                           |),
                                           [ node ]
-                                        |))
-                                        "alloc::collections::linked_list::Node"
+                                        |),
+                                        "alloc::collections::linked_list::Node",
                                         "next"
+                                      |)
                                     |)
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::linked_list::ExtractIf"
-                                      "idx" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::linked_list::ExtractIf",
+                                      "idx"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -10342,14 +10659,15 @@ Module collections.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::linked_list::ExtractIf"
-                                                    "pred";
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::linked_list::ExtractIf",
+                                                    "pred"
+                                                  |);
                                                   Value.Tuple
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.call_closure (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.call_closure (|
                                                           M.get_associated_function (|
                                                             Ty.apply
                                                               (Ty.path
@@ -10364,9 +10682,10 @@ Module collections.
                                                             []
                                                           |),
                                                           [ node ]
-                                                        |))
-                                                        "alloc::collections::linked_list::Node"
+                                                        |),
+                                                        "alloc::collections::linked_list::Node",
                                                         "element"
+                                                      |)
                                                     ]
                                                 ]
                                               |)
@@ -10392,10 +10711,11 @@ Module collections.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::linked_list::ExtractIf"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::linked_list::ExtractIf",
                                                           "list"
+                                                        |)
                                                       |);
                                                       M.read (| node |)
                                                     ]
@@ -10406,8 +10726,8 @@ Module collections.
                                                   "core::option::Option::Some"
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.call_closure (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.call_closure (|
                                                           M.get_associated_function (|
                                                             Ty.apply
                                                               (Ty.path "alloc::boxed::Box")
@@ -10439,9 +10759,10 @@ Module collections.
                                                               [ M.read (| node |) ]
                                                             |)
                                                           ]
-                                                        |))
-                                                        "alloc::collections::linked_list::Node"
+                                                        |),
+                                                        "alloc::collections::linked_list::Node",
                                                         "element"
+                                                      |)
                                                     |)
                                                   ]
                                               |)
@@ -10492,16 +10813,18 @@ Module collections.
                   [
                     BinOp.Panic.sub (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::ExtractIf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::ExtractIf",
                           "old_len"
+                        |)
                       |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::ExtractIf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::ExtractIf",
                           "idx"
+                        |)
                       |)
                     |)
                   ]
@@ -10567,10 +10890,11 @@ Module collections.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::linked_list::ExtractIf"
-                        "list")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::linked_list::ExtractIf",
+                        "list"
+                      |))
                   ]
                 |)
               ]
@@ -10612,10 +10936,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::linked_list::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::linked_list::IntoIter",
                   "list"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -10635,25 +10960,29 @@ Module collections.
             Value.Tuple
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::linked_list::IntoIter"
-                      "list")
-                    "alloc::collections::linked_list::LinkedList"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::linked_list::IntoIter",
+                      "list"
+                    |),
+                    "alloc::collections::linked_list::LinkedList",
                     "len"
+                  |)
                 |);
                 Value.StructTuple
                   "core::option::Option::Some"
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::linked_list::IntoIter"
-                          "list")
-                        "alloc::collections::linked_list::LinkedList"
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::linked_list::IntoIter",
+                          "list"
+                        |),
+                        "alloc::collections::linked_list::LinkedList",
                         "len"
+                      |)
                     |)
                   ]
               ]))
@@ -10696,10 +11025,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::linked_list::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::linked_list::IntoIter",
                   "list"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -11603,10 +11933,11 @@ Module collections.
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::linked_list::LinkedList"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::linked_list::LinkedList",
                             "alloc"
+                          |)
                         ]
                       |)
                     ]
@@ -11844,13 +12175,13 @@ Module collections.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let elem := M.copy (| γ1_0 |) in
                                         let elem_other := M.copy (| γ1_1 |) in
                                         let _ :=
@@ -12098,7 +12429,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0

--- a/CoqOfRust/alloc/collections/mod.v
+++ b/CoqOfRust/alloc/collections/mod.v
@@ -31,10 +31,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::TryReserveError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::TryReserveError",
                       "kind"
+                    |)
                   ]
                 |))
             ]))
@@ -79,14 +80,16 @@ Module collections.
               []
             |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::TryReserveError"
-                "kind";
-              M.get_struct_record_field
-                (M.read (| other |))
-                "alloc::collections::TryReserveError"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::TryReserveError",
                 "kind"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "alloc::collections::TryReserveError",
+                "kind"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -161,10 +164,11 @@ Module collections.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::TryReserveError"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::TryReserveError",
                     "kind"
+                  |)
                 |))
             ]
           |)))
@@ -201,10 +205,11 @@ Module collections.
               []
             |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::TryReserveError"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::TryReserveError",
                 "kind"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -261,13 +266,13 @@ Module collections.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "alloc::collections::TryReserveErrorKind::AllocError",
                         "layout"
                       |) in
                     let γ1_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "alloc::collections::TryReserveErrorKind::AllocError",
                         "non_exhaustive"
@@ -368,17 +373,17 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ0_0,
                                 "alloc::collections::TryReserveErrorKind::AllocError",
                                 "layout"
                               |) in
                             let γ2_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ0_0,
                                 "alloc::collections::TryReserveErrorKind::AllocError",
                                 "non_exhaustive"
@@ -387,13 +392,13 @@ Module collections.
                             let __self_1 := M.alloc (| γ2_1 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ0_1,
                                 "alloc::collections::TryReserveErrorKind::AllocError",
                                 "layout"
                               |) in
                             let γ2_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ0_1,
                                 "alloc::collections::TryReserveErrorKind::AllocError",
                                 "non_exhaustive"
@@ -519,13 +524,13 @@ Module collections.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "alloc::collections::TryReserveErrorKind::AllocError",
                         "layout"
                       |) in
                     let γ1_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "alloc::collections::TryReserveErrorKind::AllocError",
                         "non_exhaustive"
@@ -681,7 +686,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -717,7 +722,7 @@ Module collections.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -729,10 +734,11 @@ Module collections.
                 let reason :=
                   M.copy (|
                     M.match_operator (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::TryReserveError"
-                        "kind",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::TryReserveError",
+                        "kind"
+                      |),
                       [
                         fun γ =>
                           ltac:(M.monadic

--- a/CoqOfRust/alloc/collections/vec_deque/drain.v
+++ b/CoqOfRust/alloc/collections/vec_deque/drain.v
@@ -59,10 +59,11 @@ Module collections.
                     M.call_closure (|
                       M.get_function (| "core::mem::replace", [ Ty.path "usize" ] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| deque |))
-                          "alloc::collections::vec_deque::VecDeque"
-                          "len";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| deque |),
+                          "alloc::collections::vec_deque::VecDeque",
+                          "len"
+                        |);
                         M.read (| drain_start |)
                       ]
                     |)
@@ -155,10 +156,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::drain::Drain"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::drain::Drain",
                           "deque"
+                        |)
                       ]
                     |)
                   |) in
@@ -169,24 +171,27 @@ Module collections.
                       [
                         ("start",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::drain::Drain"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::drain::Drain",
                               "idx"
+                            |)
                           |));
                         ("end_",
                           BinOp.Panic.add (|
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::drain::Drain"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::drain::Drain",
                                 "idx"
+                              |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::drain::Drain"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::drain::Drain",
                                 "remaining"
+                              |)
                             |)
                           |))
                       ]
@@ -212,10 +217,11 @@ Module collections.
                           [ logical_remaining_range ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            logical_remaining_range
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            logical_remaining_range,
+                            "core::ops::range::Range",
                             "end"
+                          |)
                         |)
                       ]
                     |)
@@ -223,8 +229,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_range := M.copy (| γ0_0 |) in
                         let b_range := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -331,34 +337,38 @@ Module collections.
                                   |);
                                   (* Unsize *)
                                   M.pointer_coercion
-                                    (M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::drain::Drain"
-                                      "drain_len")
+                                    (M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::drain::Drain",
+                                      "drain_len"
+                                    |))
                                 ]
                               |);
                               (* Unsize *)
                               M.pointer_coercion
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::drain::Drain"
-                                  "idx")
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::drain::Drain",
+                                  "idx"
+                                |))
                             ]
                           |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::drain::Drain"
-                              "tail_len")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::drain::Drain",
+                              "tail_len"
+                            |))
                         ]
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::drain::Drain"
-                          "remaining")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::drain::Drain",
+                          "remaining"
+                        |))
                     ]
                   |)
                 ]
@@ -511,15 +521,17 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.ne
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (|
-                                      M.get_struct_tuple_field
-                                        guard
-                                        "alloc::collections::vec_deque::drain::drop::DropGuard"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (|
+                                      M.SubPointer.get_struct_tuple_field (|
+                                        guard,
+                                        "alloc::collections::vec_deque::drain::drop::DropGuard",
                                         0
-                                    |))
-                                    "alloc::collections::vec_deque::drain::Drain"
+                                      |)
+                                    |),
+                                    "alloc::collections::vec_deque::drain::Drain",
                                     "remaining"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -537,10 +549,11 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_tuple_field
-                                    guard
-                                    "alloc::collections::vec_deque::drain::drop::DropGuard"
+                                  M.SubPointer.get_struct_tuple_field (|
+                                    guard,
+                                    "alloc::collections::vec_deque::drain::drop::DropGuard",
                                     0
+                                  |)
                                 |)
                               ]
                             |)
@@ -548,21 +561,23 @@ Module collections.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let front := M.copy (| γ0_0 |) in
                                 let back := M.copy (| γ0_1 |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (|
-                                        M.get_struct_tuple_field
-                                          guard
-                                          "alloc::collections::vec_deque::drain::drop::DropGuard"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (|
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          guard,
+                                          "alloc::collections::vec_deque::drain::drop::DropGuard",
                                           0
-                                      |))
-                                      "alloc::collections::vec_deque::drain::Drain"
-                                      "idx" in
+                                        |)
+                                      |),
+                                      "alloc::collections::vec_deque::drain::Drain",
+                                      "idx"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -581,15 +596,17 @@ Module collections.
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (|
-                                        M.get_struct_tuple_field
-                                          guard
-                                          "alloc::collections::vec_deque::drain::drop::DropGuard"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (|
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          guard,
+                                          "alloc::collections::vec_deque::drain::drop::DropGuard",
                                           0
-                                      |))
-                                      "alloc::collections::vec_deque::drain::Drain"
-                                      "remaining" in
+                                        |)
+                                      |),
+                                      "alloc::collections::vec_deque::drain::Drain",
+                                      "remaining"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.sub (|
@@ -618,15 +635,17 @@ Module collections.
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (|
-                                        M.get_struct_tuple_field
-                                          guard
-                                          "alloc::collections::vec_deque::drain::drop::DropGuard"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (|
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          guard,
+                                          "alloc::collections::vec_deque::drain::drop::DropGuard",
                                           0
-                                      |))
-                                      "alloc::collections::vec_deque::drain::Drain"
-                                      "remaining",
+                                        |)
+                                      |),
+                                      "alloc::collections::vec_deque::drain::Drain",
+                                      "remaining"
+                                    |),
                                     Value.Integer Integer.Usize 0
                                   |) in
                                 let _ :=
@@ -696,10 +715,11 @@ Module collections.
                                   (M.alloc (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::drain::Drain"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::drain::Drain",
                                           "remaining"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -742,37 +762,41 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::drain::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::drain::Drain",
                                   "deque"
+                                |)
                               ]
                             |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::drain::Drain"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::drain::Drain",
                                 "idx"
+                              |)
                             |)
                           ]
                         |)
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::drain::Drain"
-                          "idx" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::drain::Drain",
+                          "idx"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::drain::Drain"
-                          "remaining" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::drain::Drain",
+                          "remaining"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -801,10 +825,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::drain::Drain"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::drain::Drain",
                                     "deque"
+                                  |)
                                 ]
                               |);
                               M.read (| wrapped_idx |)
@@ -832,10 +857,11 @@ Module collections.
               M.read (|
                 let len :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::drain::Drain"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::drain::Drain",
                       "remaining"
+                    |)
                   |) in
                 M.alloc (|
                   Value.Tuple
@@ -896,10 +922,11 @@ Module collections.
                                   (M.alloc (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::drain::Drain"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::drain::Drain",
                                           "remaining"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -922,10 +949,11 @@ Module collections.
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::drain::Drain"
-                          "remaining" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::drain::Drain",
+                          "remaining"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -952,24 +980,27 @@ Module collections.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::drain::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::drain::Drain",
                                   "deque"
+                                |)
                               ]
                             |);
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::drain::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::drain::Drain",
                                   "idx"
+                                |)
                               |),
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::drain::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::drain::Drain",
                                   "remaining"
+                                |)
                               |)
                             |)
                           ]
@@ -999,10 +1030,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::drain::Drain"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::drain::Drain",
                                     "deque"
+                                  |)
                                 ]
                               |);
                               M.read (| wrapped_idx |)

--- a/CoqOfRust/alloc/collections/vec_deque/into_iter.v
+++ b/CoqOfRust/alloc/collections/vec_deque/into_iter.v
@@ -36,10 +36,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::into_iter::IntoIter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::into_iter::IntoIter",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -92,10 +93,11 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  self
-                  "alloc::collections::vec_deque::into_iter::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "alloc::collections::vec_deque::into_iter::IntoIter",
                   "inner"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -147,10 +149,11 @@ Module collections.
                       |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::into_iter::IntoIter"
-                          "inner")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::into_iter::IntoIter",
+                          "inner"
+                        |))
                     ]
                   |)
                 ]
@@ -192,10 +195,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::into_iter::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::into_iter::IntoIter",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -223,10 +227,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::into_iter::IntoIter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::into_iter::IntoIter",
                           "inner"
+                        |)
                       ]
                     |)
                   |) in
@@ -264,13 +269,15 @@ Module collections.
               M.read (|
                 let len :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::into_iter::IntoIter"
-                        "inner")
-                      "alloc::collections::vec_deque::VecDeque"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::into_iter::IntoIter",
+                        "inner"
+                      |),
+                      "alloc::collections::vec_deque::VecDeque",
                       "len"
+                    |)
                   |) in
                 let rem :=
                   M.copy (|
@@ -295,10 +302,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::into_iter::IntoIter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::into_iter::IntoIter",
                                       "inner"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -320,10 +328,11 @@ Module collections.
                                     ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::into_iter::IntoIter"
-                                      "inner";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::into_iter::IntoIter",
+                                      "inner"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| n |)) ]
@@ -382,13 +391,15 @@ Module collections.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.get_struct_record_field
-                    self
-                    "alloc::collections::vec_deque::into_iter::IntoIter"
-                    "inner")
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "alloc::collections::vec_deque::into_iter::IntoIter",
+                    "inner"
+                  |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "len"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -453,10 +464,11 @@ Module collections.
                           "alloc::collections::vec_deque::into_iter::try_fold::Guard"
                           [
                             ("deque",
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::into_iter::IntoIter"
-                                "inner");
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::into_iter::IntoIter",
+                                "inner"
+                              |));
                             ("consumed", Value.Integer Integer.Usize 0)
                           ]
                       |) in
@@ -470,10 +482,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                guard
-                                "alloc::collections::vec_deque::into_iter::try_fold::Guard"
+                              M.SubPointer.get_struct_record_field (|
+                                guard,
+                                "alloc::collections::vec_deque::into_iter::try_fold::Guard",
                                 "deque"
+                              |)
                             |)
                           ]
                         |)
@@ -481,8 +494,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let head := M.copy (| γ0_0 |) in
                             let tail := M.copy (| γ0_1 |) in
                             let _ :=
@@ -558,10 +571,11 @@ Module collections.
                                                                     M.read (|
                                                                       let _ :=
                                                                         let β :=
-                                                                          M.get_struct_record_field
-                                                                            guard
-                                                                            "alloc::collections::vec_deque::into_iter::try_fold::Guard"
-                                                                            "consumed" in
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            guard,
+                                                                            "alloc::collections::vec_deque::into_iter::try_fold::Guard",
+                                                                            "consumed"
+                                                                          |) in
                                                                         M.write (|
                                                                           β,
                                                                           BinOp.Panic.add (|
@@ -599,7 +613,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -626,7 +640,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -689,10 +703,11 @@ Module collections.
                                                         M.read (|
                                                           let _ :=
                                                             let β :=
-                                                              M.get_struct_record_field
-                                                                guard
-                                                                "alloc::collections::vec_deque::into_iter::try_fold::Guard"
-                                                                "consumed" in
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                guard,
+                                                                "alloc::collections::vec_deque::into_iter::try_fold::Guard",
+                                                                "consumed"
+                                                              |) in
                                                             M.write (|
                                                               β,
                                                               BinOp.Panic.add (|
@@ -818,7 +833,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Ok",
                             0
@@ -828,7 +843,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Err",
                             0
@@ -861,10 +876,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    self
-                    "alloc::collections::vec_deque::into_iter::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "alloc::collections::vec_deque::into_iter::IntoIter",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -970,18 +986,19 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::into_iter::IntoIter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::into_iter::IntoIter",
                               "inner"
+                            |)
                           ]
                         |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let head := M.copy (| γ0_0 |) in
                             let tail := M.copy (| γ0_1 |) in
                             let _ :=
@@ -1043,13 +1060,15 @@ Module collections.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_struct_record_field
-                                                  (M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::vec_deque::into_iter::IntoIter"
-                                                    "inner")
-                                                  "alloc::collections::vec_deque::VecDeque"
-                                                  "head",
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::vec_deque::into_iter::IntoIter",
+                                                    "inner"
+                                                  |),
+                                                  "alloc::collections::vec_deque::VecDeque",
+                                                  "head"
+                                                |),
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
@@ -1060,10 +1079,11 @@ Module collections.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::vec_deque::into_iter::IntoIter"
-                                                      "inner";
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::vec_deque::into_iter::IntoIter",
+                                                      "inner"
+                                                    |);
                                                     M.read (|
                                                       M.get_constant (|
                                                         "alloc::collections::vec_deque::into_iter::next_chunk::N"
@@ -1074,13 +1094,15 @@ Module collections.
                                               |) in
                                             let _ :=
                                               let β :=
-                                                M.get_struct_record_field
-                                                  (M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::vec_deque::into_iter::IntoIter"
-                                                    "inner")
-                                                  "alloc::collections::vec_deque::VecDeque"
-                                                  "len" in
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::vec_deque::into_iter::IntoIter",
+                                                    "inner"
+                                                  |),
+                                                  "alloc::collections::vec_deque::VecDeque",
+                                                  "len"
+                                                |) in
                                               M.write (|
                                                 β,
                                                 BinOp.Panic.sub (|
@@ -1241,13 +1263,15 @@ Module collections.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::into_iter::IntoIter"
-                                            "inner")
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "head",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::into_iter::IntoIter",
+                                            "inner"
+                                          |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "head"
+                                        |),
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply
@@ -1257,10 +1281,11 @@ Module collections.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::vec_deque::into_iter::IntoIter"
-                                              "inner";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::vec_deque::into_iter::IntoIter",
+                                              "inner"
+                                            |);
                                             M.read (|
                                               M.get_constant (|
                                                 "alloc::collections::vec_deque::into_iter::next_chunk::N"
@@ -1271,13 +1296,15 @@ Module collections.
                                       |) in
                                     let _ :=
                                       let β :=
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::into_iter::IntoIter"
-                                            "inner")
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "len" in
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::into_iter::IntoIter",
+                                            "inner"
+                                          |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "len"
+                                        |) in
                                       M.write (|
                                         β,
                                         BinOp.Panic.sub (|
@@ -1391,24 +1418,28 @@ Module collections.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::into_iter::IntoIter"
-                                            "inner")
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "head",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::into_iter::IntoIter",
+                                            "inner"
+                                          |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "head"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::into_iter::IntoIter"
-                                            "inner")
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "len",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::into_iter::IntoIter",
+                                            "inner"
+                                          |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "len"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     M.alloc (|
@@ -1486,10 +1517,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::into_iter::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::into_iter::IntoIter",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1518,13 +1550,15 @@ Module collections.
               M.read (|
                 let len :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::into_iter::IntoIter"
-                        "inner")
-                      "alloc::collections::vec_deque::VecDeque"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::into_iter::IntoIter",
+                        "inner"
+                      |),
+                      "alloc::collections::vec_deque::VecDeque",
                       "len"
+                    |)
                   |) in
                 let rem :=
                   M.copy (|
@@ -1549,10 +1583,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::into_iter::IntoIter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::into_iter::IntoIter",
                                       "inner"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -1570,10 +1605,11 @@ Module collections.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::into_iter::IntoIter"
-                                      "inner";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::into_iter::IntoIter",
+                                      "inner"
+                                    |);
                                     BinOp.Panic.sub (| M.read (| len |), M.read (| n |) |)
                                   ]
                                 |)
@@ -1675,10 +1711,11 @@ Module collections.
                           "alloc::collections::vec_deque::into_iter::try_rfold::Guard"
                           [
                             ("deque",
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::into_iter::IntoIter"
-                                "inner");
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::into_iter::IntoIter",
+                                "inner"
+                              |));
                             ("consumed", Value.Integer Integer.Usize 0)
                           ]
                       |) in
@@ -1692,10 +1729,11 @@ Module collections.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                guard
-                                "alloc::collections::vec_deque::into_iter::try_rfold::Guard"
+                              M.SubPointer.get_struct_record_field (|
+                                guard,
+                                "alloc::collections::vec_deque::into_iter::try_rfold::Guard",
                                 "deque"
+                              |)
                             |)
                           ]
                         |)
@@ -1703,8 +1741,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let head := M.copy (| γ0_0 |) in
                             let tail := M.copy (| γ0_1 |) in
                             let _ :=
@@ -1780,10 +1818,11 @@ Module collections.
                                                                     M.read (|
                                                                       let _ :=
                                                                         let β :=
-                                                                          M.get_struct_record_field
-                                                                            guard
-                                                                            "alloc::collections::vec_deque::into_iter::try_rfold::Guard"
-                                                                            "consumed" in
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            guard,
+                                                                            "alloc::collections::vec_deque::into_iter::try_rfold::Guard",
+                                                                            "consumed"
+                                                                          |) in
                                                                         M.write (|
                                                                           β,
                                                                           BinOp.Panic.add (|
@@ -1821,7 +1860,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -1848,7 +1887,7 @@ Module collections.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -1911,10 +1950,11 @@ Module collections.
                                                         M.read (|
                                                           let _ :=
                                                             let β :=
-                                                              M.get_struct_record_field
-                                                                guard
-                                                                "alloc::collections::vec_deque::into_iter::try_rfold::Guard"
-                                                                "consumed" in
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                guard,
+                                                                "alloc::collections::vec_deque::into_iter::try_rfold::Guard",
+                                                                "consumed"
+                                                              |) in
                                                             M.write (|
                                                               β,
                                                               BinOp.Panic.add (|
@@ -2040,7 +2080,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Ok",
                             0
@@ -2050,7 +2090,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Err",
                             0
@@ -2102,10 +2142,11 @@ Module collections.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::into_iter::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::into_iter::IntoIter",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/alloc/collections/vec_deque/iter.v
+++ b/CoqOfRust/alloc/collections/vec_deque/iter.v
@@ -99,10 +99,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter::Iter",
                                     "i1"
+                                  |)
                                 ]
                               |)
                             |))
@@ -118,10 +119,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter::Iter",
                                 "i2"
+                              |)
                             ]
                           |)
                         |))
@@ -169,10 +171,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i1"
+                        |)
                       ]
                     |));
                   ("i2",
@@ -185,10 +188,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i2"
+                        |)
                       ]
                     |))
                 ]))
@@ -245,10 +249,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i1"
+                        |)
                       ]
                     |)
                   |),
@@ -256,7 +261,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -275,14 +280,16 @@ Module collections.
                                 [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter::Iter"
-                                  "i1";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter::Iter",
+                                  "i1"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter::Iter",
                                   "i2"
+                                |)
                               ]
                             |)
                           |) in
@@ -296,10 +303,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter::Iter",
                                 "i1"
+                              |)
                             ]
                           |)
                         |)))
@@ -342,10 +350,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::iter::Iter"
-                              "i1";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::iter::Iter",
+                              "i1"
+                            |);
                             M.read (| n |)
                           ]
                         |)
@@ -356,7 +365,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -373,7 +382,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -387,14 +396,16 @@ Module collections.
                                     [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
-                                      "i1";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
+                                      "i1"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
                                       "i2"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -408,10 +419,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter::Iter"
-                                    "i1";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter::Iter",
+                                    "i1"
+                                  |);
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.path "core::num::nonzero::NonZeroUsize",
@@ -497,10 +509,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::vec_deque::iter::Iter"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::vec_deque::iter::Iter",
                             "i1"
+                          |)
                         |);
                         M.read (| accum |);
                         f
@@ -518,10 +531,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i2"
+                        |)
                       |);
                       M.read (| accum |);
                       f
@@ -575,10 +589,11 @@ Module collections.
                                     [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
-                                      "i1";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
+                                      "i1"
+                                    |);
                                     M.read (| init |);
                                     f
                                   ]
@@ -590,7 +605,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -617,7 +632,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -637,10 +652,11 @@ Module collections.
                           [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::iter::Iter"
-                            "i2";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::iter::Iter",
+                            "i2"
+                          |);
                           M.read (| acc |);
                           f
                         ]
@@ -708,10 +724,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i1"
+                        |)
                       ]
                     |)
                   |) in
@@ -737,10 +754,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter::Iter"
-                                "i1";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter::Iter",
+                                "i1"
+                              |);
                               M.read (| idx |)
                             ]
                           |)
@@ -757,10 +775,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter::Iter"
-                                "i2";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter::Iter",
+                                "i2"
+                              |);
                               BinOp.Panic.sub (| M.read (| idx |), M.read (| i1_len |) |)
                             ]
                           |)
@@ -828,10 +847,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i2"
+                        |)
                       ]
                     |)
                   |),
@@ -839,7 +859,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -858,14 +878,16 @@ Module collections.
                                 [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter::Iter"
-                                  "i1";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter::Iter",
+                                  "i1"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter::Iter",
                                   "i2"
+                                |)
                               ]
                             |)
                           |) in
@@ -879,10 +901,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter::Iter",
                                 "i2"
+                              |)
                             ]
                           |)
                         |)))
@@ -924,10 +947,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::iter::Iter"
-                              "i2";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::iter::Iter",
+                              "i2"
+                            |);
                             M.read (| n |)
                           ]
                         |)
@@ -936,7 +960,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -953,7 +977,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -967,14 +991,16 @@ Module collections.
                                     [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
-                                      "i1";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
+                                      "i1"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
                                       "i2"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -988,10 +1014,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter::Iter"
-                                    "i2";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter::Iter",
+                                    "i2"
+                                  |);
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.path "core::num::nonzero::NonZeroUsize",
@@ -1040,10 +1067,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::vec_deque::iter::Iter"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::vec_deque::iter::Iter",
                             "i2"
+                          |)
                         |);
                         M.read (| accum |);
                         f
@@ -1061,10 +1089,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::vec_deque::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::vec_deque::iter::Iter",
                           "i1"
+                        |)
                       |);
                       M.read (| accum |);
                       f
@@ -1118,10 +1147,11 @@ Module collections.
                                     [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter::Iter"
-                                      "i2";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter::Iter",
+                                      "i2"
+                                    |);
                                     M.read (| init |);
                                     f
                                   ]
@@ -1133,7 +1163,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1160,7 +1190,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1180,10 +1210,11 @@ Module collections.
                           [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::iter::Iter"
-                            "i1";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::iter::Iter",
+                            "i1"
+                          |);
                           M.read (| acc |);
                           f
                         ]
@@ -1234,10 +1265,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter::Iter",
                       "i1"
+                    |)
                   ]
                 |),
                 M.call_closure (|
@@ -1249,10 +1281,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter::Iter",
                       "i2"
+                    |)
                   ]
                 |)
               |)))
@@ -1280,10 +1313,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter::Iter",
                       "i1"
+                    |)
                   ]
                 |),
                 ltac:(M.monadic
@@ -1296,10 +1330,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::iter::Iter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::iter::Iter",
                         "i2"
+                      |)
                     ]
                   |)))
               |)))

--- a/CoqOfRust/alloc/collections/vec_deque/iter_mut.v
+++ b/CoqOfRust/alloc/collections/vec_deque/iter_mut.v
@@ -99,10 +99,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter_mut::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter_mut::IterMut",
                                     "i1"
+                                  |)
                                 ]
                               |)
                             |))
@@ -118,10 +119,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter_mut::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter_mut::IterMut",
                                 "i2"
+                              |)
                             ]
                           |)
                         |))
@@ -182,10 +184,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter_mut::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter_mut::IterMut",
                           "i1"
+                        |)
                       ]
                     |)
                   |),
@@ -193,7 +196,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -212,14 +215,16 @@ Module collections.
                                 [ Ty.apply (Ty.path "core::slice::iter::IterMut") [ T ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter_mut::IterMut"
-                                  "i1";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter_mut::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter_mut::IterMut",
+                                  "i1"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter_mut::IterMut",
                                   "i2"
+                                |)
                               ]
                             |)
                           |) in
@@ -233,10 +238,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter_mut::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter_mut::IterMut",
                                 "i1"
+                              |)
                             ]
                           |)
                         |)))
@@ -278,10 +284,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::iter_mut::IterMut"
-                              "i1";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::iter_mut::IterMut",
+                              "i1"
+                            |);
                             M.read (| n |)
                           ]
                         |)
@@ -290,7 +297,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -307,7 +314,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -321,14 +328,16 @@ Module collections.
                                     [ Ty.apply (Ty.path "core::slice::iter::IterMut") [ T ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
-                                      "i1";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
+                                      "i1"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
                                       "i2"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -342,10 +351,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter_mut::IterMut"
-                                    "i1";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter_mut::IterMut",
+                                    "i1"
+                                  |);
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.path "core::num::nonzero::NonZeroUsize",
@@ -431,10 +441,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::vec_deque::iter_mut::IterMut"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::vec_deque::iter_mut::IterMut",
                             "i1"
+                          |)
                         |);
                         M.read (| accum |);
                         f
@@ -452,10 +463,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::vec_deque::iter_mut::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::vec_deque::iter_mut::IterMut",
                           "i2"
+                        |)
                       |);
                       M.read (| accum |);
                       f
@@ -509,10 +521,11 @@ Module collections.
                                     [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
-                                      "i1";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
+                                      "i1"
+                                    |);
                                     M.read (| init |);
                                     f
                                   ]
@@ -524,7 +537,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -551,7 +564,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -571,10 +584,11 @@ Module collections.
                           [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::iter_mut::IterMut"
-                            "i2";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::iter_mut::IterMut",
+                            "i2"
+                          |);
                           M.read (| acc |);
                           f
                         ]
@@ -642,10 +656,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter_mut::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter_mut::IterMut",
                           "i1"
+                        |)
                       ]
                     |)
                   |) in
@@ -673,10 +688,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter_mut::IterMut"
-                                    "i1";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter_mut::IterMut",
+                                    "i1"
+                                  |);
                                   M.read (| idx |)
                                 ]
                               |)
@@ -693,10 +709,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter_mut::IterMut"
-                                    "i2";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter_mut::IterMut",
+                                    "i2"
+                                  |);
                                   BinOp.Panic.sub (| M.read (| idx |), M.read (| i1_len |) |)
                                 ]
                               |)
@@ -766,10 +783,11 @@ Module collections.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::iter_mut::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::iter_mut::IterMut",
                           "i2"
+                        |)
                       ]
                     |)
                   |),
@@ -777,7 +795,7 @@ Module collections.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -796,14 +814,16 @@ Module collections.
                                 [ Ty.apply (Ty.path "core::slice::iter::IterMut") [ T ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter_mut::IterMut"
-                                  "i1";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::iter_mut::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter_mut::IterMut",
+                                  "i1"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::iter_mut::IterMut",
                                   "i2"
+                                |)
                               ]
                             |)
                           |) in
@@ -817,10 +837,11 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::iter_mut::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::iter_mut::IterMut",
                                 "i2"
+                              |)
                             ]
                           |)
                         |)))
@@ -862,10 +883,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::iter_mut::IterMut"
-                              "i2";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::iter_mut::IterMut",
+                              "i2"
+                            |);
                             M.read (| n |)
                           ]
                         |)
@@ -874,7 +896,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -891,7 +913,7 @@ Module collections.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -905,14 +927,16 @@ Module collections.
                                     [ Ty.apply (Ty.path "core::slice::iter::IterMut") [ T ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
-                                      "i1";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
+                                      "i1"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
                                       "i2"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -926,10 +950,11 @@ Module collections.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::iter_mut::IterMut"
-                                    "i2";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::iter_mut::IterMut",
+                                    "i2"
+                                  |);
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.path "core::num::nonzero::NonZeroUsize",
@@ -978,10 +1003,11 @@ Module collections.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "alloc::collections::vec_deque::iter_mut::IterMut"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "alloc::collections::vec_deque::iter_mut::IterMut",
                             "i2"
+                          |)
                         |);
                         M.read (| accum |);
                         f
@@ -999,10 +1025,11 @@ Module collections.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "alloc::collections::vec_deque::iter_mut::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "alloc::collections::vec_deque::iter_mut::IterMut",
                           "i1"
+                        |)
                       |);
                       M.read (| accum |);
                       f
@@ -1056,10 +1083,11 @@ Module collections.
                                     [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::iter_mut::IterMut"
-                                      "i2";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::iter_mut::IterMut",
+                                      "i2"
+                                    |);
                                     M.read (| init |);
                                     f
                                   ]
@@ -1071,7 +1099,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1098,7 +1126,7 @@ Module collections.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1118,10 +1146,11 @@ Module collections.
                           [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::iter_mut::IterMut"
-                            "i1";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::iter_mut::IterMut",
+                            "i1"
+                          |);
                           M.read (| acc |);
                           f
                         ]
@@ -1172,10 +1201,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter_mut::IterMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter_mut::IterMut",
                       "i1"
+                    |)
                   ]
                 |),
                 M.call_closure (|
@@ -1187,10 +1217,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter_mut::IterMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter_mut::IterMut",
                       "i2"
+                    |)
                   ]
                 |)
               |)))
@@ -1218,10 +1249,11 @@ Module collections.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::iter_mut::IterMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::iter_mut::IterMut",
                       "i1"
+                    |)
                   ]
                 |),
                 ltac:(M.monadic
@@ -1234,10 +1266,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::iter_mut::IterMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::iter_mut::IterMut",
                         "i2"
+                      |)
                     ]
                   |)))
               |)))

--- a/CoqOfRust/alloc/collections/vec_deque/macros.v
+++ b/CoqOfRust/alloc/collections/vec_deque/macros.v
@@ -78,8 +78,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -118,8 +118,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|
@@ -252,8 +252,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -292,8 +292,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|
@@ -427,8 +427,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -467,8 +467,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|
@@ -602,8 +602,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -642,8 +642,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|
@@ -779,8 +779,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -819,8 +819,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|
@@ -957,8 +957,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -997,8 +997,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.alloc (|

--- a/CoqOfRust/alloc/collections/vec_deque/mod.v
+++ b/CoqOfRust/alloc/collections/vec_deque/mod.v
@@ -238,8 +238,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let front := M.copy (| γ0_0 |) in
                       let back := M.copy (| γ0_1 |) in
                       let _back_dropper :=
@@ -334,10 +334,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "buf"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -463,12 +464,30 @@ Module collections.
                       |),
                       [ M.read (| self |) ]
                     |);
-                    M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |)
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        range,
+                        "core::ops::range::Range",
+                        "start"
+                      |)
+                    |)
                   ]
                 |);
                 BinOp.Panic.sub (|
-                  M.read (| M.get_struct_record_field range "core::ops::range::Range" "end" |),
-                  M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |)
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      range,
+                      "core::ops::range::Range",
+                      "end"
+                    |)
+                  |),
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      range,
+                      "core::ops::range::Range",
+                      "start"
+                    |)
+                  |)
                 |)
               ]
             |)))
@@ -492,10 +511,11 @@ Module collections.
             (let self := M.alloc (| self |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "len"
+                |)
               |))
               (M.call_closure (|
                 M.get_associated_function (|
@@ -570,10 +590,11 @@ Module collections.
               [
                 M.read (| self |);
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
                     "head"
+                  |)
                 |);
                 M.read (| idx |)
               ]
@@ -1730,9 +1751,9 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (|
                               M.read (| γ0_1 |),
@@ -1764,9 +1785,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (|
                               M.read (| γ0_0 |),
@@ -1824,9 +1845,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                           let _ :=
@@ -1881,9 +1902,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (|
                               M.read (| γ0_0 |),
@@ -1941,9 +1962,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                           let _ :=
@@ -1998,9 +2019,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (|
                               M.read (| γ0_0 |),
@@ -2134,9 +2155,9 @@ Module collections.
                           M.alloc (| Value.Tuple [] |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                           let _ :=
@@ -2471,8 +2492,8 @@ Module collections.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let left := M.copy (| γ0_0 |) in
                               let right := M.copy (| γ0_1 |) in
                               let _ :=
@@ -2628,8 +2649,8 @@ Module collections.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let i := M.copy (| γ0_0 |) in
                                       let element := M.copy (| γ0_1 |) in
                                       M.read (|
@@ -2774,17 +2795,19 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    guard
-                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                  M.SubPointer.get_struct_record_field (|
+                                    guard,
+                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                     "deque"
+                                  |)
                                 |);
                                 M.read (| dst |);
                                 M.read (| iter |);
-                                M.get_struct_record_field
-                                  guard
-                                  "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                M.SubPointer.get_struct_record_field (|
+                                  guard,
+                                  "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                   "written"
+                                |)
                               ]
                             |)
                           |) in
@@ -2812,10 +2835,11 @@ Module collections.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      guard
-                                      "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                    M.SubPointer.get_struct_record_field (|
+                                      guard,
+                                      "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                       "deque"
+                                    |)
                                   |);
                                   M.read (| dst |);
                                   M.call_closure (|
@@ -2835,10 +2859,11 @@ Module collections.
                                       M.read (| head_room |)
                                     ]
                                   |);
-                                  M.get_struct_record_field
-                                    guard
-                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                  M.SubPointer.get_struct_record_field (|
+                                    guard,
+                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                     "written"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -2853,27 +2878,30 @@ Module collections.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    guard
-                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                  M.SubPointer.get_struct_record_field (|
+                                    guard,
+                                    "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                     "deque"
+                                  |)
                                 |);
                                 Value.Integer Integer.Usize 0;
                                 M.read (| iter |);
-                                M.get_struct_record_field
-                                  guard
-                                  "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+                                M.SubPointer.get_struct_record_field (|
+                                  guard,
+                                  "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                                   "written"
+                                |)
                               ]
                             |)
                           |) in
                         M.alloc (| Value.Tuple [] |)))
                   ]
                 |) in
-              M.get_struct_record_field
-                guard
-                "alloc::collections::vec_deque::write_iter_wrapping::Guard"
+              M.SubPointer.get_struct_record_field (|
+                guard,
+                "alloc::collections::vec_deque::write_iter_wrapping::Guard",
                 "written"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3009,18 +3037,20 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.le
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::VecDeque"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::VecDeque",
                                     "head"
+                                  |)
                                 |))
                                 (BinOp.Panic.sub (|
                                   M.read (| old_capacity |),
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::VecDeque"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::VecDeque",
                                       "len"
+                                    |)
                                   |)
                                 |))
                             |)) in
@@ -3034,10 +3064,11 @@ Module collections.
                             BinOp.Panic.sub (|
                               M.read (| old_capacity |),
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "head"
+                                |)
                               |)
                             |)
                           |) in
@@ -3045,10 +3076,11 @@ Module collections.
                           M.alloc (|
                             BinOp.Panic.sub (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |),
                               M.read (| head_len |)
                             |)
@@ -3121,10 +3153,11 @@ Module collections.
                                         [
                                           M.read (| self |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::vec_deque::VecDeque"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::vec_deque::VecDeque",
                                               "head"
+                                            |)
                                           |);
                                           M.read (| new_head |);
                                           M.read (| head_len |)
@@ -3134,10 +3167,11 @@ Module collections.
                                   M.alloc (| Value.Tuple [] |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::collections::vec_deque::VecDeque"
-                                      "head",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::collections::vec_deque::VecDeque",
+                                      "head"
+                                    |),
                                     M.read (| new_head |)
                                   |) in
                                 M.alloc (| Value.Tuple [] |)))
@@ -3167,10 +3201,11 @@ Module collections.
                                           (LogicalOp.or (|
                                             BinOp.Pure.lt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "head"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -3351,16 +3386,18 @@ Module collections.
                                         UnOp.Pure.not
                                           (BinOp.Pure.le
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                initialized
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                initialized,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                initialized
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                initialized,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |)))
                                       |)) in
                                   let _ :=
@@ -3409,10 +3446,11 @@ Module collections.
                                         UnOp.Pure.not
                                           (BinOp.Pure.le
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                initialized
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                initialized,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |))
                                             (M.read (| capacity |)))
                                       |)) in
@@ -3447,17 +3485,29 @@ Module collections.
                   [
                     ("head",
                       M.read (|
-                        M.get_struct_record_field initialized "core::ops::range::Range" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          initialized,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
                       |));
                     ("len",
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "usize", "unchecked_sub", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field initialized "core::ops::range::Range" "end"
+                            M.SubPointer.get_struct_record_field (|
+                              initialized,
+                              "core::ops::range::Range",
+                              "end"
+                            |)
                           |);
                           M.read (|
-                            M.get_struct_record_field initialized "core::ops::range::Range" "start"
+                            M.SubPointer.get_struct_record_field (|
+                              initialized,
+                              "core::ops::range::Range",
+                              "start"
+                            |)
                           |)
                         ]
                       |));
@@ -3512,10 +3562,11 @@ Module collections.
                             BinOp.Pure.lt
                               (M.read (| index |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -3598,10 +3649,11 @@ Module collections.
                             BinOp.Pure.lt
                               (M.read (| index |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -3841,10 +3893,11 @@ Module collections.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "buf"
+                            |)
                           ]
                         |)
                       |)))
@@ -3892,10 +3945,11 @@ Module collections.
                         M.get_associated_function (| Ty.path "usize", "checked_add", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |);
                           M.read (| additional |)
                         ]
@@ -3935,15 +3989,17 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::VecDeque"
-                                "buf";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::VecDeque",
+                                "buf"
+                              |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |);
                               M.read (| additional |)
                             ]
@@ -4008,10 +4064,11 @@ Module collections.
                         M.get_associated_function (| Ty.path "usize", "checked_add", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |);
                           M.read (| additional |)
                         ]
@@ -4051,15 +4108,17 @@ Module collections.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::VecDeque"
-                                "buf";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::VecDeque",
+                                "buf"
+                              |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |);
                               M.read (| additional |)
                             ]
@@ -4144,10 +4203,11 @@ Module collections.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::VecDeque"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::VecDeque",
                                           "len"
+                                        |)
                                       |);
                                       M.read (| additional |)
                                     ]
@@ -4164,7 +4224,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -4203,7 +4263,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -4259,15 +4319,17 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::VecDeque"
-                                            "buf";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::VecDeque",
+                                            "buf"
+                                          |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::vec_deque::VecDeque"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::vec_deque::VecDeque",
                                               "len"
+                                            |)
                                           |);
                                           M.read (| additional |)
                                         ]
@@ -4279,7 +4341,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -4319,7 +4381,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -4411,10 +4473,11 @@ Module collections.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::VecDeque"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::VecDeque",
                                           "len"
+                                        |)
                                       |);
                                       M.read (| additional |)
                                     ]
@@ -4431,7 +4494,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -4470,7 +4533,7 @@ Module collections.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -4526,15 +4589,17 @@ Module collections.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::VecDeque"
-                                            "buf";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::VecDeque",
+                                            "buf"
+                                          |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::vec_deque::VecDeque"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::vec_deque::VecDeque",
                                               "len"
+                                            |)
                                           |);
                                           M.read (| additional |)
                                         ]
@@ -4546,7 +4611,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -4586,7 +4651,7 @@ Module collections.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -4748,10 +4813,11 @@ Module collections.
                         [
                           M.read (| min_capacity |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |)
                         ]
                       |)
@@ -4831,16 +4897,18 @@ Module collections.
                           M.alloc (|
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "head"
+                                |)
                               |),
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |)
                             |)
                           |)
@@ -4858,10 +4926,11 @@ Module collections.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "len"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -4869,10 +4938,11 @@ Module collections.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
-                                  "head",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
+                                  "head"
+                                |),
                                 Value.Integer Integer.Usize 0
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -4889,10 +4959,11 @@ Module collections.
                                           LogicalOp.and (|
                                             BinOp.Pure.ge
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "head"
+                                                |)
                                               |))
                                               (M.read (| target_cap |)),
                                             ltac:(M.monadic (M.read (| tail_outside |)))
@@ -4917,17 +4988,19 @@ Module collections.
                                             [
                                               M.read (| self |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "head"
+                                                |)
                                               |);
                                               Value.Integer Integer.Usize 0;
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "len"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -4935,10 +5008,11 @@ Module collections.
                                       M.alloc (| Value.Tuple [] |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "head",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "head"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     M.alloc (| Value.Tuple [] |)));
@@ -4955,10 +5029,11 @@ Module collections.
                                                   LogicalOp.and (|
                                                     BinOp.Pure.lt
                                                       (M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::vec_deque::VecDeque"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::vec_deque::VecDeque",
                                                           "head"
+                                                        |)
                                                       |))
                                                       (M.read (| target_cap |)),
                                                     ltac:(M.monadic (M.read (| tail_outside |)))
@@ -4974,16 +5049,18 @@ Module collections.
                                                 BinOp.Panic.sub (|
                                                   BinOp.Panic.add (|
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::vec_deque::VecDeque"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::vec_deque::VecDeque",
                                                         "head"
+                                                      |)
                                                     |),
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "alloc::collections::vec_deque::VecDeque"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "alloc::collections::vec_deque::VecDeque",
                                                         "len"
+                                                      |)
                                                     |)
                                                   |),
                                                   M.read (| target_cap |)
@@ -5052,10 +5129,11 @@ Module collections.
                                                             [ M.read (| self |) ]
                                                           |),
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "alloc::collections::vec_deque::VecDeque"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "alloc::collections::vec_deque::VecDeque",
                                                               "head"
+                                                            |)
                                                           |)
                                                         |)
                                                       |) in
@@ -5081,10 +5159,11 @@ Module collections.
                                                             [
                                                               M.read (| self |);
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "alloc::collections::vec_deque::VecDeque"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "alloc::collections::vec_deque::VecDeque",
                                                                   "head"
+                                                                |)
                                                               |);
                                                               M.read (| new_head |);
                                                               M.read (| head_len |)
@@ -5094,10 +5173,11 @@ Module collections.
                                                       M.alloc (| Value.Tuple [] |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::vec_deque::VecDeque"
-                                                          "head",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::vec_deque::VecDeque",
+                                                          "head"
+                                                        |),
                                                         M.read (| new_head |)
                                                       |) in
                                                     M.alloc (| Value.Tuple [] |)));
@@ -5120,10 +5200,11 @@ Module collections.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "buf";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "buf"
+                          |);
                           M.read (| target_cap |)
                         ]
                       |)
@@ -5150,10 +5231,11 @@ Module collections.
                                               (LogicalOp.or (|
                                                 BinOp.Pure.lt
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::collections::vec_deque::VecDeque"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::collections::vec_deque::VecDeque",
                                                       "head"
+                                                    |)
                                                   |))
                                                   (M.call_closure (|
                                                     M.get_associated_function (|
@@ -5228,10 +5310,11 @@ Module collections.
                                             UnOp.Pure.not
                                               (BinOp.Pure.le
                                                 (M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::collections::vec_deque::VecDeque"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::collections::vec_deque::VecDeque",
                                                     "len"
+                                                  |)
                                                 |))
                                                 (M.call_closure (|
                                                   M.get_associated_function (|
@@ -5347,10 +5430,11 @@ Module collections.
                                   BinOp.Pure.ge
                                     (M.read (| len |))
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "len"
+                                      |)
                                     |))
                                 |)) in
                             let _ :=
@@ -5375,8 +5459,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let front := M.copy (| γ0_0 |) in
                           let back := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -5442,10 +5526,11 @@ Module collections.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
-                                        "len",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
+                                        "len"
+                                      |),
                                       M.read (| len |)
                                     |) in
                                   let _ :=
@@ -5488,10 +5573,11 @@ Module collections.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
-                                        "len",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
+                                        "len"
+                                      |),
                                       M.read (| len |)
                                     |) in
                                   let _back_dropper :=
@@ -5542,10 +5628,11 @@ Module collections.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "buf"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5582,8 +5669,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -5650,8 +5737,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -5720,10 +5807,11 @@ Module collections.
                       M.read (| self |);
                       Value.StructTuple "core::ops::range::RangeFull" [];
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "len"
+                        |)
                       |)
                     ]
                   |)
@@ -5731,8 +5819,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a_range := M.copy (| γ0_0 |) in
                       let b_range := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -5797,10 +5885,11 @@ Module collections.
                       M.read (| self |);
                       Value.StructTuple "core::ops::range::RangeFull" [];
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "len"
+                        |)
                       |)
                     ]
                   |)
@@ -5808,8 +5897,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a_range := M.copy (| γ0_0 |) in
                       let b_range := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -5859,10 +5948,11 @@ Module collections.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::collections::vec_deque::VecDeque"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::collections::vec_deque::VecDeque",
                 "len"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -5884,10 +5974,11 @@ Module collections.
             (let self := M.alloc (| self |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "len"
+                |)
               |))
               (Value.Integer Integer.Usize 0)))
         | _, _ => M.impossible
@@ -5952,13 +6043,13 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "core::ops::range::Range",
                           "start"
                         |) in
                       let γ0_1 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "core::ops::range::Range",
                           "end"
@@ -6152,10 +6243,11 @@ Module collections.
                       M.read (| self |);
                       M.read (| range |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "len"
+                        |)
                       |)
                     ]
                   |)
@@ -6163,8 +6255,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a_range := M.copy (| γ0_0 |) in
                       let b_range := M.copy (| γ0_1 |) in
                       let a :=
@@ -6261,10 +6353,11 @@ Module collections.
                       M.read (| self |);
                       M.read (| range |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "len"
+                        |)
                       |)
                     ]
                   |)
@@ -6272,8 +6365,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a_range := M.copy (| γ0_0 |) in
                       let b_range := M.copy (| γ0_1 |) in
                       let a :=
@@ -6397,10 +6490,11 @@ Module collections.
                         [
                           ("end_",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::VecDeque"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::VecDeque",
                                 "len"
+                              |)
                             |))
                         ]
                     ]
@@ -6410,13 +6504,13 @@ Module collections.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "core::ops::range::Range",
                           "start"
                         |) in
                       let γ0_1 :=
-                        M.get_struct_record_field_or_break_match (|
+                        M.SubPointer.get_struct_record_field (|
                           γ,
                           "core::ops::range::Range",
                           "end"
@@ -6475,10 +6569,11 @@ Module collections.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "head"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -6521,8 +6616,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -6631,10 +6726,11 @@ Module collections.
                   M.get_associated_function (| Ty.path "usize", "wrapping_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |);
                     Value.Integer Integer.Usize 1
                   ]
@@ -6671,10 +6767,11 @@ Module collections.
                   M.get_associated_function (| Ty.path "usize", "wrapping_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |);
                     Value.Integer Integer.Usize 1
                   ]
@@ -6732,17 +6829,19 @@ Module collections.
                     ltac:(M.monadic
                       (let old_head :=
                         M.copy (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
                             "head"
+                          |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "head",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "head"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "alloc::collections::vec_deque::VecDeque") [ T; A ],
@@ -6754,10 +6853,11 @@ Module collections.
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "len" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "len"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -6830,10 +6930,11 @@ Module collections.
                     ltac:(M.monadic
                       (let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "len" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "len"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -6863,10 +6964,11 @@ Module collections.
                                   [
                                     M.read (| self |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "len"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -6947,10 +7049,11 @@ Module collections.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "head"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "alloc::collections::vec_deque::VecDeque") [ T; A ],
@@ -6960,10 +7063,11 @@ Module collections.
                     [
                       M.read (| self |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "head"
+                        |)
                       |);
                       Value.Integer Integer.Usize 1
                     ]
@@ -6971,10 +7075,11 @@ Module collections.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "len"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -6990,10 +7095,11 @@ Module collections.
                     [
                       M.read (| self |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "head"
+                        |)
                       |);
                       M.read (| value |)
                     ]
@@ -7084,10 +7190,11 @@ Module collections.
                         [
                           M.read (| self |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |)
                         ]
                       |);
@@ -7097,10 +7204,11 @@ Module collections.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "len"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -7128,10 +7236,11 @@ Module collections.
             (let self := M.alloc (| self |) in
             BinOp.Pure.le
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::collections::vec_deque::VecDeque"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::collections::vec_deque::VecDeque",
                   "head"
+                |)
               |))
               (BinOp.Panic.sub (|
                 M.call_closure (|
@@ -7143,10 +7252,11 @@ Module collections.
                   [ M.read (| self |) ]
                 |),
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
                     "len"
+                  |)
                 |)
               |))))
         | _, _ => M.impossible
@@ -7179,10 +7289,11 @@ Module collections.
                 (M.read (|
                   let length :=
                     M.copy (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |) in
                   let _ :=
                     M.match_operator (|
@@ -7294,10 +7405,11 @@ Module collections.
                 (M.read (|
                   let length :=
                     M.copy (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |) in
                   let _ :=
                     M.match_operator (|
@@ -7527,10 +7639,11 @@ Module collections.
                 M.alloc (|
                   BinOp.Panic.sub (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |),
                     M.read (| index |)
                   |)
@@ -7609,10 +7722,11 @@ Module collections.
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "len" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "len"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -7622,17 +7736,19 @@ Module collections.
                     ltac:(M.monadic
                       (let old_head :=
                         M.copy (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
                             "head"
+                          |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "head",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "head"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "alloc::collections::vec_deque::VecDeque") [ T; A ],
@@ -7642,10 +7758,11 @@ Module collections.
                             [
                               M.read (| self |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "head"
+                                |)
                               |);
                               Value.Integer Integer.Usize 1
                             ]
@@ -7663,10 +7780,11 @@ Module collections.
                               M.read (| self |);
                               M.read (| old_head |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "head"
+                                |)
                               |);
                               M.read (| index |)
                             ]
@@ -7698,10 +7816,11 @@ Module collections.
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
-                            "len" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
+                            "len"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -7765,10 +7884,11 @@ Module collections.
                                 (M.alloc (|
                                   BinOp.Pure.le
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "len"
+                                      |)
                                     |))
                                     (M.read (| index |))
                                 |)) in
@@ -7815,10 +7935,11 @@ Module collections.
                       BinOp.Panic.sub (|
                         BinOp.Panic.sub (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |),
                           M.read (| index |)
                         |),
@@ -7871,10 +7992,11 @@ Module collections.
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
-                                  "len" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
+                                  "len"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -7884,17 +8006,19 @@ Module collections.
                           ltac:(M.monadic
                             (let old_head :=
                               M.copy (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "head"
+                                |)
                               |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
-                                  "head",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
+                                  "head"
+                                |),
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply
@@ -7920,10 +8044,11 @@ Module collections.
                                     M.read (| self |);
                                     M.read (| old_head |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "head"
+                                      |)
                                     |);
                                     M.read (| index |)
                                   ]
@@ -7931,10 +8056,11 @@ Module collections.
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
-                                  "len" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
+                                  "len"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -8010,10 +8136,11 @@ Module collections.
             M.read (|
               let len :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
                     "len"
+                  |)
                 |) in
               let _ :=
                 M.match_operator (|
@@ -8098,8 +8225,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let first_half := M.copy (| γ0_0 |) in
                         let second_half := M.copy (| γ0_1 |) in
                         let first_len :=
@@ -8285,15 +8412,20 @@ Module collections.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "len",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "len"
+                  |),
                   M.read (| at_ |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field other "alloc::collections::vec_deque::VecDeque" "len",
+                  M.SubPointer.get_struct_record_field (|
+                    other,
+                    "alloc::collections::vec_deque::VecDeque",
+                    "len"
+                  |),
                   M.read (| other_len |)
                 |) in
               other
@@ -8355,10 +8487,11 @@ Module collections.
                                 M.read (|
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
-                                        "len",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
+                                        "len"
+                                      |),
                                       M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
@@ -8376,16 +8509,18 @@ Module collections.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "len"
+                                                |)
                                               |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| other |))
-                                                  "alloc::collections::vec_deque::VecDeque"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| other |),
+                                                  "alloc::collections::vec_deque::VecDeque",
                                                   "len"
+                                                |)
                                               |)
                                             ]
                                           |);
@@ -8395,18 +8530,20 @@ Module collections.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "alloc::collections::vec_deque::VecDeque"
-                                        "len",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "alloc::collections::vec_deque::VecDeque",
+                                        "len"
+                                      |),
                                       Value.Integer Integer.Usize 0
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "alloc::collections::vec_deque::VecDeque"
-                                        "head",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "alloc::collections::vec_deque::VecDeque",
+                                        "head"
+                                      |),
                                       Value.Integer Integer.Usize 0
                                     |) in
                                   M.return_ (| Value.Tuple [] |)
@@ -8427,10 +8564,11 @@ Module collections.
                         [
                           M.read (| self |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| other |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| other |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |)
                         ]
                       |)
@@ -8450,8 +8588,8 @@ Module collections.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let left := M.copy (| γ0_0 |) in
                             let right := M.copy (| γ0_1 |) in
                             let _ :=
@@ -8477,10 +8615,11 @@ Module collections.
                                       [
                                         M.read (| self |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::VecDeque"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::VecDeque",
                                             "len"
+                                          |)
                                         |)
                                       ]
                                     |);
@@ -8512,10 +8651,11 @@ Module collections.
                                         M.read (| self |);
                                         BinOp.Panic.add (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::collections::vec_deque::VecDeque"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::collections::vec_deque::VecDeque",
                                               "len"
+                                            |)
                                           |),
                                           M.call_closure (|
                                             M.get_associated_function (|
@@ -8537,36 +8677,40 @@ Module collections.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
-                        "len" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
+                        "len"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.add (|
                         M.read (| β |),
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "alloc::collections::vec_deque::VecDeque"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "alloc::collections::vec_deque::VecDeque",
                             "len"
+                          |)
                         |)
                       |)
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "alloc::collections::vec_deque::VecDeque"
-                        "len",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::collections::vec_deque::VecDeque",
+                        "len"
+                      |),
                       Value.Integer Integer.Usize 0
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "alloc::collections::vec_deque::VecDeque"
-                        "head",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::collections::vec_deque::VecDeque",
+                        "head"
+                      |),
                       Value.Integer Integer.Usize 0
                     |) in
                   M.alloc (| Value.Tuple [] |)
@@ -8691,10 +8835,11 @@ Module collections.
             M.read (|
               let len :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
                     "len"
+                  |)
                 |) in
               let idx := M.alloc (| Value.Integer Integer.Usize 0 |) in
               let cur := M.alloc (| Value.Integer Integer.Usize 0 |) in
@@ -9046,10 +9191,11 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
-                        "buf";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
+                        "buf"
+                      |);
                       M.read (| old_cap |)
                     ]
                   |)
@@ -9154,10 +9300,11 @@ Module collections.
             M.read (|
               let len :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
                     "len"
+                  |)
                 |) in
               M.match_operator (|
                 M.alloc (| Value.Tuple [] |),
@@ -9384,10 +9531,11 @@ Module collections.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
-                                  "head",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
+                                  "head"
+                                |),
                                 Value.Integer Integer.Usize 0
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -9445,18 +9593,20 @@ Module collections.
                                               [ M.read (| self |) ]
                                             |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::vec_deque::VecDeque"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::vec_deque::VecDeque",
                                                 "head"
+                                              |)
                                             |)
                                           ]
                                         |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::collections::vec_deque::VecDeque"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::collections::vec_deque::VecDeque",
                                             "len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -9474,13 +9624,13 @@ Module collections.
                         ltac:(M.monadic
                           (let γ := M.read (| γ |) in
                           let γ1_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::vec_deque::VecDeque",
                               "head"
                             |) in
                           let γ1_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "alloc::collections::vec_deque::VecDeque",
                               "len"
@@ -9582,10 +9732,11 @@ Module collections.
                                       M.alloc (| Value.Tuple [] |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::collections::vec_deque::VecDeque"
-                                          "head",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::collections::vec_deque::VecDeque",
+                                          "head"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     M.alloc (| Value.Tuple [] |)));
@@ -9653,10 +9804,11 @@ Module collections.
                                               M.alloc (| Value.Tuple [] |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::collections::vec_deque::VecDeque"
-                                                  "head",
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::collections::vec_deque::VecDeque",
+                                                  "head"
+                                                |),
                                                 M.read (| tail |)
                                               |) in
                                             M.alloc (| Value.Tuple [] |)));
@@ -9773,10 +9925,11 @@ Module collections.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::vec_deque::VecDeque"
-                                                          "head",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::vec_deque::VecDeque",
+                                                          "head"
+                                                        |),
                                                         M.read (| free |)
                                                       |) in
                                                     M.alloc (| Value.Tuple [] |)));
@@ -9816,10 +9969,11 @@ Module collections.
                                                                     [
                                                                       M.read (| self |);
                                                                       M.read (|
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "alloc::collections::vec_deque::VecDeque"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "alloc::collections::vec_deque::VecDeque",
                                                                           "head"
+                                                                        |)
                                                                       |);
                                                                       M.read (| tail_len |);
                                                                       M.read (| head_len |)
@@ -9852,10 +10006,11 @@ Module collections.
                                                                   Value.Integer Integer.Usize 0);
                                                                 ("end_",
                                                                   M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "alloc::collections::vec_deque::VecDeque"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "alloc::collections::vec_deque::VecDeque",
                                                                       "len"
+                                                                    |)
                                                                   |))
                                                               ]
                                                           ]
@@ -9877,10 +10032,11 @@ Module collections.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::collections::vec_deque::VecDeque"
-                                                          "head",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::collections::vec_deque::VecDeque",
+                                                          "head"
+                                                        |),
                                                         Value.Integer Integer.Usize 0
                                                       |) in
                                                     M.alloc (| Value.Tuple [] |)))
@@ -9903,18 +10059,20 @@ Module collections.
                                   [
                                     M.read (| ptr |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "head"
+                                      |)
                                     |)
                                   ]
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::collections::vec_deque::VecDeque"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::collections::vec_deque::VecDeque",
                                     "len"
+                                  |)
                                 |)
                               ]
                             |)
@@ -9989,10 +10147,11 @@ Module collections.
                 M.alloc (|
                   BinOp.Panic.sub (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |),
                     M.read (| n |)
                   |)
@@ -10096,10 +10255,11 @@ Module collections.
                 M.alloc (|
                   BinOp.Panic.sub (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "len"
+                      |)
                     |),
                     M.read (| n |)
                   |)
@@ -10233,10 +10393,11 @@ Module collections.
                       [
                         M.read (| self |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::collections::vec_deque::VecDeque"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::collections::vec_deque::VecDeque",
                             "head"
+                          |)
                         |);
                         M.call_closure (|
                           M.get_associated_function (|
@@ -10247,10 +10408,11 @@ Module collections.
                           [
                             M.read (| self |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::VecDeque"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::VecDeque",
                                 "len"
+                              |)
                             |)
                           ]
                         |);
@@ -10261,10 +10423,11 @@ Module collections.
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "head"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "alloc::collections::vec_deque::VecDeque") [ T; A ],
@@ -10362,10 +10525,11 @@ Module collections.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::collections::vec_deque::VecDeque"
-                    "head",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::collections::vec_deque::VecDeque",
+                    "head"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "alloc::collections::vec_deque::VecDeque") [ T; A ],
@@ -10375,10 +10539,11 @@ Module collections.
                     [
                       M.read (| self |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "head"
+                        |)
                       |);
                       M.read (| k |)
                     ]
@@ -10403,18 +10568,20 @@ Module collections.
                         [
                           M.read (| self |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::collections::vec_deque::VecDeque"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::collections::vec_deque::VecDeque",
                               "len"
+                            |)
                           |)
                         ]
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "head"
+                        |)
                       |);
                       M.read (| k |)
                     ]
@@ -10523,8 +10690,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let front := M.copy (| γ0_0 |) in
                       let back := M.copy (| γ0_1 |) in
                       let cmp_back :=
@@ -10586,7 +10753,7 @@ Module collections.
                             ltac:(M.monadic
                               (let γ := cmp_back in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -10614,7 +10781,7 @@ Module collections.
                                     ltac:(M.monadic
                                       (let γ := cmp_back in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -10848,8 +11015,8 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let front := M.copy (| γ0_0 |) in
                       let back := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -10913,7 +11080,7 @@ Module collections.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -11297,10 +11464,11 @@ Module collections.
                                 (M.alloc (|
                                   BinOp.Pure.ne
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::collections::vec_deque::VecDeque"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::collections::vec_deque::VecDeque",
                                         "len"
+                                      |)
                                     |))
                                     (M.call_closure (|
                                       M.get_associated_function (|
@@ -11335,8 +11503,8 @@ Module collections.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let sa := M.copy (| γ0_0 |) in
                           let sb := M.copy (| γ0_1 |) in
                           M.match_operator (|
@@ -11355,8 +11523,8 @@ Module collections.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let oa := M.copy (| γ0_0 |) in
                                   let ob := M.copy (| γ0_1 |) in
                                   M.match_operator (|
@@ -11499,8 +11667,16 @@ Module collections.
                                                     [
                                                       fun γ =>
                                                         ltac:(M.monadic
-                                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                                          (let γ0_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              0
+                                                            |) in
+                                                          let γ0_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              1
+                                                            |) in
                                                           let oa_front := M.copy (| γ0_0 |) in
                                                           let oa_mid := M.copy (| γ0_1 |) in
                                                           M.match_operator (|
@@ -11519,9 +11695,15 @@ Module collections.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let sb_mid := M.copy (| γ0_0 |) in
                                                                   let sb_back :=
                                                                     M.copy (| γ0_1 |) in
@@ -11586,13 +11768,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -11758,13 +11942,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -11930,13 +12116,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -12170,8 +12358,16 @@ Module collections.
                                                     [
                                                       fun γ =>
                                                         ltac:(M.monadic
-                                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                                          (let γ0_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              0
+                                                            |) in
+                                                          let γ0_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              1
+                                                            |) in
                                                           let sa_front := M.copy (| γ0_0 |) in
                                                           let sa_mid := M.copy (| γ0_1 |) in
                                                           M.match_operator (|
@@ -12190,9 +12386,15 @@ Module collections.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let ob_mid := M.copy (| γ0_0 |) in
                                                                   let ob_back :=
                                                                     M.copy (| γ0_1 |) in
@@ -12257,13 +12459,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -12429,13 +12633,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -12601,13 +12807,15 @@ Module collections.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          0 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          0
+                                                                                        |) in
                                                                                       let γ0_1 :=
-                                                                                        M.get_tuple_field
-                                                                                          γ
-                                                                                          1 in
+                                                                                        M.SubPointer.get_tuple_field (|
+                                                                                          γ,
+                                                                                          1
+                                                                                        |) in
                                                                                       let
                                                                                             left_val :=
                                                                                         M.copy (|
@@ -12976,10 +13184,11 @@ Module collections.
                     [
                       M.read (| state |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::collections::vec_deque::VecDeque"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::collections::vec_deque::VecDeque",
                           "len"
+                        |)
                       |)
                     ]
                   |)
@@ -13684,10 +13893,10 @@ Module collections.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                       let ptr := M.copy (| γ0_0 |) in
                       let len := M.copy (| γ0_1 |) in
                       let cap := M.copy (| γ0_2 |) in
@@ -13785,8 +13994,8 @@ Module collections.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -13801,9 +14010,10 @@ Module collections.
                             []
                           |),
                           [ other ]
-                        |))
-                        "alloc::collections::vec_deque::VecDeque"
+                        |),
+                        "alloc::collections::vec_deque::VecDeque",
                         "buf"
+                      |)
                     ]
                   |)
                 |) in
@@ -13901,8 +14111,8 @@ Module collections.
                             (M.alloc (|
                               BinOp.Pure.ne
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.call_closure (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.call_closure (|
                                       M.get_trait_method (|
                                         "core::ops::deref::Deref",
                                         Ty.apply
@@ -13917,9 +14127,10 @@ Module collections.
                                         []
                                       |),
                                       [ other ]
-                                    |))
-                                    "alloc::collections::vec_deque::VecDeque"
+                                    |),
+                                    "alloc::collections::vec_deque::VecDeque",
                                     "head"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -13941,8 +14152,8 @@ Module collections.
                                     [
                                       M.read (| buf |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.call_closure (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.call_closure (|
                                             M.get_trait_method (|
                                               "core::ops::deref::Deref",
                                               Ty.apply
@@ -13958,9 +14169,10 @@ Module collections.
                                               []
                                             |),
                                             [ other ]
-                                          |))
-                                          "alloc::collections::vec_deque::VecDeque"
+                                          |),
+                                          "alloc::collections::vec_deque::VecDeque",
                                           "head"
+                                        |)
                                       |)
                                     ]
                                   |));
@@ -14115,12 +14327,20 @@ Module collections.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field deq "alloc::collections::vec_deque::VecDeque" "head",
+                  M.SubPointer.get_struct_record_field (|
+                    deq,
+                    "alloc::collections::vec_deque::VecDeque",
+                    "head"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field deq "alloc::collections::vec_deque::VecDeque" "len",
+                  M.SubPointer.get_struct_record_field (|
+                    deq,
+                    "alloc::collections::vec_deque::VecDeque",
+                    "len"
+                  |),
                   M.read (| M.get_constant (| "alloc::collections::vec_deque::N" |) |)
                 |) in
               deq

--- a/CoqOfRust/alloc/collections/vec_deque/spec_extend.v
+++ b/CoqOfRust/alloc/collections/vec_deque/spec_extend.v
@@ -75,7 +75,7 @@ Module collections.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -97,8 +97,8 @@ Module collections.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let lower := M.copy (| γ0_0 |) in
                                     let _ :=
                                       M.alloc (|
@@ -146,10 +146,11 @@ Module collections.
                                                     (M.alloc (|
                                                       BinOp.Pure.lt
                                                         (M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "alloc::collections::vec_deque::VecDeque"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "alloc::collections::vec_deque::VecDeque",
                                                             "len"
+                                                          |)
                                                         |))
                                                         (M.call_closure (|
                                                           M.get_associated_function (|
@@ -185,7 +186,7 @@ Module collections.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -314,8 +315,8 @@ Module collections.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let low := M.copy (| γ0_0 |) in
                         let high := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -325,7 +326,7 @@ Module collections.
                               ltac:(M.monadic
                                 (let γ := high in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -349,8 +350,10 @@ Module collections.
                                               [
                                                 fun γ =>
                                                   ltac:(M.monadic
-                                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                                    (let γ0_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ0_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let left_val := M.copy (| γ0_0 |) in
                                                     let right_val := M.copy (| γ0_1 |) in
                                                     M.match_operator (|
@@ -516,10 +519,11 @@ Module collections.
                                           [
                                             M.read (| self |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::collections::vec_deque::VecDeque"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::collections::vec_deque::VecDeque",
                                                 "len"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -546,8 +550,10 @@ Module collections.
                                               [
                                                 fun γ =>
                                                   ltac:(M.monadic
-                                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                                    (let γ0_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ0_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let left_val := M.copy (| γ0_0 |) in
                                                     let right_val := M.copy (| γ0_1 |) in
                                                     M.match_operator (|
@@ -758,10 +764,11 @@ Module collections.
                             [
                               M.read (| self |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::collections::vec_deque::VecDeque"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::collections::vec_deque::VecDeque",
                                   "len"
+                                |)
                               |)
                             ]
                           |);
@@ -771,10 +778,11 @@ Module collections.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::collections::vec_deque::VecDeque"
-                        "len" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::collections::vec_deque::VecDeque",
+                        "len"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.add (|
@@ -948,10 +956,11 @@ Module collections.
                           [
                             M.read (| self |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::collections::vec_deque::VecDeque"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::collections::vec_deque::VecDeque",
                                 "len"
+                              |)
                             |)
                           ]
                         |);
@@ -961,10 +970,11 @@ Module collections.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::collections::vec_deque::VecDeque"
-                      "len" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::collections::vec_deque::VecDeque",
+                      "len"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Panic.add (|

--- a/CoqOfRust/alloc/ffi/c_str.v
+++ b/CoqOfRust/alloc/ffi/c_str.v
@@ -52,8 +52,16 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner";
-                M.get_struct_record_field (M.read (| other |)) "alloc::ffi::c_str::CString" "inner"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -92,8 +100,16 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner";
-                M.get_struct_record_field (M.read (| other |)) "alloc::ffi::c_str::CString" "inner"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -166,8 +182,16 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner";
-                M.get_struct_record_field (M.read (| other |)) "alloc::ffi::c_str::CString" "inner"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -202,7 +226,11 @@ Module ffi.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::CString",
+                  "inner"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -244,10 +272,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::ffi::c_str::CString"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::ffi::c_str::CString",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -287,7 +316,13 @@ Module ffi.
               [
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::NulError",
+                      0
+                    |)
+                  ]
                 |);
                 M.call_closure (|
                   M.get_trait_method (|
@@ -299,7 +334,13 @@ Module ffi.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 1 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::NulError",
+                      1
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -337,10 +378,18 @@ Module ffi.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::NulError",
+                    0
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_tuple_field (M.read (| other |)) "alloc::ffi::c_str::NulError" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| other |),
+                    "alloc::ffi::c_str::NulError",
+                    0
+                  |)
                 |)),
               ltac:(M.monadic
                 (M.call_closure (|
@@ -358,8 +407,16 @@ Module ffi.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 1;
-                    M.get_struct_tuple_field (M.read (| other |)) "alloc::ffi::c_str::NulError" 1
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::NulError",
+                      1
+                    |);
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| other |),
+                      "alloc::ffi::c_str::NulError",
+                      1
+                    |)
                   ]
                 |)))
             |)))
@@ -440,11 +497,19 @@ Module ffi.
                 M.read (| Value.String "NulError" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 0);
+                  (M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::NulError",
+                    0
+                  |));
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 1
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::NulError",
+                      1
+                    |)
                   |))
               ]
             |)))
@@ -496,7 +561,7 @@ Module ffi.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "alloc::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                           0
@@ -592,11 +657,11 @@ Module ffi.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "alloc::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                                   0
@@ -604,7 +669,7 @@ Module ffi.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "alloc::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                                   0
@@ -689,7 +754,7 @@ Module ffi.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "alloc::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                           0
@@ -770,10 +835,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::ffi::c_str::FromVecWithNulError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::ffi::c_str::FromVecWithNulError",
                         "error_kind"
+                      |)
                     ]
                   |));
                 ("bytes",
@@ -788,10 +854,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::ffi::c_str::FromVecWithNulError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::ffi::c_str::FromVecWithNulError",
                         "bytes"
+                      |)
                     ]
                   |))
               ]))
@@ -837,14 +904,16 @@ Module ffi.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::ffi::c_str::FromVecWithNulError"
-                    "error_kind";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::ffi::c_str::FromVecWithNulError"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::FromVecWithNulError",
                     "error_kind"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::ffi::c_str::FromVecWithNulError",
+                    "error_kind"
+                  |)
                 ]
               |),
               ltac:(M.monadic
@@ -863,14 +932,16 @@ Module ffi.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::ffi::c_str::FromVecWithNulError"
-                      "bytes";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "alloc::ffi::c_str::FromVecWithNulError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::FromVecWithNulError",
                       "bytes"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "alloc::ffi::c_str::FromVecWithNulError",
+                      "bytes"
+                    |)
                   ]
                 |)))
             |)))
@@ -952,18 +1023,20 @@ Module ffi.
                 M.read (| Value.String "error_kind" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::ffi::c_str::FromVecWithNulError"
-                    "error_kind");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::FromVecWithNulError",
+                    "error_kind"
+                  |));
                 M.read (| Value.String "bytes" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::ffi::c_str::FromVecWithNulError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::FromVecWithNulError",
                       "bytes"
+                    |)
                   |))
               ]
             |)))
@@ -1002,10 +1075,11 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::ffi::c_str::FromVecWithNulError"
-                  "bytes";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::FromVecWithNulError",
+                  "bytes"
+                |);
                 Value.StructTuple "core::ops::range::RangeFull" []
               ]
             |)))
@@ -1025,7 +1099,11 @@ Module ffi.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field self "alloc::ffi::c_str::FromVecWithNulError" "bytes"
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "alloc::ffi::c_str::FromVecWithNulError",
+                "bytes"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -1066,10 +1144,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::ffi::c_str::IntoStringError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::ffi::c_str::IntoStringError",
                         "inner"
+                      |)
                     ]
                   |));
                 ("error",
@@ -1082,10 +1161,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::ffi::c_str::IntoStringError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::ffi::c_str::IntoStringError",
                         "error"
+                      |)
                     ]
                   |))
               ]))
@@ -1131,14 +1211,16 @@ Module ffi.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::ffi::c_str::IntoStringError"
-                    "inner";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::ffi::c_str::IntoStringError"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::IntoStringError",
                     "inner"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::ffi::c_str::IntoStringError",
+                    "inner"
+                  |)
                 ]
               |),
               ltac:(M.monadic
@@ -1151,14 +1233,16 @@ Module ffi.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::ffi::c_str::IntoStringError"
-                      "error";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "alloc::ffi::c_str::IntoStringError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::IntoStringError",
                       "error"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "alloc::ffi::c_str::IntoStringError",
+                      "error"
+                    |)
                   ]
                 |)))
             |)))
@@ -1240,18 +1324,20 @@ Module ffi.
                 M.read (| Value.String "inner" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::ffi::c_str::IntoStringError"
-                    "inner");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::IntoStringError",
+                    "inner"
+                  |));
                 M.read (| Value.String "error" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::ffi::c_str::IntoStringError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::ffi::c_str::IntoStringError",
                       "error"
+                    |)
                   |))
               ]
             |)))
@@ -1788,8 +1874,8 @@ Module ffi.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let left_val := M.copy (| γ0_0 |) in
                                   let right_val := M.copy (| γ0_1 |) in
                                   M.match_operator (|
@@ -1926,7 +2012,11 @@ Module ffi.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::CString",
+                    "inner"
+                  |)
                 |);
                 Value.StructRecord
                   "core::ops::range::RangeTo"
@@ -1941,10 +2031,11 @@ Module ffi.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::ffi::c_str::CString"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::ffi::c_str::CString",
                                 "inner"
+                              |)
                             |)
                           ]
                         |),
@@ -1969,7 +2060,11 @@ Module ffi.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "alloc::ffi::c_str::CString" "inner"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::ffi::c_str::CString",
+                "inner"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2095,8 +2190,8 @@ Module ffi.
                     ]
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::Deref",
                           Ty.apply
@@ -2107,9 +2202,10 @@ Module ffi.
                           []
                         |),
                         [ this ]
-                      |))
-                      "alloc::ffi::c_str::CString"
+                      |),
+                      "alloc::ffi::c_str::CString",
                       "inner"
+                    |)
                   ]
                 |)
               |)
@@ -2326,7 +2422,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2368,7 +2464,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2442,10 +2538,11 @@ Module ffi.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::ffi::c_str::CString"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::ffi::c_str::CString",
                           "inner"
+                        |)
                       |);
                       Value.Integer Integer.Usize 0
                     ]
@@ -2819,7 +2916,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "alloc::borrow::Cow::Borrowed",
                           0
@@ -2842,7 +2939,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "alloc::borrow::Cow::Owned",
                           0
@@ -2991,9 +3088,9 @@ Module ffi.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let ptr := M.copy (| γ0_0 |) in
                           let len := M.copy (| γ0_1 |) in
                           let cap := M.copy (| γ0_2 |) in
@@ -3660,7 +3757,11 @@ Module ffi.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_tuple_field (M.read (| self |)) "alloc::ffi::c_str::NulError" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "alloc::ffi::c_str::NulError",
+                0
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3678,7 +3779,9 @@ Module ffi.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "alloc::ffi::c_str::NulError" 1 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "alloc::ffi::c_str::NulError", 1 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -3728,10 +3831,11 @@ Module ffi.
                                 [ Ty.path "usize" ]
                               |),
                               [
-                                M.get_struct_tuple_field
-                                  (M.read (| self |))
-                                  "alloc::ffi::c_str::NulError"
+                                M.SubPointer.get_struct_tuple_field (|
+                                  M.read (| self |),
+                                  "alloc::ffi::c_str::NulError",
                                   0
+                                |)
                               ]
                             |)
                           ]
@@ -3774,15 +3878,16 @@ Module ffi.
             let f := M.alloc (| f |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::ffi::c_str::FromVecWithNulError"
-                  "error_kind",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::ffi::c_str::FromVecWithNulError",
+                  "error_kind"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "alloc::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                           0
@@ -3896,7 +4001,11 @@ Module ffi.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field self "alloc::ffi::c_str::IntoStringError" "inner"
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "alloc::ffi::c_str::IntoStringError",
+                "inner"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3915,10 +4024,11 @@ Module ffi.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::ffi::c_str::IntoStringError"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::ffi::c_str::IntoStringError",
                 "error"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -4066,10 +4176,11 @@ Module ffi.
                           ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| target |))
-                            "alloc::ffi::c_str::CString"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| target |),
+                            "alloc::ffi::c_str::CString",
                             "inner"
+                          |)
                         ]
                       |)
                     ]
@@ -4100,10 +4211,11 @@ Module ffi.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| target |))
-                    "alloc::ffi::c_str::CString"
-                    "inner",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| target |),
+                    "alloc::ffi::c_str::CString",
+                    "inner"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -4372,10 +4484,11 @@ Module ffi.
               [
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::ffi::c_str::IntoStringError"
-                    "error")
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::ffi::c_str::IntoStringError",
+                    "error"
+                  |))
               ]))
         | _, _ => M.impossible
         end.

--- a/CoqOfRust/alloc/raw_vec.v
+++ b/CoqOfRust/alloc/raw_vec.v
@@ -454,8 +454,8 @@ Module raw_vec.
                   M.call_closure (|
                     M.get_function (| "core::ptr::read", [ A ] |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -466,9 +466,10 @@ Module raw_vec.
                             []
                           |),
                           [ me ]
-                        |))
-                        "alloc::raw_vec::RawVec"
+                        |),
+                        "alloc::raw_vec::RawVec",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -575,7 +576,7 @@ Module raw_vec.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -585,7 +586,7 @@ Module raw_vec.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -622,7 +623,7 @@ Module raw_vec.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::result::Result::Ok",
                                   0
@@ -631,7 +632,7 @@ Module raw_vec.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::result::Result::Err",
                                   0
@@ -690,7 +691,7 @@ Module raw_vec.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -700,7 +701,7 @@ Module raw_vec.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -817,7 +818,11 @@ Module raw_vec.
             |),
             [
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "alloc::raw_vec::RawVec" "ptr"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::raw_vec::RawVec",
+                  "ptr"
+                |)
               |)
             ]
           |)))
@@ -851,7 +856,11 @@ Module raw_vec.
                     M.get_constant (| "core::num::MAX" |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (M.get_struct_record_field (M.read (| self |)) "alloc::raw_vec::RawVec" "cap"))
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::raw_vec::RawVec",
+                      "cap"
+                    |)))
               ]
             |)
           |)))
@@ -873,7 +882,11 @@ Module raw_vec.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field (M.read (| self |)) "alloc::raw_vec::RawVec" "alloc"))
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "alloc::raw_vec::RawVec",
+            "alloc"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -922,10 +935,11 @@ Module raw_vec.
                             ltac:(M.monadic
                               (BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::raw_vec::RawVec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::raw_vec::RawVec",
                                     "cap"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)))
                           |)
@@ -960,10 +974,11 @@ Module raw_vec.
                                       []
                                     |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::raw_vec::RawVec"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::raw_vec::RawVec",
                                         "cap"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -1008,10 +1023,11 @@ Module raw_vec.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::raw_vec::RawVec"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::raw_vec::RawVec",
                                                   "ptr"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -1211,7 +1227,7 @@ Module raw_vec.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1250,7 +1266,7 @@ Module raw_vec.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1409,7 +1425,7 @@ Module raw_vec.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1448,7 +1464,7 @@ Module raw_vec.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1583,7 +1599,11 @@ Module raw_vec.
           M.read (|
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "alloc::raw_vec::RawVec" "ptr",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::raw_vec::RawVec",
+                  "ptr"
+                |),
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "core::ptr::unique::Unique") [ T ],
@@ -1615,7 +1635,11 @@ Module raw_vec.
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "alloc::raw_vec::RawVec" "cap",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::raw_vec::RawVec",
+                  "cap"
+                |),
                 M.read (| cap |)
               |) in
             M.alloc (| Value.Tuple [] |)
@@ -1794,7 +1818,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1833,7 +1857,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1850,10 +1874,11 @@ Module raw_vec.
                       [
                         BinOp.Panic.mul (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::raw_vec::RawVec"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::raw_vec::RawVec",
                               "cap"
+                            |)
                           |),
                           Value.Integer Integer.Usize 2
                         |);
@@ -1914,10 +1939,11 @@ Module raw_vec.
                                   |),
                                   [ M.read (| self |) ]
                                 |);
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::raw_vec::RawVec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::raw_vec::RawVec",
                                   "alloc"
+                                |)
                               ]
                             |)
                           ]
@@ -1927,7 +1953,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1966,7 +1992,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2107,7 +2133,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2146,7 +2172,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2199,10 +2225,11 @@ Module raw_vec.
                                   |),
                                   [ M.read (| self |) ]
                                 |);
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::raw_vec::RawVec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::raw_vec::RawVec",
                                   "alloc"
+                                |)
                               ]
                             |)
                           ]
@@ -2212,7 +2239,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2251,7 +2278,7 @@ Module raw_vec.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2394,7 +2421,7 @@ Module raw_vec.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2417,8 +2444,8 @@ Module raw_vec.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let ptr := M.copy (| γ0_0 |) in
                         let layout := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -2455,10 +2482,11 @@ Module raw_vec.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::raw_vec::RawVec"
-                                                    "alloc";
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::raw_vec::RawVec",
+                                                    "alloc"
+                                                  |);
                                                   M.read (| ptr |);
                                                   M.read (| layout |)
                                                 ]
@@ -2466,10 +2494,11 @@ Module raw_vec.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::raw_vec::RawVec"
-                                                "ptr",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::raw_vec::RawVec",
+                                                "ptr"
+                                              |),
                                               M.call_closure (|
                                                 M.get_associated_function (|
                                                   Ty.apply
@@ -2483,10 +2512,11 @@ Module raw_vec.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::raw_vec::RawVec"
-                                                "cap",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::raw_vec::RawVec",
+                                                "cap"
+                                              |),
                                               Value.Integer Integer.Usize 0
                                             |) in
                                           M.alloc (| Value.Tuple [] |)));
@@ -2599,10 +2629,11 @@ Module raw_vec.
                                                               []
                                                             |),
                                                             [
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "alloc::raw_vec::RawVec"
-                                                                "alloc";
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "alloc::raw_vec::RawVec",
+                                                                "alloc"
+                                                              |);
                                                               M.read (| ptr |);
                                                               M.read (| layout |);
                                                               M.read (| new_layout |)
@@ -2641,7 +2672,7 @@ Module raw_vec.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Break",
                                                           0
@@ -2684,7 +2715,7 @@ Module raw_vec.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                           0
@@ -2832,7 +2863,7 @@ Module raw_vec.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -2873,7 +2904,7 @@ Module raw_vec.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -2917,7 +2948,7 @@ Module raw_vec.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2958,7 +2989,7 @@ Module raw_vec.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2976,13 +3007,13 @@ Module raw_vec.
                         ltac:(M.monadic
                           (let γ := current_memory in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let ptr := M.copy (| γ1_0 |) in
                           let old_layout := M.copy (| γ1_1 |) in
                           let _ :=
@@ -3027,8 +3058,9 @@ Module raw_vec.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let left_val := M.copy (| γ0_0 |) in
                                               let right_val := M.copy (| γ0_1 |) in
                                               M.match_operator (|
@@ -3237,23 +3269,24 @@ Module raw_vec.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
-                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                    let γ1_1 := M.get_tuple_field γ0_0 1 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                     let ptr := M.copy (| γ1_0 |) in
                     let layout := M.copy (| γ1_1 |) in
                     M.alloc (|
                       M.call_closure (|
                         M.get_trait_method (| "core::alloc::Allocator", A, [], "deallocate", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::raw_vec::RawVec"
-                            "alloc";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::raw_vec::RawVec",
+                            "alloc"
+                          |);
                           M.read (| ptr |);
                           M.read (| layout |)
                         ]
@@ -3337,11 +3370,7 @@ Module raw_vec.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|
@@ -3353,13 +3382,9 @@ Module raw_vec.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let γ1_0 :=
-                    M.get_struct_record_field_or_break_match (|
+                    M.SubPointer.get_struct_record_field (|
                       γ0_0,
                       "alloc::collections::TryReserveErrorKind::AllocError",
                       "layout"
@@ -3376,11 +3401,7 @@ Module raw_vec.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (| Value.Tuple [] |)))
             ]
           |)

--- a/CoqOfRust/alloc/rc.v
+++ b/CoqOfRust/alloc/rc.v
@@ -31,8 +31,8 @@ Module rc.
         M.call_closure (|
           M.get_associated_function (| Ty.path "core::alloc::layout::Layout", "pad_to_align", [] |),
           [
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
@@ -67,8 +67,9 @@ Module rc.
                     |)
                   ]
                 |)
-              |))
+              |),
               0
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -546,7 +547,11 @@ Module rc.
                     M.call_closure (|
                       M.get_function (| "core::ptr::write", [ T ] |),
                       [
-                        M.get_struct_record_field (M.read (| inner |)) "alloc::rc::RcBox" "value";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| inner |),
+                          "alloc::rc::RcBox",
+                          "value"
+                        |);
                         M.read (| data |)
                       ]
                     |)
@@ -559,7 +564,13 @@ Module rc.
                         "get",
                         []
                       |),
-                      [ M.get_struct_record_field (M.read (| inner |)) "alloc::rc::RcBox" "strong" ]
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| inner |),
+                          "alloc::rc::RcBox",
+                          "strong"
+                        |)
+                      ]
                     |)
                   |) in
                 let _ :=
@@ -580,8 +591,8 @@ Module rc.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let left_val := M.copy (| γ0_0 |) in
                                     let right_val := M.copy (| γ0_1 |) in
                                     M.match_operator (|
@@ -669,7 +680,11 @@ Module rc.
                         []
                       |),
                       [
-                        M.get_struct_record_field (M.read (| inner |)) "alloc::rc::RcBox" "strong";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| inner |),
+                          "alloc::rc::RcBox",
+                          "strong"
+                        |);
                         Value.Integer Integer.Usize 1
                       ]
                     |)
@@ -1063,7 +1078,7 @@ Module rc.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -1104,7 +1119,7 @@ Module rc.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -1289,7 +1304,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1336,7 +1351,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1517,7 +1532,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1564,7 +1579,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1870,7 +1885,7 @@ Module rc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1911,7 +1926,7 @@ Module rc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1989,8 +2004,8 @@ Module rc.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let left_val := M.copy (| γ0_0 |) in
                                       let right_val := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -2069,10 +2084,11 @@ Module rc.
                           [ Ty.apply (Ty.path "core::cell::Cell") [ Ty.path "usize" ] ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| inner |))
-                            "alloc::rc::RcBox"
-                            "strong";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| inner |),
+                            "alloc::rc::RcBox",
+                            "strong"
+                          |);
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::cell::Cell") [ Ty.path "usize" ],
@@ -2092,7 +2108,11 @@ Module rc.
                           [ Ty.apply (Ty.path "core::cell::Cell") [ Ty.path "usize" ] ]
                         |),
                         [
-                          M.get_struct_record_field (M.read (| inner |)) "alloc::rc::RcBox" "weak";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| inner |),
+                            "alloc::rc::RcBox",
+                            "weak"
+                          |);
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::cell::Cell") [ Ty.path "usize" ],
@@ -2140,7 +2160,7 @@ Module rc.
               "as_ref",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::rc::Rc" "ptr" ]
+            [ M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::rc::Rc", "ptr" |) ]
           |)))
       | _, _ => M.impossible
       end.
@@ -2224,7 +2244,7 @@ Module rc.
       | [], [ this ] =>
         ltac:(M.monadic
           (let this := M.alloc (| this |) in
-          M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "alloc"))
+          M.SubPointer.get_struct_record_field (| M.read (| this |), "alloc::rc::Rc", "alloc" |)))
       | _, _ => M.impossible
       end.
     
@@ -2265,21 +2285,13 @@ Module rc.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let m := M.copy (| γ0_0 |) in
                     m));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (|
                       M.never_to_any (|
                         M.call_closure (|
@@ -2636,7 +2648,7 @@ Module rc.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -2675,7 +2687,7 @@ Module rc.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2691,8 +2703,8 @@ Module rc.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let ptr := M.copy (| γ0_0 |) in
                         let alloc := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -2892,7 +2904,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2939,7 +2951,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -3115,7 +3127,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -3162,7 +3174,7 @@ Module rc.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -3290,7 +3302,13 @@ Module rc.
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (| "core::ptr::read", [ A ] |),
-                          [ M.get_struct_record_field this "alloc::rc::Rc" "alloc" ]
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              this,
+                              "alloc::rc::Rc",
+                              "alloc"
+                            |)
+                          ]
                         |)
                       |) in
                     let _ :=
@@ -3321,7 +3339,13 @@ Module rc.
                           "alloc::rc::Weak"
                           [
                             ("ptr",
-                              M.read (| M.get_struct_record_field this "alloc::rc::Rc" "ptr" |));
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  this,
+                                  "alloc::rc::Rc",
+                                  "ptr"
+                                |)
+                              |));
                             ("alloc", M.read (| alloc |))
                           ]
                       |) in
@@ -3460,14 +3484,25 @@ Module rc.
                     "as_ptr",
                     []
                   |),
-                  [ M.read (| M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "ptr" |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::rc::Rc",
+                        "ptr"
+                      |)
+                    |)
                   ]
                 |)
               |) in
             M.alloc (|
               (* MutToConstPointer *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| ptr |)) "alloc::rc::RcBox" "value")
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| ptr |),
+                  "alloc::rc::RcBox",
+                  "value"
+                |))
             |)
           |)))
       | _, _ => M.impossible
@@ -3607,10 +3642,11 @@ Module rc.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| this |))
-                                                      "alloc::rc::Rc"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| this |),
+                                                      "alloc::rc::Rc",
                                                       "ptr"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -3648,12 +3684,22 @@ Module rc.
                 [
                   ("ptr",
                     M.read (|
-                      M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::rc::Rc",
+                        "ptr"
+                      |)
                     |));
                   ("alloc",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                      [ M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "alloc" ]
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| this |),
+                          "alloc::rc::Rc",
+                          "alloc"
+                        |)
+                      ]
                     |))
                 ]
             |)
@@ -3958,8 +4004,8 @@ Module rc.
       | [], [ this ] =>
         ltac:(M.monadic
           (let this := M.alloc (| this |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply
                   (Ty.path "core::ptr::non_null::NonNull")
@@ -3967,10 +4013,19 @@ Module rc.
                 "as_ptr",
                 []
               |),
-              [ M.read (| M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "ptr" |) ]
-            |))
-            "alloc::rc::RcBox"
-            "value"))
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| this |),
+                    "alloc::rc::Rc",
+                    "ptr"
+                  |)
+                |)
+              ]
+            |),
+            "alloc::rc::RcBox",
+            "value"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -4009,7 +4064,14 @@ Module rc.
                     "as_ptr",
                     []
                   |),
-                  [ M.read (| M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "ptr" |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::rc::Rc",
+                        "ptr"
+                      |)
+                    |)
                   ]
                 |));
               (* MutToConstPointer *)
@@ -4024,7 +4086,11 @@ Module rc.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "alloc::rc::Rc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::rc::Rc",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |))
@@ -4109,10 +4175,11 @@ Module rc.
                               M.call_closure (|
                                 M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| this |))
-                                    "alloc::rc::Rc"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| this |),
+                                    "alloc::rc::Rc",
                                     "alloc"
+                                  |)
                                 ]
                               |)
                             ]
@@ -4224,10 +4291,11 @@ Module rc.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| this |))
-                                            "alloc::rc::Rc"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| this |),
+                                            "alloc::rc::Rc",
                                             "alloc"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -4362,8 +4430,8 @@ Module rc.
                 ]
               |) in
             M.alloc (|
-              M.get_struct_record_field
-                (M.call_closure (|
+              M.SubPointer.get_struct_record_field (|
+                M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
                       (Ty.path "core::ptr::non_null::NonNull")
@@ -4371,10 +4439,17 @@ Module rc.
                     "as_mut",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| this |)) "alloc::rc::Rc" "ptr" ]
-                |))
-                "alloc::rc::RcBox"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| this |),
+                      "alloc::rc::Rc",
+                      "ptr"
+                    |)
+                  ]
+                |),
+                "alloc::rc::RcBox",
                 "value"
+              |)
             |)
           |)))
       | _, _ => M.impossible
@@ -4622,7 +4697,11 @@ Module rc.
                       (M.read (|
                         M.use
                           (M.alloc (|
-                            M.get_struct_record_field (M.read (| ptr |)) "alloc::rc::RcBox" "value"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| ptr |),
+                              "alloc::rc::RcBox",
+                              "value"
+                            |)
                           |))
                       |));
                     M.read (| value_size |)
@@ -4643,8 +4722,8 @@ Module rc.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let bptr := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     let src :=
@@ -5105,7 +5184,11 @@ Module rc.
                       (M.read (|
                         M.use
                           (M.alloc (|
-                            M.get_struct_record_field (M.read (| ptr |)) "alloc::rc::RcBox" "value"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| ptr |),
+                              "alloc::rc::RcBox",
+                              "value"
+                            |)
                           |))
                       |));
                     M.call_closure (|
@@ -5220,7 +5303,11 @@ Module rc.
                   (M.read (|
                     M.use
                       (M.alloc (|
-                        M.get_struct_record_field (M.read (| ptr |)) "alloc::rc::RcBox" "value"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| ptr |),
+                          "alloc::rc::RcBox",
+                          "value"
+                        |)
                       |))
                   |))
               |) in
@@ -5302,13 +5389,13 @@ Module rc.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let i := M.copy (| γ1_0 |) in
                                       let item := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -5330,10 +5417,11 @@ Module rc.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            guard
-                                            "alloc::rc::from_iter_exact::Guard"
-                                            "n_elems" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            guard,
+                                            "alloc::rc::from_iter_exact::Guard",
+                                            "n_elems"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -5792,8 +5880,8 @@ Module rc.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::deref::Deref",
                               Ty.apply
@@ -5813,17 +5901,18 @@ Module rc.
                               []
                             |),
                             [ md_self ]
-                          |))
-                          "alloc::rc::Rc"
+                          |),
+                          "alloc::rc::Rc",
                           "ptr"
+                        |)
                       |)
                     ]
                   |);
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -5841,9 +5930,10 @@ Module rc.
                             []
                           |),
                           [ md_self ]
-                        |))
-                        "alloc::rc::Rc"
+                        |),
+                        "alloc::rc::Rc",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -5935,8 +6025,8 @@ Module rc.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_trait_method (|
                                 "core::ops::deref::Deref",
                                 Ty.apply
@@ -5960,17 +6050,18 @@ Module rc.
                                 []
                               |),
                               [ md_self ]
-                            |))
-                            "alloc::rc::Rc"
+                            |),
+                            "alloc::rc::Rc",
                             "ptr"
+                          |)
                         |)
                       ]
                     |));
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -5994,9 +6085,10 @@ Module rc.
                             []
                           |),
                           [ md_self ]
-                        |))
-                        "alloc::rc::Rc"
+                        |),
+                        "alloc::rc::Rc",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -6084,14 +6176,28 @@ Module rc.
                             "cast",
                             [ Ty.apply (Ty.path "alloc::rc::RcBox") [ T ] ]
                           |),
-                          [ M.read (| M.get_struct_record_field self "alloc::rc::Rc" "ptr" |) ]
+                          [
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::rc::Rc",
+                                "ptr"
+                              |)
+                            |)
+                          ]
                         |)
                       |) in
                     let alloc :=
                       M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                          [ M.get_struct_record_field self "alloc::rc::Rc" "alloc" ]
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::rc::Rc",
+                              "alloc"
+                            |)
+                          ]
                         |)
                       |) in
                     let _ :=
@@ -6170,14 +6276,18 @@ Module rc.
                     "cast",
                     [ Ty.apply (Ty.path "alloc::rc::RcBox") [ T ] ]
                   |),
-                  [ M.read (| M.get_struct_record_field self "alloc::rc::Rc" "ptr" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (| self, "alloc::rc::Rc", "ptr" |)
+                    |)
+                  ]
                 |)
               |) in
             let alloc :=
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                  [ M.get_struct_record_field self "alloc::rc::Rc" "alloc" ]
+                  [ M.SubPointer.get_struct_record_field (| self, "alloc::rc::Rc", "alloc" |) ]
                 |)
               |) in
             let _ :=
@@ -6339,17 +6449,18 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply (Ty.path "alloc::rc::Rc") [ T; A ],
                 "inner",
                 []
               |),
               [ M.read (| self |) ]
-            |))
-            "alloc::rc::RcBox"
-            "value"))
+            |),
+            "alloc::rc::RcBox",
+            "value"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -6539,10 +6650,11 @@ Module rc.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::rc::Rc"
-                                      "alloc";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::rc::Rc",
+                                      "alloc"
+                                    |);
                                     M.call_closure (|
                                       M.get_associated_function (|
                                         Ty.apply
@@ -6553,10 +6665,11 @@ Module rc.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::rc::Rc"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::rc::Rc",
                                             "ptr"
+                                          |)
                                         |)
                                       ]
                                     |);
@@ -6576,10 +6689,11 @@ Module rc.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::rc::Rc"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::rc::Rc",
                                               "ptr"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -6655,10 +6769,22 @@ Module rc.
                   []
                 |),
                 [
-                  M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::rc::Rc" "ptr" |);
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::rc::Rc",
+                      "ptr"
+                    |)
+                  |);
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                    [ M.get_struct_record_field (M.read (| self |)) "alloc::rc::Rc" "alloc" ]
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::rc::Rc",
+                        "alloc"
+                      |)
+                    ]
                   |)
                 ]
               |)
@@ -7792,10 +7918,10 @@ Module rc.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let vec_ptr := M.copy (| γ0_0 |) in
                     let len := M.copy (| γ0_1 |) in
                     let cap := M.copy (| γ0_2 |) in
@@ -7823,10 +7949,11 @@ Module rc.
                               (M.read (|
                                 M.use
                                   (M.alloc (|
-                                    M.get_struct_record_field
-                                      (M.read (| rc_ptr |))
-                                      "alloc::rc::RcBox"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| rc_ptr |),
+                                      "alloc::rc::RcBox",
                                       "value"
+                                    |)
                                   |))
                               |));
                             M.read (| len |)
@@ -7908,7 +8035,7 @@ Module rc.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -7929,11 +8056,7 @@ Module rc.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let s := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -8296,8 +8419,8 @@ Module rc.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let low := M.copy (| γ0_0 |) in
                     let high := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -8307,7 +8430,7 @@ Module rc.
                           ltac:(M.monadic
                             (let γ := high in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -8331,8 +8454,10 @@ Module rc.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let left_val := M.copy (| γ0_0 |) in
                                                 let right_val := M.copy (| γ0_1 |) in
                                                 M.match_operator (|
@@ -8733,7 +8858,11 @@ Module rc.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::rc::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::rc::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |)
@@ -8761,7 +8890,11 @@ Module rc.
                     (M.alloc (|
                       (* MutToConstPointer *)
                       M.pointer_coercion
-                        (M.get_struct_record_field (M.read (| ptr |)) "alloc::rc::RcBox" "value")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| ptr |),
+                          "alloc::rc::RcBox",
+                          "value"
+                        |))
                     |)))
               ]
             |)
@@ -8850,7 +8983,7 @@ Module rc.
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                  [ M.get_struct_record_field self "alloc::rc::Weak" "alloc" ]
+                  [ M.SubPointer.get_struct_record_field (| self, "alloc::rc::Weak", "alloc" |) ]
                 |)
               |) in
             let _ :=
@@ -9023,7 +9156,7 @@ Module rc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -9056,7 +9189,7 @@ Module rc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -9117,10 +9250,11 @@ Module rc.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::rc::Weak"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::rc::Weak",
                                       "ptr"
+                                    |)
                                   |);
                                   M.call_closure (|
                                     M.get_trait_method (|
@@ -9131,10 +9265,11 @@ Module rc.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::rc::Weak"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::rc::Weak",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -9181,7 +9316,7 @@ Module rc.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9247,7 +9382,7 @@ Module rc.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9351,10 +9486,11 @@ Module rc.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::rc::Weak"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::rc::Weak",
                                       "ptr"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -9382,10 +9518,11 @@ Module rc.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::rc::Weak"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::rc::Weak",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -9395,15 +9532,17 @@ Module rc.
                                 "alloc::rc::WeakInner"
                                 [
                                   ("strong",
-                                    M.get_struct_record_field
-                                      (M.read (| ptr |))
-                                      "alloc::rc::RcBox"
-                                      "strong");
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| ptr |),
+                                      "alloc::rc::RcBox",
+                                      "strong"
+                                    |));
                                   ("weak",
-                                    M.get_struct_record_field
-                                      (M.read (| ptr |))
-                                      "alloc::rc::RcBox"
-                                      "weak")
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| ptr |),
+                                      "alloc::rc::RcBox",
+                                      "weak"
+                                    |))
                                 ]
                             |)
                           |)
@@ -9452,7 +9591,11 @@ Module rc.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::rc::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::rc::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |));
@@ -9468,7 +9611,11 @@ Module rc.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "alloc::rc::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::rc::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |))
@@ -9570,7 +9717,7 @@ Module rc.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -9632,10 +9779,11 @@ Module rc.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::rc::Weak"
-                                  "alloc";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::rc::Weak",
+                                  "alloc"
+                                |);
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply
@@ -9646,10 +9794,11 @@ Module rc.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::rc::Weak"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::rc::Weak",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |);
@@ -9672,10 +9821,11 @@ Module rc.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::rc::Weak"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::rc::Weak",
                                               "ptr"
+                                            |)
                                           |)
                                         ]
                                       |))
@@ -9738,7 +9888,7 @@ Module rc.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -9765,12 +9915,22 @@ Module rc.
                 [
                   ("ptr",
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::rc::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::rc::Weak",
+                        "ptr"
+                      |)
                     |));
                   ("alloc",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                      [ M.get_struct_record_field (M.read (| self |)) "alloc::rc::Weak" "alloc" ]
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::rc::Weak",
+                          "alloc"
+                        |)
+                      ]
                     |))
                 ]
             |)
@@ -10142,7 +10302,7 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field (M.read (| self |)) "alloc::rc::RcBox" "weak"))
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::rc::RcBox", "weak" |)))
       | _, _ => M.impossible
       end.
     
@@ -10157,7 +10317,11 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field (M.read (| self |)) "alloc::rc::RcBox" "strong"))
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "alloc::rc::RcBox",
+            "strong"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -10187,7 +10351,13 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::rc::WeakInner" "weak" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "alloc::rc::WeakInner",
+              "weak"
+            |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -10202,7 +10372,11 @@ Module rc.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "alloc::rc::WeakInner" "strong"
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "alloc::rc::WeakInner",
+              "strong"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -10414,12 +10588,20 @@ Module rc.
               M.read (| Value.String "ptr" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| self |)) "alloc::rc::UniqueRc" "ptr");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::rc::UniqueRc",
+                  "ptr"
+                |));
               M.read (| Value.String "phantom" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "alloc::rc::UniqueRc" "phantom"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::rc::UniqueRc",
+                    "phantom"
+                  |)
                 |))
             ]
           |)))
@@ -10573,7 +10755,12 @@ Module rc.
                           "as_ref",
                           []
                         |),
-                        [ M.get_struct_record_field (M.read (| this |)) "alloc::rc::UniqueRc" "ptr"
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| this |),
+                            "alloc::rc::UniqueRc",
+                            "ptr"
+                          |)
                         ]
                       |)
                     ]
@@ -10586,7 +10773,11 @@ Module rc.
                 [
                   ("ptr",
                     M.read (|
-                      M.get_struct_record_field (M.read (| this |)) "alloc::rc::UniqueRc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::rc::UniqueRc",
+                        "ptr"
+                      |)
                     |));
                   ("alloc", Value.StructTuple "alloc::alloc::Global" [])
                 ]
@@ -10639,8 +10830,8 @@ Module rc.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply
                             (Ty.path "core::ptr::non_null::NonNull")
@@ -10649,8 +10840,8 @@ Module rc.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_trait_method (|
                                 "core::ops::deref::DerefMut",
                                 Ty.apply
@@ -10661,13 +10852,15 @@ Module rc.
                                 []
                               |),
                               [ this ]
-                            |))
-                            "alloc::rc::UniqueRc"
+                            |),
+                            "alloc::rc::UniqueRc",
                             "ptr"
+                          |)
                         ]
-                      |))
-                      "alloc::rc::RcBox"
-                      "strong";
+                      |),
+                      "alloc::rc::RcBox",
+                      "strong"
+                    |);
                     Value.Integer Integer.Usize 1
                   ]
                 |)
@@ -10681,8 +10874,8 @@ Module rc.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::Deref",
                           Ty.apply
@@ -10693,9 +10886,10 @@ Module rc.
                           []
                         |),
                         [ this ]
-                      |))
-                      "alloc::rc::UniqueRc"
+                      |),
+                      "alloc::rc::UniqueRc",
                       "ptr"
+                    |)
                   |)
                 ]
               |)
@@ -10727,8 +10921,8 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply
                   (Ty.path "core::ptr::non_null::NonNull")
@@ -10736,10 +10930,17 @@ Module rc.
                 "as_ref",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::rc::UniqueRc" "ptr" ]
-            |))
-            "alloc::rc::RcBox"
-            "value"))
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::rc::UniqueRc",
+                  "ptr"
+                |)
+              ]
+            |),
+            "alloc::rc::RcBox",
+            "value"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -10770,8 +10971,8 @@ Module rc.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply
                   (Ty.path "core::ptr::non_null::NonNull")
@@ -10781,12 +10982,17 @@ Module rc.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "alloc::rc::UniqueRc" "ptr"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::rc::UniqueRc",
+                    "ptr"
+                  |)
                 |)
               ]
-            |))
-            "alloc::rc::RcBox"
-            "value"))
+            |),
+            "alloc::rc::RcBox",
+            "value"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -10861,7 +11067,13 @@ Module rc.
                         "as_ref",
                         []
                       |),
-                      [ M.get_struct_record_field (M.read (| self |)) "alloc::rc::UniqueRc" "ptr" ]
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::rc::UniqueRc",
+                          "ptr"
+                        |)
+                      ]
                     |)
                   ]
                 |)
@@ -10893,10 +11105,11 @@ Module rc.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::rc::UniqueRc"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::rc::UniqueRc",
                                       "ptr"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -10926,10 +11139,11 @@ Module rc.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::rc::UniqueRc"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::rc::UniqueRc",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |);
@@ -10949,10 +11163,11 @@ Module rc.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::rc::UniqueRc"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::rc::UniqueRc",
                                       "ptr"
+                                    |)
                                   ]
                                 |)
                               ]

--- a/CoqOfRust/alloc/slice.v
+++ b/CoqOfRust/alloc/slice.v
@@ -39,8 +39,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let b := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -163,10 +163,11 @@ Module slice.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          guard
-                          "alloc::slice::hack::to_vec::DropGuard"
+                        M.SubPointer.get_struct_record_field (|
+                          guard,
+                          "alloc::slice::hack::to_vec::DropGuard",
                           "vec"
+                        |)
                       |)
                     ]
                   |)
@@ -274,21 +275,22 @@ Module slice.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let i := M.copy (| γ1_0 |) in
                                         let b := M.copy (| γ1_1 |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              guard
-                                              "alloc::slice::hack::to_vec::DropGuard"
-                                              "num_init",
+                                            M.SubPointer.get_struct_record_field (|
+                                              guard,
+                                              "alloc::slice::hack::to_vec::DropGuard",
+                                              "num_init"
+                                            |),
                                             M.read (| i |)
                                           |) in
                                         let _ :=
@@ -302,7 +304,10 @@ Module slice.
                                                 []
                                               |),
                                               [
-                                                M.get_array_field (| M.read (| slots |), i |);
+                                                M.SubPointer.get_array_field (|
+                                                  M.read (| slots |),
+                                                  i
+                                                |);
                                                 M.call_closure (|
                                                   M.get_trait_method (|
                                                     "core::clone::Clone",
@@ -984,8 +989,15 @@ Module slice.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let i := M.copy (| γ0_0 |) in
                                                                 let k := M.copy (| γ0_1 |) in
                                                                 Value.Tuple
@@ -1095,7 +1107,7 @@ Module slice.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -1103,8 +1115,8 @@ Module slice.
                                                             let i := M.copy (| γ0_0 |) in
                                                             let index :=
                                                               M.copy (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::Index",
                                                                       Ty.apply
@@ -1120,8 +1132,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
+                                                                  |),
                                                                   1
+                                                                |)
                                                               |) in
                                                             let _ :=
                                                               M.loop (|
@@ -1150,8 +1163,8 @@ Module slice.
                                                                             M.write (|
                                                                               index,
                                                                               M.read (|
-                                                                                M.get_tuple_field
-                                                                                  (M.call_closure (|
+                                                                                M.SubPointer.get_tuple_field (|
+                                                                                  M.call_closure (|
                                                                                     M.get_trait_method (|
                                                                                       "core::ops::index::Index",
                                                                                       Ty.apply
@@ -1181,8 +1194,9 @@ Module slice.
                                                                                           index
                                                                                         |))
                                                                                     ]
-                                                                                  |))
+                                                                                  |),
                                                                                   1
+                                                                                |)
                                                                               |)
                                                                             |) in
                                                                           M.alloc (|
@@ -1212,8 +1226,8 @@ Module slice.
                                                               |) in
                                                             let _ :=
                                                               M.write (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::IndexMut",
                                                                       Ty.apply
@@ -1229,8 +1243,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
-                                                                  1,
+                                                                  |),
+                                                                  1
+                                                                |),
                                                                 M.read (| index |)
                                                               |) in
                                                             let _ :=
@@ -1404,8 +1419,15 @@ Module slice.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let i := M.copy (| γ0_0 |) in
                                                                 let k := M.copy (| γ0_1 |) in
                                                                 Value.Tuple
@@ -1515,7 +1537,7 @@ Module slice.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -1523,8 +1545,8 @@ Module slice.
                                                             let i := M.copy (| γ0_0 |) in
                                                             let index :=
                                                               M.copy (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::Index",
                                                                       Ty.apply
@@ -1540,8 +1562,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
+                                                                  |),
                                                                   1
+                                                                |)
                                                               |) in
                                                             let _ :=
                                                               M.loop (|
@@ -1570,8 +1593,8 @@ Module slice.
                                                                             M.write (|
                                                                               index,
                                                                               M.read (|
-                                                                                M.get_tuple_field
-                                                                                  (M.call_closure (|
+                                                                                M.SubPointer.get_tuple_field (|
+                                                                                  M.call_closure (|
                                                                                     M.get_trait_method (|
                                                                                       "core::ops::index::Index",
                                                                                       Ty.apply
@@ -1601,8 +1624,9 @@ Module slice.
                                                                                           index
                                                                                         |))
                                                                                     ]
-                                                                                  |))
+                                                                                  |),
                                                                                   1
+                                                                                |)
                                                                               |)
                                                                             |) in
                                                                           M.alloc (|
@@ -1632,8 +1656,8 @@ Module slice.
                                                               |) in
                                                             let _ :=
                                                               M.write (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::IndexMut",
                                                                       Ty.apply
@@ -1649,8 +1673,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
-                                                                  1,
+                                                                  |),
+                                                                  1
+                                                                |),
                                                                 M.read (| index |)
                                                               |) in
                                                             let _ :=
@@ -1824,8 +1849,15 @@ Module slice.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let i := M.copy (| γ0_0 |) in
                                                                 let k := M.copy (| γ0_1 |) in
                                                                 Value.Tuple
@@ -1935,7 +1967,7 @@ Module slice.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -1943,8 +1975,8 @@ Module slice.
                                                             let i := M.copy (| γ0_0 |) in
                                                             let index :=
                                                               M.copy (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::Index",
                                                                       Ty.apply
@@ -1960,8 +1992,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
+                                                                  |),
                                                                   1
+                                                                |)
                                                               |) in
                                                             let _ :=
                                                               M.loop (|
@@ -1990,8 +2023,8 @@ Module slice.
                                                                             M.write (|
                                                                               index,
                                                                               M.read (|
-                                                                                M.get_tuple_field
-                                                                                  (M.call_closure (|
+                                                                                M.SubPointer.get_tuple_field (|
+                                                                                  M.call_closure (|
                                                                                     M.get_trait_method (|
                                                                                       "core::ops::index::Index",
                                                                                       Ty.apply
@@ -2021,8 +2054,9 @@ Module slice.
                                                                                           index
                                                                                         |))
                                                                                     ]
-                                                                                  |))
+                                                                                  |),
                                                                                   1
+                                                                                |)
                                                                               |)
                                                                             |) in
                                                                           M.alloc (|
@@ -2052,8 +2086,8 @@ Module slice.
                                                               |) in
                                                             let _ :=
                                                               M.write (|
-                                                                M.get_tuple_field
-                                                                  (M.call_closure (|
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  M.call_closure (|
                                                                     M.get_trait_method (|
                                                                       "core::ops::index::IndexMut",
                                                                       Ty.apply
@@ -2069,8 +2103,9 @@ Module slice.
                                                                       []
                                                                     |),
                                                                     [ indices; M.read (| i |) ]
-                                                                  |))
-                                                                  1,
+                                                                  |),
+                                                                  1
+                                                                |),
                                                                 M.read (| index |)
                                                               |) in
                                                             let _ :=
@@ -2196,8 +2231,8 @@ Module slice.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let i := M.copy (| γ0_0 |) in
                                             let k := M.copy (| γ0_1 |) in
                                             Value.Tuple [ M.read (| k |); M.read (| M.use i |) ]))
@@ -2294,7 +2329,7 @@ Module slice.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2302,8 +2337,8 @@ Module slice.
                                         let i := M.copy (| γ0_0 |) in
                                         let index :=
                                           M.copy (|
-                                            M.get_tuple_field
-                                              (M.call_closure (|
+                                            M.SubPointer.get_tuple_field (|
+                                              M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::ops::index::Index",
                                                   Ty.apply
@@ -2317,8 +2352,9 @@ Module slice.
                                                   []
                                                 |),
                                                 [ indices; M.read (| i |) ]
-                                              |))
+                                              |),
                                               1
+                                            |)
                                           |) in
                                         let _ :=
                                           M.loop (|
@@ -2344,8 +2380,8 @@ Module slice.
                                                         M.write (|
                                                           index,
                                                           M.read (|
-                                                            M.get_tuple_field
-                                                              (M.call_closure (|
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.call_closure (|
                                                                 M.get_trait_method (|
                                                                   "core::ops::index::Index",
                                                                   Ty.apply
@@ -2361,8 +2397,9 @@ Module slice.
                                                                 |),
                                                                 [ indices; M.read (| M.use index |)
                                                                 ]
-                                                              |))
+                                                              |),
                                                               1
+                                                            |)
                                                           |)
                                                         |) in
                                                       M.alloc (| Value.Tuple [] |)));
@@ -2386,8 +2423,8 @@ Module slice.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_tuple_field
-                                              (M.call_closure (|
+                                            M.SubPointer.get_tuple_field (|
+                                              M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::ops::index::IndexMut",
                                                   Ty.apply
@@ -2401,8 +2438,9 @@ Module slice.
                                                   []
                                                 |),
                                                 [ indices; M.read (| i |) ]
-                                              |))
-                                              1,
+                                              |),
+                                              1
+                                            |),
                                             M.read (| index |)
                                           |) in
                                         let _ :=
@@ -3288,7 +3326,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -3401,7 +3439,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -3601,7 +3639,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -3740,7 +3778,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -3950,7 +3988,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -4153,8 +4191,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let init := M.copy (| γ0_0 |) in
                     let tail := M.copy (| γ0_1 |) in
                     let _ :=

--- a/CoqOfRust/alloc/str.v
+++ b/CoqOfRust/alloc/str.v
@@ -196,7 +196,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -809,7 +809,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -858,8 +858,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -987,9 +994,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -1128,7 +1141,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -1177,8 +1190,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -1306,9 +1326,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -1447,7 +1473,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -1496,8 +1522,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -1625,9 +1658,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -1766,7 +1805,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -1815,8 +1854,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -1944,9 +1990,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -2085,7 +2137,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -2134,8 +2186,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -2263,9 +2322,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -2399,7 +2464,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -2448,8 +2513,15 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let head := M.copy (| γ0_0 |) in
                                                                 let tail := M.copy (| γ0_1 |) in
                                                                 let _ :=
@@ -2577,9 +2649,15 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_tuple_field γ 0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            0
+                                                                          |) in
                                                                         let γ0_1 :=
-                                                                          M.get_tuple_field γ 1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ,
+                                                                            1
+                                                                          |) in
                                                                         let head :=
                                                                           M.copy (| γ0_0 |) in
                                                                         let tail :=
@@ -2961,13 +3039,13 @@ Module str.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let start := M.copy (| γ1_0 |) in
                                       let part := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -3173,13 +3251,13 @@ Module str.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let start := M.copy (| γ1_0 |) in
                                       let part := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -3464,13 +3542,15 @@ Module str.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
-                                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                            let γ1_0 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                            let γ1_1 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                             let i := M.copy (| γ1_0 |) in
                                             let c := M.copy (| γ1_1 |) in
                                             M.match_operator (|
@@ -3516,17 +3596,17 @@ Module str.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 0
                                                               |) in
                                                             let γ0_1 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 1
                                                               |) in
                                                             let γ0_2 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 2
                                                               |) in
@@ -3549,17 +3629,17 @@ Module str.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 0
                                                               |) in
                                                             let γ0_1 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 1
                                                               |) in
                                                             let γ0_2 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 2
                                                               |) in
@@ -3596,17 +3676,17 @@ Module str.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 0
                                                               |) in
                                                             let γ0_1 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 1
                                                               |) in
                                                             let γ0_2 :=
-                                                              M.get_slice_index_or_break_match (|
+                                                              M.SubPointer.get_slice_index (|
                                                                 γ,
                                                                 2
                                                               |) in
@@ -3803,7 +3883,7 @@ Module str.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -3823,11 +3903,9 @@ Module str.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_slice_index_or_break_match (| γ, 0 |) in
-                                              let γ0_1 :=
-                                                M.get_slice_index_or_break_match (| γ, 1 |) in
-                                              let γ0_2 :=
-                                                M.get_slice_index_or_break_match (| γ, 2 |) in
+                                                M.SubPointer.get_slice_index (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                                               let a := M.copy (| γ0_0 |) in
                                               let _ :=
                                                 M.is_constant_or_break_match (|
@@ -3847,11 +3925,9 @@ Module str.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_slice_index_or_break_match (| γ, 0 |) in
-                                              let γ0_1 :=
-                                                M.get_slice_index_or_break_match (| γ, 1 |) in
-                                              let γ0_2 :=
-                                                M.get_slice_index_or_break_match (| γ, 2 |) in
+                                                M.SubPointer.get_slice_index (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                                               let a := M.copy (| γ0_0 |) in
                                               let b := M.copy (| γ0_1 |) in
                                               let _ :=
@@ -3885,11 +3961,9 @@ Module str.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_slice_index_or_break_match (| γ, 0 |) in
-                                              let γ0_1 :=
-                                                M.get_slice_index_or_break_match (| γ, 1 |) in
-                                              let γ0_2 :=
-                                                M.get_slice_index_or_break_match (| γ, 2 |) in
+                                                M.SubPointer.get_slice_index (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                                               let a := M.copy (| γ0_0 |) in
                                               let b := M.copy (| γ0_1 |) in
                                               let c := M.copy (| γ0_2 |) in
@@ -4413,7 +4487,7 @@ Module str.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -4565,7 +4639,7 @@ Module str.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0

--- a/CoqOfRust/alloc/string.v
+++ b/CoqOfRust/alloc/string.v
@@ -47,8 +47,16 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
-              M.get_struct_record_field (M.read (| other |)) "alloc::string::String" "vec"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "alloc::string::String",
+                "vec"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -85,8 +93,16 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
-              M.get_struct_record_field (M.read (| other |)) "alloc::string::String" "vec"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "alloc::string::String",
+                "vec"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -157,8 +173,16 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
-              M.get_struct_record_field (M.read (| other |)) "alloc::string::String" "vec"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "alloc::string::String",
+                "vec"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -206,18 +230,20 @@ Module string.
               M.read (| Value.String "bytes" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::string::FromUtf8Error"
-                  "bytes");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::string::FromUtf8Error",
+                  "bytes"
+                |));
               M.read (| Value.String "error" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::string::FromUtf8Error"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::FromUtf8Error",
                     "error"
+                  |)
                 |))
             ]
           |)))
@@ -269,14 +295,16 @@ Module string.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::string::FromUtf8Error"
-                  "bytes";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "alloc::string::FromUtf8Error"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::string::FromUtf8Error",
                   "bytes"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "alloc::string::FromUtf8Error",
+                  "bytes"
+                |)
               ]
             |),
             ltac:(M.monadic
@@ -289,14 +317,16 @@ Module string.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::string::FromUtf8Error"
-                    "error";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "alloc::string::FromUtf8Error"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::FromUtf8Error",
                     "error"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "alloc::string::FromUtf8Error",
+                    "error"
+                  |)
                 ]
               |)))
           |)))
@@ -380,10 +410,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::string::FromUtf8Error"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::FromUtf8Error",
                       "bytes"
+                    |)
                   ]
                 |));
               ("error",
@@ -396,10 +427,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::string::FromUtf8Error"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::FromUtf8Error",
                       "error"
+                    |)
                   ]
                 |))
             ]))
@@ -443,7 +475,11 @@ Module string.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "alloc::string::FromUtf16Error" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "alloc::string::FromUtf16Error",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -566,11 +602,7 @@ Module string.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -660,7 +692,7 @@ Module string.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -758,8 +790,15 @@ Module string.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let left_val := M.copy (| γ0_0 |) in
                                                                 let right_val :=
                                                                   M.copy (| γ0_1 |) in
@@ -961,7 +1000,7 @@ Module string.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -1198,7 +1237,7 @@ Module string.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -1211,7 +1250,7 @@ Module string.
                                                 ltac:(M.monadic
                                                   (let γ := c in
                                                   let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::result::Result::Ok",
                                                       0
@@ -1489,13 +1528,13 @@ Module string.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                        let γ1_0 := M.get_tuple_field γ0_1 0 in
-                        let γ1_1 := M.get_tuple_field γ0_1 1 in
-                        let γ1_2 := M.get_tuple_field γ0_1 2 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                        let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                         let γ1_0 := M.read (| γ1_0 |) in
                         let v := M.copy (| γ1_1 |) in
                         let γ1_2 := M.read (| γ1_2 |) in
@@ -1704,13 +1743,13 @@ Module string.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                    let γ1_0 := M.get_tuple_field γ0_1 0 in
-                    let γ1_1 := M.get_tuple_field γ0_1 1 in
-                    let γ1_2 := M.get_tuple_field γ0_1 2 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                    let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                     let γ1_0 := M.read (| γ1_0 |) in
                     let v := M.copy (| γ1_1 |) in
                     let γ1_2 := M.read (| γ1_2 |) in
@@ -1726,17 +1765,17 @@ Module string.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                    let γ1_0 := M.get_tuple_field γ0_1 0 in
-                    let γ1_1 := M.get_tuple_field γ0_1 1 in
-                    let γ1_2 := M.get_tuple_field γ0_1 2 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                    let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                     let γ1_0 := M.read (| γ1_0 |) in
                     let v := M.copy (| γ1_1 |) in
                     let γ1_2 := M.read (| γ1_2 |) in
-                    let γ3_0 := M.get_slice_index_or_break_match (| γ1_2, 0 |) in
+                    let γ3_0 := M.SubPointer.get_slice_index (| γ1_2, 0 |) in
                     let _remainder := M.alloc (| γ3_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -2137,13 +2176,13 @@ Module string.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                        let γ1_0 := M.get_tuple_field γ0_1 0 in
-                        let γ1_1 := M.get_tuple_field γ0_1 1 in
-                        let γ1_2 := M.get_tuple_field γ0_1 2 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                        let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                         let γ1_0 := M.read (| γ1_0 |) in
                         let v := M.copy (| γ1_1 |) in
                         let γ1_2 := M.read (| γ1_2 |) in
@@ -2352,13 +2391,13 @@ Module string.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                    let γ1_0 := M.get_tuple_field γ0_1 0 in
-                    let γ1_1 := M.get_tuple_field γ0_1 1 in
-                    let γ1_2 := M.get_tuple_field γ0_1 2 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                    let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                     let γ1_0 := M.read (| γ1_0 |) in
                     let v := M.copy (| γ1_1 |) in
                     let γ1_2 := M.read (| γ1_2 |) in
@@ -2374,17 +2413,17 @@ Module string.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
-                    let γ1_0 := M.get_tuple_field γ0_1 0 in
-                    let γ1_1 := M.get_tuple_field γ0_1 1 in
-                    let γ1_2 := M.get_tuple_field γ0_1 2 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_1, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_1, 1 |) in
+                    let γ1_2 := M.SubPointer.get_tuple_field (| γ0_1, 2 |) in
                     let γ1_0 := M.read (| γ1_0 |) in
                     let v := M.copy (| γ1_1 |) in
                     let γ1_2 := M.read (| γ1_2 |) in
-                    let γ3_0 := M.get_slice_index_or_break_match (| γ1_2, 0 |) in
+                    let γ3_0 := M.SubPointer.get_slice_index (| γ1_2, 0 |) in
                     let _remainder := M.alloc (| γ3_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -2719,7 +2758,11 @@ Module string.
               "into_raw_parts",
               []
             |),
-            [ M.read (| M.get_struct_record_field self "alloc::string::String" "vec" |) ]
+            [
+              M.read (|
+                M.SubPointer.get_struct_record_field (| self, "alloc::string::String", "vec" |)
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -2787,7 +2830,9 @@ Module string.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "alloc::string::String" "vec" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "alloc::string::String", "vec" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -2861,7 +2906,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.call_closure (|
                 M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                 [ M.read (| string |) ]
@@ -2920,13 +2969,13 @@ Module string.
                   ltac:(M.monadic
                     (let src := M.copy (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "start"
                       |) in
                     let γ1_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "end"
@@ -3047,10 +3096,11 @@ Module string.
                             [ Ty.apply (Ty.path "core::ops::range::Range") [ Ty.path "usize" ] ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::string::String"
-                              "vec";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::string::String",
+                              "vec"
+                            |);
                             M.read (| src |)
                           ]
                         |)
@@ -3081,7 +3131,13 @@ Module string.
               "capacity",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3106,7 +3162,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -3133,7 +3193,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -3161,7 +3225,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -3188,7 +3256,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -3214,7 +3286,13 @@ Module string.
               "shrink_to_fit",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3240,7 +3318,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |);
               M.read (| min_capacity |)
             ]
           |)))
@@ -3289,10 +3371,11 @@ Module string.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::string::String"
-                            "vec";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::string::String",
+                            "vec"
+                          |);
                           M.rust_cast (M.read (| ch |))
                         ]
                       |)
@@ -3309,10 +3392,11 @@ Module string.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::string::String"
-                            "vec";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::string::String",
+                            "vec"
+                          |);
                           M.call_closure (|
                             M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                             [
@@ -3356,7 +3440,13 @@ Module string.
               "deref",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3460,10 +3550,11 @@ Module string.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::string::String"
-                            "vec";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::string::String",
+                            "vec"
+                          |);
                           M.read (| new_len |)
                         ]
                       |)
@@ -3556,7 +3647,7 @@ Module string.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -3589,7 +3680,7 @@ Module string.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -3624,10 +3715,11 @@ Module string.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::string::String"
-                            "vec";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::string::String",
+                            "vec"
+                          |);
                           M.read (| newlen |)
                         ]
                       |)
@@ -3710,7 +3802,7 @@ Module string.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -3790,10 +3882,11 @@ Module string.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::string::String"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::string::String",
                                 "vec"
+                              |)
                             ]
                           |);
                           M.read (| next |)
@@ -3815,10 +3908,11 @@ Module string.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::string::String"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::string::String",
                                 "vec"
+                              |)
                             ]
                           |);
                           M.read (| idx |)
@@ -3839,7 +3933,11 @@ Module string.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::string::String",
+                        "vec"
+                      |);
                       BinOp.Panic.sub (|
                         M.read (| len |),
                         BinOp.Panic.sub (| M.read (| next |), M.read (| idx |) |)
@@ -4027,7 +4125,7 @@ Module string.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Break",
                                                             0
@@ -4071,7 +4169,7 @@ Module string.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                             0
@@ -4083,8 +4181,10 @@ Module string.
                                                 [
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let start := M.copy (| γ0_0 |) in
                                                       let end_ := M.copy (| γ0_1 |) in
                                                       let prev_front := M.copy (| front |) in
@@ -4182,7 +4282,13 @@ Module string.
                     "as_mut_ptr",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |)
+                  ]
                 |)
               |) in
             let _ :=
@@ -4253,13 +4359,13 @@ Module string.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let start := M.copy (| γ1_0 |) in
                                       let end_ := M.copy (| γ1_1 |) in
                                       let count :=
@@ -4349,7 +4455,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |);
                     M.read (| len |)
                   ]
                 |)
@@ -4453,10 +4563,11 @@ Module string.
                               (M.alloc (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      guard
-                                      "alloc::string::retain::SetLenOnDrop"
+                                    M.SubPointer.get_struct_record_field (|
+                                      guard,
+                                      "alloc::string::retain::SetLenOnDrop",
                                       "idx"
+                                    |)
                                   |))
                                   (M.read (| len |))
                               |)) in
@@ -4509,10 +4620,11 @@ Module string.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        guard
-                                                        "alloc::string::retain::SetLenOnDrop"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        guard,
+                                                        "alloc::string::retain::SetLenOnDrop",
                                                         "s"
+                                                      |)
                                                     |)
                                                   ]
                                                 |);
@@ -4521,10 +4633,11 @@ Module string.
                                                   [
                                                     ("start",
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          guard
-                                                          "alloc::string::retain::SetLenOnDrop"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          guard,
+                                                          "alloc::string::retain::SetLenOnDrop",
                                                           "idx"
+                                                        |)
                                                       |));
                                                     ("end_", M.read (| len |))
                                                   ]
@@ -4573,10 +4686,11 @@ Module string.
                                       |) in
                                     let _ :=
                                       let β :=
-                                        M.get_struct_record_field
-                                          guard
-                                          "alloc::string::retain::SetLenOnDrop"
-                                          "del_bytes" in
+                                        M.SubPointer.get_struct_record_field (|
+                                          guard,
+                                          "alloc::string::retain::SetLenOnDrop",
+                                          "del_bytes"
+                                        |) in
                                       M.write (|
                                         β,
                                         BinOp.Panic.add (| M.read (| β |), M.read (| ch_len |) |)
@@ -4594,10 +4708,11 @@ Module string.
                                                 (M.alloc (|
                                                   BinOp.Pure.gt
                                                     (M.read (|
-                                                      M.get_struct_record_field
-                                                        guard
-                                                        "alloc::string::retain::SetLenOnDrop"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        guard,
+                                                        "alloc::string::retain::SetLenOnDrop",
                                                         "del_bytes"
+                                                      |)
                                                     |))
                                                     (Value.Integer Integer.Usize 0)
                                                 |)) in
@@ -4648,10 +4763,11 @@ Module string.
                                                                   |),
                                                                   [
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        guard
-                                                                        "alloc::string::retain::SetLenOnDrop"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        guard,
+                                                                        "alloc::string::retain::SetLenOnDrop",
                                                                         "s"
+                                                                      |)
                                                                     |)
                                                                   ]
                                                                 |)
@@ -4659,16 +4775,18 @@ Module string.
                                                             |);
                                                             BinOp.Panic.sub (|
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  guard
-                                                                  "alloc::string::retain::SetLenOnDrop"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  guard,
+                                                                  "alloc::string::retain::SetLenOnDrop",
                                                                   "idx"
+                                                                |)
                                                               |),
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  guard
-                                                                  "alloc::string::retain::SetLenOnDrop"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  guard,
+                                                                  "alloc::string::retain::SetLenOnDrop",
                                                                   "del_bytes"
+                                                                |)
                                                               |)
                                                             |)
                                                           ]
@@ -4694,10 +4812,11 @@ Module string.
                             |) in
                           let _ :=
                             let β :=
-                              M.get_struct_record_field
-                                guard
-                                "alloc::string::retain::SetLenOnDrop"
-                                "idx" in
+                              M.SubPointer.get_struct_record_field (|
+                                guard,
+                                "alloc::string::retain::SetLenOnDrop",
+                                "idx"
+                              |) in
                             M.write (|
                               β,
                               BinOp.Panic.add (| M.read (| β |), M.read (| ch_len |) |)
@@ -4881,7 +5000,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |);
                     M.read (| amt |)
                   ]
                 |)
@@ -4907,10 +5030,11 @@ Module string.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::string::String"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::string::String",
                               "vec"
+                            |)
                           ]
                         |);
                         M.read (| idx |)
@@ -4932,10 +5056,11 @@ Module string.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::string::String"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::string::String",
                               "vec"
+                            |)
                           ]
                         |);
                         BinOp.Panic.add (| M.read (| idx |), M.read (| amt |) |)
@@ -4974,10 +5099,11 @@ Module string.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::string::String"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::string::String",
                               "vec"
+                            |)
                           ]
                         |);
                         M.read (| idx |)
@@ -4998,7 +5124,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |);
                     BinOp.Panic.add (| M.read (| len |), M.read (| amt |) |)
                   ]
                 |)
@@ -5109,7 +5239,11 @@ Module string.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec"))
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "alloc::string::String",
+            "vec"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -5131,7 +5265,13 @@ Module string.
               "len",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5231,7 +5371,11 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |);
                     M.read (| at_ |)
                   ]
                 |)
@@ -5268,7 +5412,13 @@ Module string.
               "clear",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::String",
+                "vec"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5332,13 +5482,13 @@ Module string.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "start"
                       |) in
                     let γ0_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "end"
@@ -5556,7 +5706,7 @@ Module string.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -5616,7 +5766,7 @@ Module string.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -5700,7 +5850,7 @@ Module string.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -5764,7 +5914,7 @@ Module string.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -5892,7 +6042,15 @@ Module string.
                     "into_boxed_slice",
                     []
                   |),
-                  [ M.read (| M.get_struct_record_field self "alloc::string::String" "vec" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::string::String",
+                        "vec"
+                      |)
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -5930,7 +6088,15 @@ Module string.
                     "leak",
                     []
                   |),
-                  [ M.read (| M.get_struct_record_field self "alloc::string::String" "vec" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "alloc::string::String",
+                        "vec"
+                      |)
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -5968,7 +6134,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::FromUtf8Error" "bytes";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::FromUtf8Error",
+                "bytes"
+              |);
               Value.StructTuple "core::ops::range::RangeFull" []
             ]
           |)))
@@ -5987,7 +6157,9 @@ Module string.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "alloc::string::FromUtf8Error" "bytes" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "alloc::string::FromUtf8Error", "bytes" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -6004,7 +6176,11 @@ Module string.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "alloc::string::FromUtf8Error" "error"
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "alloc::string::FromUtf8Error",
+              "error"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -6035,7 +6211,11 @@ Module string.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::string::FromUtf8Error" "error";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::FromUtf8Error",
+                "error"
+              |);
               M.read (| f |)
             ]
           |)))
@@ -6156,7 +6336,13 @@ Module string.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -6187,8 +6373,16 @@ Module string.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec";
-                    M.get_struct_record_field (M.read (| source |)) "alloc::string::String" "vec"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::string::String",
+                      "vec"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| source |),
+                      "alloc::string::String",
+                      "vec"
+                    |)
                   ]
                 |)
               |) in
@@ -6416,7 +6610,7 @@ Module string.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6571,7 +6765,7 @@ Module string.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6664,8 +6858,8 @@ Module string.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let lower_bound := M.copy (| γ0_0 |) in
                     let _ :=
                       M.alloc (|
@@ -9188,7 +9382,13 @@ Module string.
                   "deref",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::String",
+                    "vec"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -9479,7 +9679,13 @@ Module string.
                   "deref_mut",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::String",
+                    "vec"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -9619,7 +9825,13 @@ Module string.
                   "deref",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::String",
+                    "vec"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -9661,7 +9873,13 @@ Module string.
                   "deref_mut",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "alloc::string::String" "vec" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::string::String",
+                    "vec"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -11094,7 +11312,11 @@ Module string.
                   M.get_associated_function (| Ty.path "alloc::string::String", "as_mut_vec", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::string::Drain" "string"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::string::Drain",
+                        "string"
+                      |)
                     |)
                   ]
                 |)
@@ -11110,24 +11332,27 @@ Module string.
                           LogicalOp.and (|
                             BinOp.Pure.le
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::string::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::string::Drain",
                                   "start"
+                                |)
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::string::Drain"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::string::Drain",
                                   "end"
+                                |)
                               |)),
                             ltac:(M.monadic
                               (BinOp.Pure.le
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::string::Drain"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::string::Drain",
                                     "end"
+                                  |)
                                 |))
                                 (M.call_closure (|
                                   M.get_associated_function (|
@@ -11159,17 +11384,19 @@ Module string.
                               [
                                 ("start",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::string::Drain"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::string::Drain",
                                       "start"
+                                    |)
                                   |));
                                 ("end_",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::string::Drain"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::string::Drain",
                                       "end"
+                                    |)
                                   |))
                               ]
                           ]
@@ -11206,7 +11433,13 @@ Module string.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::str::iter::Chars", "as_str", [] |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::Drain" "iter" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::Drain",
+                "iter"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -11299,7 +11532,13 @@ Module string.
               "next",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::Drain" "iter" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::Drain",
+                "iter"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -11322,7 +11561,13 @@ Module string.
               "size_hint",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::Drain" "iter" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::Drain",
+                "iter"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -11385,7 +11630,13 @@ Module string.
               "next_back",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::string::Drain" "iter" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::string::Drain",
+                "iter"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.

--- a/CoqOfRust/alloc/sync.v
+++ b/CoqOfRust/alloc/sync.v
@@ -477,10 +477,11 @@ Module sync.
                     M.call_closure (|
                       M.get_function (| "core::ptr::write", [ T ] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| inner |))
-                          "alloc::sync::ArcInner"
-                          "data";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| inner |),
+                          "alloc::sync::ArcInner",
+                          "data"
+                        |);
                         M.read (| data |)
                       ]
                     |)
@@ -494,10 +495,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| inner |))
-                          "alloc::sync::ArcInner"
-                          "strong";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| inner |),
+                          "alloc::sync::ArcInner",
+                          "strong"
+                        |);
                         Value.Integer Integer.Usize 1;
                         Value.StructTuple "core::sync::atomic::Ordering::Release" []
                       ]
@@ -521,8 +523,8 @@ Module sync.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let left_val := M.copy (| γ0_0 |) in
                                     let right_val := M.copy (| γ0_1 |) in
                                     M.match_operator (|
@@ -963,7 +965,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1008,7 +1010,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1117,7 +1119,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1158,7 +1160,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1384,7 +1386,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1431,7 +1433,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1612,7 +1614,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1659,7 +1661,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1936,7 +1938,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1977,7 +1979,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2100,8 +2102,8 @@ Module sync.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let left_val := M.copy (| γ0_0 |) in
                                 let right_val := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -2178,10 +2180,11 @@ Module sync.
                       [ Ty.path "core::sync::atomic::AtomicUsize" ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| inner |))
-                        "alloc::sync::ArcInner"
-                        "strong";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| inner |),
+                        "alloc::sync::ArcInner",
+                        "strong"
+                      |);
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.path "core::sync::atomic::AtomicUsize",
@@ -2201,7 +2204,11 @@ Module sync.
                       [ Ty.path "core::sync::atomic::AtomicUsize" ]
                     |),
                     [
-                      M.get_struct_record_field (M.read (| inner |)) "alloc::sync::ArcInner" "weak";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| inner |),
+                        "alloc::sync::ArcInner",
+                        "weak"
+                      |);
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.path "core::sync::atomic::AtomicUsize",
@@ -2302,7 +2309,11 @@ Module sync.
       | [], [ this ] =>
         ltac:(M.monadic
           (let this := M.alloc (| this |) in
-          M.get_struct_record_field (M.read (| this |)) "alloc::sync::Arc" "alloc"))
+          M.SubPointer.get_struct_record_field (|
+            M.read (| this |),
+            "alloc::sync::Arc",
+            "alloc"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -2388,8 +2399,8 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let ptr := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -2756,7 +2767,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2798,7 +2809,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2907,7 +2918,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2946,7 +2957,7 @@ Module sync.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2972,8 +2983,8 @@ Module sync.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let ptr := M.copy (| γ0_0 |) in
                         let alloc := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -3173,7 +3184,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -3220,7 +3231,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -3396,7 +3407,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -3443,7 +3454,7 @@ Module sync.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -3520,17 +3531,18 @@ Module sync.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.call_closure (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.call_closure (|
                                               M.get_associated_function (|
                                                 Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                                 "inner",
                                                 []
                                               |),
                                               [ this ]
-                                            |))
-                                            "alloc::sync::ArcInner"
-                                            "strong";
+                                            |),
+                                            "alloc::sync::ArcInner",
+                                            "strong"
+                                          |);
                                           Value.Integer Integer.Usize 1;
                                           Value.Integer Integer.Usize 0;
                                           Value.StructTuple
@@ -3573,8 +3585,8 @@ Module sync.
                     M.call_closure (|
                       M.get_function (| "core::ptr::read", [ T ] |),
                       [
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
                                 (Ty.path "core::ptr::non_null::NonNull")
@@ -3582,10 +3594,17 @@ Module sync.
                               "as_ref",
                               []
                             |),
-                            [ M.get_struct_record_field this "alloc::sync::Arc" "ptr" ]
-                          |))
-                          "alloc::sync::ArcInner"
+                            [
+                              M.SubPointer.get_struct_record_field (|
+                                this,
+                                "alloc::sync::Arc",
+                                "ptr"
+                              |)
+                            ]
+                          |),
+                          "alloc::sync::ArcInner",
                           "data"
+                        |)
                       ]
                     |)
                   |) in
@@ -3593,7 +3612,8 @@ Module sync.
                   M.alloc (|
                     M.call_closure (|
                       M.get_function (| "core::ptr::read", [ A ] |),
-                      [ M.get_struct_record_field this "alloc::sync::Arc" "alloc" ]
+                      [ M.SubPointer.get_struct_record_field (| this, "alloc::sync::Arc", "alloc" |)
+                      ]
                     |)
                   |) in
                 let _weak :=
@@ -3602,7 +3622,13 @@ Module sync.
                       "alloc::sync::Weak"
                       [
                         ("ptr",
-                          M.read (| M.get_struct_record_field this "alloc::sync::Arc" "ptr" |));
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              this,
+                              "alloc::sync::Arc",
+                              "ptr"
+                            |)
+                          |));
                         ("alloc", M.read (| alloc |))
                       ]
                   |) in
@@ -3693,8 +3719,8 @@ Module sync.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                             "inner",
@@ -3715,9 +3741,10 @@ Module sync.
                                               [ this ]
                                             |)
                                           ]
-                                        |))
-                                        "alloc::sync::ArcInner"
-                                        "strong";
+                                        |),
+                                        "alloc::sync::ArcInner",
+                                        "strong"
+                                      |);
                                       Value.Integer Integer.Usize 1;
                                       Value.StructTuple "core::sync::atomic::Ordering::Release" []
                                     ]
@@ -3777,8 +3804,8 @@ Module sync.
                     M.call_closure (|
                       M.get_function (| "core::ptr::read", [ A ] |),
                       [
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::deref::Deref",
                               Ty.apply
@@ -3789,9 +3816,10 @@ Module sync.
                               []
                             |),
                             [ this ]
-                          |))
-                          "alloc::sync::Arc"
+                          |),
+                          "alloc::sync::Arc",
                           "alloc"
+                        |)
                       ]
                     |)
                   |) in
@@ -3808,8 +3836,8 @@ Module sync.
                           [
                             ("ptr",
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.call_closure (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::deref::Deref",
                                       Ty.apply
@@ -3820,9 +3848,10 @@ Module sync.
                                       []
                                     |),
                                     [ this ]
-                                  |))
-                                  "alloc::sync::Arc"
+                                  |),
+                                  "alloc::sync::Arc",
                                   "ptr"
+                                |)
                               |));
                             ("alloc", M.read (| alloc |))
                           ]
@@ -3911,7 +3940,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| this |)) "alloc::sync::Arc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::sync::Arc",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |)
@@ -3919,7 +3952,11 @@ Module sync.
             M.alloc (|
               (* MutToConstPointer *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| ptr |)) "alloc::sync::ArcInner" "data")
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| ptr |),
+                  "alloc::sync::ArcInner",
+                  "data"
+                |))
             |)
           |)))
       | _, _ => M.impossible
@@ -4042,17 +4079,18 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                               "inner",
                               []
                             |),
                             [ M.read (| this |) ]
-                          |))
-                          "alloc::sync::ArcInner"
-                          "weak";
+                          |),
+                          "alloc::sync::ArcInner",
+                          "weak"
+                        |);
                         Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                       ]
                     |)
@@ -4100,8 +4138,8 @@ Module sync.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.call_closure (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.call_closure (|
                                                       M.get_associated_function (|
                                                         Ty.apply
                                                           (Ty.path "alloc::sync::Arc")
@@ -4110,9 +4148,10 @@ Module sync.
                                                         []
                                                       |),
                                                       [ M.read (| this |) ]
-                                                    |))
-                                                    "alloc::sync::ArcInner"
-                                                    "weak";
+                                                    |),
+                                                    "alloc::sync::ArcInner",
+                                                    "weak"
+                                                  |);
                                                   Value.StructTuple
                                                     "core::sync::atomic::Ordering::Relaxed"
                                                     []
@@ -4175,17 +4214,18 @@ Module sync.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.call_closure (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.call_closure (|
                                       M.get_associated_function (|
                                         Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                         "inner",
                                         []
                                       |),
                                       [ M.read (| this |) ]
-                                    |))
-                                    "alloc::sync::ArcInner"
-                                    "weak";
+                                    |),
+                                    "alloc::sync::ArcInner",
+                                    "weak"
+                                  |);
                                   M.read (| cur |);
                                   BinOp.Panic.add (|
                                     M.read (| cur |),
@@ -4200,7 +4240,7 @@ Module sync.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Ok",
                                       0
@@ -4258,12 +4298,11 @@ Module sync.
                                                                             |),
                                                                             [
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    this
-                                                                                  |))
-                                                                                  "alloc::sync::Arc"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| this |),
+                                                                                  "alloc::sync::Arc",
                                                                                   "ptr"
+                                                                                |)
                                                                               |)
                                                                             ]
                                                                           |)
@@ -4307,10 +4346,11 @@ Module sync.
                                             [
                                               ("ptr",
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| this |))
-                                                    "alloc::sync::Arc"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| this |),
+                                                    "alloc::sync::Arc",
                                                     "ptr"
+                                                  |)
                                                 |));
                                               ("alloc",
                                                 M.call_closure (|
@@ -4322,10 +4362,11 @@ Module sync.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| this |))
-                                                      "alloc::sync::Arc"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| this |),
+                                                      "alloc::sync::Arc",
                                                       "alloc"
+                                                    |)
                                                   ]
                                                 |))
                                             ]
@@ -4336,7 +4377,7 @@ Module sync.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Err",
                                       0
@@ -4382,17 +4423,18 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                           "inner",
                           []
                         |),
                         [ M.read (| this |) ]
-                      |))
-                      "alloc::sync::ArcInner"
-                      "weak";
+                      |),
+                      "alloc::sync::ArcInner",
+                      "weak"
+                    |);
                     Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                   ]
                 |)
@@ -4440,17 +4482,18 @@ Module sync.
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::sync::atomic::AtomicUsize", "load", [] |),
             [
-              M.get_struct_record_field
-                (M.call_closure (|
+              M.SubPointer.get_struct_record_field (|
+                M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                     "inner",
                     []
                   |),
                   [ M.read (| this |) ]
-                |))
-                "alloc::sync::ArcInner"
-                "strong";
+                |),
+                "alloc::sync::ArcInner",
+                "strong"
+              |);
               Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
             ]
           |)))
@@ -4591,7 +4634,13 @@ Module sync.
               "as_ref",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::sync::Arc" "ptr" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::sync::Arc",
+                "ptr"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4649,10 +4698,18 @@ Module sync.
                       [
                         ("ptr",
                           M.read (|
-                            M.get_struct_record_field (M.read (| self |)) "alloc::sync::Arc" "ptr"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::sync::Arc",
+                              "ptr"
+                            |)
                           |));
                         ("alloc",
-                          M.get_struct_record_field (M.read (| self |)) "alloc::sync::Arc" "alloc")
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::sync::Arc",
+                            "alloc"
+                          |))
                       ]
                   ]
                 |)
@@ -4699,7 +4756,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| this |)) "alloc::sync::Arc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "alloc::sync::Arc",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |));
@@ -4715,7 +4776,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "alloc::sync::Arc" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::sync::Arc",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |))
@@ -4899,10 +4964,11 @@ Module sync.
                       (M.read (|
                         M.use
                           (M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| ptr |))
-                              "alloc::sync::ArcInner"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| ptr |),
+                              "alloc::sync::ArcInner",
                               "data"
+                            |)
                           |))
                       |));
                     M.read (| value_size |)
@@ -4923,8 +4989,8 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let bptr := M.copy (| γ0_0 |) in
                     let alloc := M.copy (| γ0_1 |) in
                     let src :=
@@ -5066,17 +5132,18 @@ Module sync.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                             "inner",
                                             []
                                           |),
                                           [ M.read (| this |) ]
-                                        |))
-                                        "alloc::sync::ArcInner"
-                                        "strong";
+                                        |),
+                                        "alloc::sync::ArcInner",
+                                        "strong"
+                                      |);
                                       Value.Integer Integer.Usize 1;
                                       Value.Integer Integer.Usize 0;
                                       Value.StructTuple "core::sync::atomic::Ordering::Acquire" [];
@@ -5100,10 +5167,11 @@ Module sync.
                               M.call_closure (|
                                 M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| this |))
-                                    "alloc::sync::Arc"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| this |),
+                                    "alloc::sync::Arc",
                                     "alloc"
+                                  |)
                                 ]
                               |)
                             ]
@@ -5189,17 +5257,18 @@ Module sync.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.call_closure (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.call_closure (|
                                               M.get_associated_function (|
                                                 Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                                 "inner",
                                                 []
                                               |),
                                               [ M.read (| this |) ]
-                                            |))
-                                            "alloc::sync::ArcInner"
-                                            "weak";
+                                            |),
+                                            "alloc::sync::ArcInner",
+                                            "weak"
+                                          |);
                                           Value.StructTuple
                                             "core::sync::atomic::Ordering::Relaxed"
                                             []
@@ -5219,10 +5288,11 @@ Module sync.
                                     [
                                       ("ptr",
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| this |))
-                                            "alloc::sync::Arc"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| this |),
+                                            "alloc::sync::Arc",
                                             "ptr"
+                                          |)
                                         |));
                                       ("alloc",
                                         M.call_closure (|
@@ -5234,10 +5304,11 @@ Module sync.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| this |))
-                                              "alloc::sync::Arc"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| this |),
+                                              "alloc::sync::Arc",
                                               "alloc"
+                                            |)
                                           ]
                                         |))
                                     ]
@@ -5260,10 +5331,11 @@ Module sync.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| this |))
-                                            "alloc::sync::Arc"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| this |),
+                                            "alloc::sync::Arc",
                                             "alloc"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -5359,17 +5431,18 @@ Module sync.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                             "inner",
                                             []
                                           |),
                                           [ M.read (| this |) ]
-                                        |))
-                                        "alloc::sync::ArcInner"
-                                        "strong";
+                                        |),
+                                        "alloc::sync::ArcInner",
+                                        "strong"
+                                      |);
                                       Value.Integer Integer.Usize 1;
                                       Value.StructTuple "core::sync::atomic::Ordering::Release" []
                                     ]
@@ -5542,8 +5615,8 @@ Module sync.
       | [], [ this ] =>
         ltac:(M.monadic
           (let this := M.alloc (| this |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply
                   (Ty.path "core::ptr::non_null::NonNull")
@@ -5551,11 +5624,19 @@ Module sync.
                 "as_ptr",
                 []
               |),
-              [ M.read (| M.get_struct_record_field (M.read (| this |)) "alloc::sync::Arc" "ptr" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| this |),
+                    "alloc::sync::Arc",
+                    "ptr"
+                  |)
+                |)
               ]
-            |))
-            "alloc::sync::ArcInner"
-            "data"))
+            |),
+            "alloc::sync::ArcInner",
+            "data"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -5620,17 +5701,18 @@ Module sync.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.call_closure (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                           "inner",
                                           []
                                         |),
                                         [ M.read (| self |) ]
-                                      |))
-                                      "alloc::sync::ArcInner"
-                                      "weak";
+                                      |),
+                                      "alloc::sync::ArcInner",
+                                      "weak"
+                                    |);
                                     Value.Integer Integer.Usize 1;
                                     M.read (| M.get_constant (| "core::num::MAX" |) |);
                                     Value.StructTuple "core::sync::atomic::Ordering::Acquire" [];
@@ -5652,17 +5734,18 @@ Module sync.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.call_closure (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                     "inner",
                                     []
                                   |),
                                   [ M.read (| self |) ]
-                                |))
-                                "alloc::sync::ArcInner"
-                                "strong";
+                                |),
+                                "alloc::sync::ArcInner",
+                                "strong"
+                              |);
                               Value.StructTuple "core::sync::atomic::Ordering::Acquire" []
                             ]
                           |))
@@ -5677,17 +5760,18 @@ Module sync.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                   "inner",
                                   []
                                 |),
                                 [ M.read (| self |) ]
-                              |))
-                              "alloc::sync::ArcInner"
-                              "weak";
+                              |),
+                              "alloc::sync::ArcInner",
+                              "weak"
+                            |);
                             Value.Integer Integer.Usize 1;
                             Value.StructTuple "core::sync::atomic::Ordering::Release" []
                           ]
@@ -5841,8 +5925,8 @@ Module sync.
         M.call_closure (|
           M.get_associated_function (| Ty.path "core::alloc::layout::Layout", "pad_to_align", [] |),
           [
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
@@ -5877,8 +5961,9 @@ Module sync.
                     |)
                   ]
                 |)
-              |))
+              |),
               0
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -6308,10 +6393,11 @@ Module sync.
                       (M.read (|
                         M.use
                           (M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| ptr |))
-                              "alloc::sync::ArcInner"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| ptr |),
+                              "alloc::sync::ArcInner",
                               "data"
+                            |)
                           |))
                       |));
                     M.call_closure (|
@@ -6430,7 +6516,11 @@ Module sync.
                   (M.read (|
                     M.use
                       (M.alloc (|
-                        M.get_struct_record_field (M.read (| ptr |)) "alloc::sync::ArcInner" "data"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| ptr |),
+                          "alloc::sync::ArcInner",
+                          "data"
+                        |)
                       |))
                   |))
               |) in
@@ -6512,13 +6602,13 @@ Module sync.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let i := M.copy (| γ1_0 |) in
                                       let item := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -6540,10 +6630,11 @@ Module sync.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            guard
-                                            "alloc::sync::from_iter_exact::Guard"
-                                            "n_elems" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            guard,
+                                            "alloc::sync::from_iter_exact::Guard",
+                                            "n_elems"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -7006,8 +7097,8 @@ Module sync.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::deref::Deref",
                               Ty.apply
@@ -7027,17 +7118,18 @@ Module sync.
                               []
                             |),
                             [ md_self ]
-                          |))
-                          "alloc::sync::Arc"
+                          |),
+                          "alloc::sync::Arc",
                           "ptr"
+                        |)
                       |)
                     ]
                   |);
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -7055,9 +7147,10 @@ Module sync.
                             []
                           |),
                           [ md_self ]
-                        |))
-                        "alloc::sync::Arc"
+                        |),
+                        "alloc::sync::Arc",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -7149,8 +7242,8 @@ Module sync.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_trait_method (|
                                 "core::ops::deref::Deref",
                                 Ty.apply
@@ -7174,17 +7267,18 @@ Module sync.
                                 []
                               |),
                               [ md_self ]
-                            |))
-                            "alloc::sync::Arc"
+                            |),
+                            "alloc::sync::Arc",
                             "ptr"
+                          |)
                         |)
                       ]
                     |));
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -7208,9 +7302,10 @@ Module sync.
                             []
                           |),
                           [ md_self ]
-                        |))
-                        "alloc::sync::Arc"
+                        |),
+                        "alloc::sync::Arc",
                         "alloc"
+                      |)
                     ]
                   |)
                 ]
@@ -7392,17 +7487,18 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                           "inner",
                           []
                         |),
                         [ M.read (| self |) ]
-                      |))
-                      "alloc::sync::ArcInner"
-                      "strong";
+                      |),
+                      "alloc::sync::ArcInner",
+                      "strong"
+                    |);
                     Value.Integer Integer.Usize 1;
                     Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                   ]
@@ -7442,11 +7538,21 @@ Module sync.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "alloc::sync::Arc" "ptr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::sync::Arc",
+                      "ptr"
+                    |)
                   |);
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                    [ M.get_struct_record_field (M.read (| self |)) "alloc::sync::Arc" "alloc" ]
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::sync::Arc",
+                        "alloc"
+                      |)
+                    ]
                   |)
                 ]
               |)
@@ -7481,17 +7587,18 @@ Module sync.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field
-            (M.call_closure (|
+          M.SubPointer.get_struct_record_field (|
+            M.call_closure (|
               M.get_associated_function (|
                 Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                 "inner",
                 []
               |),
               [ M.read (| self |) ]
-            |))
-            "alloc::sync::ArcInner"
-            "data"))
+            |),
+            "alloc::sync::ArcInner",
+            "data"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -7593,17 +7700,18 @@ Module sync.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.call_closure (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply (Ty.path "alloc::sync::Arc") [ T; A ],
                                             "inner",
                                             []
                                           |),
                                           [ M.read (| self |) ]
-                                        |))
-                                        "alloc::sync::ArcInner"
-                                        "strong";
+                                        |),
+                                        "alloc::sync::ArcInner",
+                                        "strong"
+                                      |);
                                       Value.Integer Integer.Usize 1;
                                       Value.StructTuple "core::sync::atomic::Ordering::Release" []
                                     ]
@@ -7724,14 +7832,28 @@ Module sync.
                             "cast",
                             [ Ty.apply (Ty.path "alloc::sync::ArcInner") [ T ] ]
                           |),
-                          [ M.read (| M.get_struct_record_field self "alloc::sync::Arc" "ptr" |) ]
+                          [
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "alloc::sync::Arc",
+                                "ptr"
+                              |)
+                            |)
+                          ]
                         |)
                       |) in
                     let alloc :=
                       M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                          [ M.get_struct_record_field self "alloc::sync::Arc" "alloc" ]
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "alloc::sync::Arc",
+                              "alloc"
+                            |)
+                          ]
                         |)
                       |) in
                     let _ :=
@@ -7813,14 +7935,18 @@ Module sync.
                     "cast",
                     [ Ty.apply (Ty.path "alloc::sync::ArcInner") [ T ] ]
                   |),
-                  [ M.read (| M.get_struct_record_field self "alloc::sync::Arc" "ptr" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (| self, "alloc::sync::Arc", "ptr" |)
+                    |)
+                  ]
                 |)
               |) in
             let alloc :=
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                  [ M.get_struct_record_field self "alloc::sync::Arc" "alloc" ]
+                  [ M.SubPointer.get_struct_record_field (| self, "alloc::sync::Arc", "alloc" |) ]
                 |)
               |) in
             let _ :=
@@ -8010,7 +8136,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::sync::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::sync::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |)
@@ -8038,10 +8168,11 @@ Module sync.
                     (M.alloc (|
                       (* MutToConstPointer *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| ptr |))
-                          "alloc::sync::ArcInner"
-                          "data")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| ptr |),
+                          "alloc::sync::ArcInner",
+                          "data"
+                        |))
                     |)))
               ]
             |)
@@ -8264,8 +8395,8 @@ Module sync.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.match_operator (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.match_operator (|
                                               M.alloc (|
                                                 M.call_closure (|
                                                   M.get_trait_method (|
@@ -8295,7 +8426,7 @@ Module sync.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -8335,7 +8466,7 @@ Module sync.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -8343,9 +8474,10 @@ Module sync.
                                                     let val := M.copy (| γ0_0 |) in
                                                     val))
                                               ]
-                                            |))
-                                            "alloc::sync::WeakInner"
+                                            |),
+                                            "alloc::sync::WeakInner",
                                             "strong"
+                                          |)
                                         |);
                                         Value.StructTuple
                                           "core::sync::atomic::Ordering::Acquire"
@@ -8378,10 +8510,11 @@ Module sync.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::sync::Weak"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::sync::Weak",
                                       "ptr"
+                                    |)
                                   |);
                                   M.call_closure (|
                                     M.get_trait_method (|
@@ -8392,10 +8525,11 @@ Module sync.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::sync::Weak"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::sync::Weak",
                                         "alloc"
+                                      |)
                                     ]
                                   |)
                                 ]
@@ -8445,7 +8579,7 @@ Module sync.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -8460,7 +8594,11 @@ Module sync.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field inner "alloc::sync::WeakInner" "strong"
+                            M.SubPointer.get_struct_record_field (|
+                              inner,
+                              "alloc::sync::WeakInner",
+                              "strong"
+                            |)
                           |);
                           Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                         ]
@@ -8521,7 +8659,7 @@ Module sync.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -8537,7 +8675,11 @@ Module sync.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field inner "alloc::sync::WeakInner" "weak"
+                              M.SubPointer.get_struct_record_field (|
+                                inner,
+                                "alloc::sync::WeakInner",
+                                "weak"
+                              |)
                             |);
                             Value.StructTuple "core::sync::atomic::Ordering::Acquire" []
                           ]
@@ -8553,7 +8695,11 @@ Module sync.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field inner "alloc::sync::WeakInner" "strong"
+                              M.SubPointer.get_struct_record_field (|
+                                inner,
+                                "alloc::sync::WeakInner",
+                                "strong"
+                              |)
                             |);
                             Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                           ]
@@ -8624,7 +8770,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::sync::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::sync::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |)
@@ -8657,15 +8807,17 @@ Module sync.
                             "alloc::sync::WeakInner"
                             [
                               ("strong",
-                                M.get_struct_record_field
-                                  (M.read (| ptr |))
-                                  "alloc::sync::ArcInner"
-                                  "strong");
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| ptr |),
+                                  "alloc::sync::ArcInner",
+                                  "strong"
+                                |));
                               ("weak",
-                                M.get_struct_record_field
-                                  (M.read (| ptr |))
-                                  "alloc::sync::ArcInner"
-                                  "weak")
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| ptr |),
+                                  "alloc::sync::ArcInner",
+                                  "weak"
+                                |))
                             ]
                         ]
                     |)))
@@ -8712,7 +8864,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::sync::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::sync::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |));
@@ -8728,7 +8884,11 @@ Module sync.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "alloc::sync::Weak" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "alloc::sync::Weak",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |))
@@ -8808,7 +8968,7 @@ Module sync.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -8826,10 +8986,11 @@ Module sync.
                                       [
                                         ("ptr",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::sync::Weak"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::sync::Weak",
                                               "ptr"
+                                            |)
                                           |));
                                         ("alloc",
                                           M.call_closure (|
@@ -8841,10 +9002,11 @@ Module sync.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::sync::Weak"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::sync::Weak",
                                                 "alloc"
+                                              |)
                                             ]
                                           |))
                                       ]
@@ -8865,7 +9027,11 @@ Module sync.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field inner "alloc::sync::WeakInner" "weak"
+                          M.SubPointer.get_struct_record_field (|
+                            inner,
+                            "alloc::sync::WeakInner",
+                            "weak"
+                          |)
                         |);
                         Value.Integer Integer.Usize 1;
                         Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
@@ -8904,16 +9070,21 @@ Module sync.
                     [
                       ("ptr",
                         M.read (|
-                          M.get_struct_record_field (M.read (| self |)) "alloc::sync::Weak" "ptr"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::sync::Weak",
+                            "ptr"
+                          |)
                         |));
                       ("alloc",
                         M.call_closure (|
                           M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::sync::Weak"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::sync::Weak",
                               "alloc"
+                            |)
                           ]
                         |))
                     ]
@@ -9017,7 +9188,7 @@ Module sync.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -9049,10 +9220,11 @@ Module sync.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        inner
-                                        "alloc::sync::WeakInner"
+                                      M.SubPointer.get_struct_record_field (|
+                                        inner,
+                                        "alloc::sync::WeakInner",
                                         "weak"
+                                      |)
                                     |);
                                     Value.Integer Integer.Usize 1;
                                     Value.StructTuple "core::sync::atomic::Ordering::Release" []
@@ -9079,10 +9251,11 @@ Module sync.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::sync::Weak"
-                                "alloc";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::sync::Weak",
+                                "alloc"
+                              |);
                               M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
@@ -9093,10 +9266,11 @@ Module sync.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::sync::Weak"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::sync::Weak",
                                       "ptr"
+                                    |)
                                   |)
                                 ]
                               |);
@@ -9119,10 +9293,11 @@ Module sync.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::sync::Weak"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::sync::Weak",
                                             "ptr"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -10245,10 +10420,10 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let vec_ptr := M.copy (| γ0_0 |) in
                     let len := M.copy (| γ0_1 |) in
                     let cap := M.copy (| γ0_2 |) in
@@ -10276,10 +10451,11 @@ Module sync.
                               (M.read (|
                                 M.use
                                   (M.alloc (|
-                                    M.get_struct_record_field
-                                      (M.read (| rc_ptr |))
-                                      "alloc::sync::ArcInner"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| rc_ptr |),
+                                      "alloc::sync::ArcInner",
                                       "data"
+                                    |)
                                   |))
                               |));
                             M.read (| len |)
@@ -10361,7 +10537,7 @@ Module sync.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "alloc::borrow::Cow::Borrowed",
                         0
@@ -10384,11 +10560,7 @@ Module sync.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "alloc::borrow::Cow::Owned",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "alloc::borrow::Cow::Owned", 0 |) in
                     let s := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -10535,7 +10707,13 @@ Module sync.
                       M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                          [ M.get_struct_record_field boxed_slice "alloc::sync::Arc" "alloc" ]
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              boxed_slice,
+                              "alloc::sync::Arc",
+                              "alloc"
+                            |)
+                          ]
                         |)
                       |) in
                     M.alloc (|
@@ -10749,8 +10927,8 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let low := M.copy (| γ0_0 |) in
                     let high := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -10760,7 +10938,7 @@ Module sync.
                           ltac:(M.monadic
                             (let γ := high in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -10784,8 +10962,10 @@ Module sync.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let left_val := M.copy (| γ0_0 |) in
                                                 let right_val := M.copy (| γ0_1 |) in
                                                 M.match_operator (|

--- a/CoqOfRust/alloc/vec/drain.v
+++ b/CoqOfRust/alloc/vec/drain.v
@@ -68,10 +68,11 @@ Module vec.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::drain::Drain"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::drain::Drain",
                               "iter"
+                            |)
                           ]
                         |)
                       |))
@@ -111,7 +112,13 @@ Module vec.
                 "as_slice",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "iter" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::drain::Drain",
+                  "iter"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -146,7 +153,13 @@ Module vec.
                     "as_ref",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "vec" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::drain::Drain",
+                      "vec"
+                    |)
+                  ]
                 |)
               ]
             |)))
@@ -238,8 +251,8 @@ Module vec.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::DerefMut",
                             Ty.apply
@@ -250,9 +263,10 @@ Module vec.
                             []
                           |),
                           [ this ]
-                        |))
-                        "alloc::vec::drain::Drain"
+                        |),
+                        "alloc::vec::drain::Drain",
                         "vec"
+                      |)
                     ]
                   |)
                 |) in
@@ -269,8 +283,8 @@ Module vec.
                 |) in
               let tail :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_trait_method (|
                         "core::ops::deref::Deref",
                         Ty.apply
@@ -281,9 +295,10 @@ Module vec.
                         []
                       |),
                       [ this ]
-                    |))
-                    "alloc::vec::drain::Drain"
+                    |),
+                    "alloc::vec::drain::Drain",
                     "tail_start"
+                  |)
                 |) in
               let unyielded_len :=
                 M.alloc (|
@@ -296,8 +311,8 @@ Module vec.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -308,9 +323,10 @@ Module vec.
                             []
                           |),
                           [ this ]
-                        |))
-                        "alloc::vec::drain::Drain"
+                        |),
+                        "alloc::vec::drain::Drain",
                         "iter"
+                      |)
                     ]
                   |)
                 |) in
@@ -326,8 +342,8 @@ Module vec.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_trait_method (|
                                 "core::ops::deref::Deref",
                                 Ty.apply
@@ -338,9 +354,10 @@ Module vec.
                                 []
                               |),
                               [ this ]
-                            |))
-                            "alloc::vec::drain::Drain"
+                            |),
+                            "alloc::vec::drain::Drain",
                             "iter"
+                          |)
                         ]
                       |)
                     ]
@@ -479,8 +496,8 @@ Module vec.
                                         M.read (| src |);
                                         M.read (| dst |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.call_closure (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.call_closure (|
                                               M.get_trait_method (|
                                                 "core::ops::deref::Deref",
                                                 Ty.apply
@@ -495,9 +512,10 @@ Module vec.
                                                 []
                                               |),
                                               [ this ]
-                                            |))
-                                            "alloc::vec::drain::Drain"
+                                            |),
+                                            "alloc::vec::drain::Drain",
                                             "tail_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -522,8 +540,8 @@ Module vec.
                       BinOp.Panic.add (|
                         BinOp.Panic.add (| M.read (| start |), M.read (| unyielded_len |) |),
                         M.read (|
-                          M.get_struct_record_field
-                            (M.call_closure (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.call_closure (|
                               M.get_trait_method (|
                                 "core::ops::deref::Deref",
                                 Ty.apply
@@ -534,9 +552,10 @@ Module vec.
                                 []
                               |),
                               [ this ]
-                            |))
-                            "alloc::vec::drain::Drain"
+                            |),
+                            "alloc::vec::drain::Drain",
                             "tail_len"
+                          |)
                         |)
                       |)
                     ]
@@ -642,7 +661,12 @@ Module vec.
                     "next",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "iter"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::drain::Drain",
+                      "iter"
+                    |)
                   ]
                 |);
                 M.closure
@@ -688,7 +712,13 @@ Module vec.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "iter" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::drain::Drain",
+                  "iter"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -736,7 +766,12 @@ Module vec.
                     "next_back",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "iter"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::drain::Drain",
+                      "iter"
+                    |)
                   ]
                 |);
                 M.closure
@@ -859,10 +894,11 @@ Module vec.
                           [ Ty.apply (Ty.path "core::slice::iter::Iter") [ T ] ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::drain::Drain"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::drain::Drain",
                             "iter"
+                          |)
                         ]
                       |)
                     |) in
@@ -881,7 +917,11 @@ Module vec.
                     |) in
                   let vec :=
                     M.copy (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "vec"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
+                        "vec"
+                      |)
                     |) in
                   let _ :=
                     M.match_operator (|
@@ -938,10 +978,11 @@ Module vec.
                                                 M.read (| drop_len |)
                                               |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::vec::drain::Drain"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::vec::drain::Drain",
                                                   "tail_len"
+                                                |)
                                               |)
                                             |)
                                           ]
@@ -960,10 +1001,11 @@ Module vec.
                                             BinOp.Panic.add (|
                                               M.read (| old_len |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::vec::drain::Drain"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::vec::drain::Drain",
                                                   "tail_len"
+                                                |)
                                               |)
                                             |)
                                           ]
@@ -1122,7 +1164,13 @@ Module vec.
                 "is_empty",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "iter" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::drain::Drain",
+                  "iter"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.

--- a/CoqOfRust/alloc/vec/extract_if.v
+++ b/CoqOfRust/alloc/vec/extract_if.v
@@ -41,39 +41,44 @@ Module vec.
                 M.read (| Value.String "vec" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::extract_if::ExtractIf"
-                    "vec");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::extract_if::ExtractIf",
+                    "vec"
+                  |));
                 M.read (| Value.String "idx" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::extract_if::ExtractIf"
-                    "idx");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::extract_if::ExtractIf",
+                    "idx"
+                  |));
                 M.read (| Value.String "del" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::extract_if::ExtractIf"
-                    "del");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::extract_if::ExtractIf",
+                    "del"
+                  |));
                 M.read (| Value.String "old_len" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::extract_if::ExtractIf"
-                    "old_len");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::extract_if::ExtractIf",
+                    "old_len"
+                  |));
                 M.read (| Value.String "pred" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::extract_if::ExtractIf"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::extract_if::ExtractIf",
                       "pred"
+                    |)
                   |))
               ]
             |)))
@@ -112,10 +117,11 @@ Module vec.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::extract_if::ExtractIf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::extract_if::ExtractIf",
                     "vec"
+                  |)
                 |)
               ]
             |)))
@@ -181,16 +187,18 @@ Module vec.
                                     (M.alloc (|
                                       BinOp.Pure.lt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::extract_if::ExtractIf"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::extract_if::ExtractIf",
                                             "idx"
+                                          |)
                                         |))
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::extract_if::ExtractIf"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::extract_if::ExtractIf",
                                             "old_len"
+                                          |)
                                         |))
                                     |)) in
                                 let _ :=
@@ -200,10 +208,11 @@ Module vec.
                                   |) in
                                 let i :=
                                   M.copy (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::extract_if::ExtractIf"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::extract_if::ExtractIf",
                                       "idx"
+                                    |)
                                   |) in
                                 let v :=
                                   M.alloc (|
@@ -221,18 +230,20 @@ Module vec.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::vec::extract_if::ExtractIf"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::vec::extract_if::ExtractIf",
                                                 "vec"
+                                              |)
                                             |)
                                           ]
                                         |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::extract_if::ExtractIf"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::extract_if::ExtractIf",
                                             "old_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -248,20 +259,23 @@ Module vec.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::extract_if::ExtractIf"
-                                          "pred";
-                                        Value.Tuple [ M.get_array_field (| M.read (| v |), i |) ]
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::extract_if::ExtractIf",
+                                          "pred"
+                                        |);
+                                        Value.Tuple
+                                          [ M.SubPointer.get_array_field (| M.read (| v |), i |) ]
                                       ]
                                     |)
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::extract_if::ExtractIf"
-                                      "idx" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::extract_if::ExtractIf",
+                                      "idx"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -285,10 +299,11 @@ Module vec.
                                             M.read (|
                                               let _ :=
                                                 let β :=
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "alloc::vec::extract_if::ExtractIf"
-                                                    "del" in
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "alloc::vec::extract_if::ExtractIf",
+                                                    "del"
+                                                  |) in
                                                 M.write (|
                                                   β,
                                                   BinOp.Panic.add (|
@@ -302,7 +317,12 @@ Module vec.
                                                   [
                                                     M.call_closure (|
                                                       M.get_function (| "core::ptr::read", [ T ] |),
-                                                      [ M.get_array_field (| M.read (| v |), i |) ]
+                                                      [
+                                                        M.SubPointer.get_array_field (|
+                                                          M.read (| v |),
+                                                          i
+                                                        |)
+                                                      ]
                                                     |)
                                                   ]
                                               |)
@@ -321,10 +341,11 @@ Module vec.
                                                     (M.alloc (|
                                                       BinOp.Pure.gt
                                                         (M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "alloc::vec::extract_if::ExtractIf"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "alloc::vec::extract_if::ExtractIf",
                                                             "del"
+                                                          |)
                                                         |))
                                                         (Value.Integer Integer.Usize 0)
                                                     |)) in
@@ -335,18 +356,22 @@ Module vec.
                                                   |) in
                                                 let del :=
                                                   M.copy (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "alloc::vec::extract_if::ExtractIf"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "alloc::vec::extract_if::ExtractIf",
                                                       "del"
+                                                    |)
                                                   |) in
                                                 let src :=
                                                   M.alloc (|
-                                                    M.get_array_field (| M.read (| v |), i |)
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| v |),
+                                                      i
+                                                    |)
                                                   |) in
                                                 let dst :=
                                                   M.alloc (|
-                                                    M.get_array_field (|
+                                                    M.SubPointer.get_array_field (|
                                                       M.read (| v |),
                                                       M.alloc (|
                                                         BinOp.Panic.sub (|
@@ -417,16 +442,18 @@ Module vec.
                   [
                     BinOp.Panic.sub (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::extract_if::ExtractIf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::extract_if::ExtractIf",
                           "old_len"
+                        |)
                       |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::extract_if::ExtractIf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::extract_if::ExtractIf",
                           "idx"
+                        |)
                       |)
                     |)
                   ]
@@ -491,24 +518,27 @@ Module vec.
                               LogicalOp.and (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::extract_if::ExtractIf"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::extract_if::ExtractIf",
                                       "idx"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::extract_if::ExtractIf"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::extract_if::ExtractIf",
                                       "old_len"
+                                    |)
                                   |)),
                                 ltac:(M.monadic
                                   (BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::vec::extract_if::ExtractIf"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::vec::extract_if::ExtractIf",
                                         "del"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)))
                               |)
@@ -525,10 +555,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::extract_if::ExtractIf"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::extract_if::ExtractIf",
                                     "vec"
+                                  |)
                                 |)
                               ]
                             |)
@@ -544,10 +575,11 @@ Module vec.
                               [
                                 M.read (| ptr |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::extract_if::ExtractIf"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::extract_if::ExtractIf",
                                     "idx"
+                                  |)
                                 |)
                               ]
                             |)
@@ -563,10 +595,11 @@ Module vec.
                               [
                                 M.read (| src |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::extract_if::ExtractIf"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::extract_if::ExtractIf",
                                     "del"
+                                  |)
                                 |)
                               ]
                             |)
@@ -575,16 +608,18 @@ Module vec.
                           M.alloc (|
                             BinOp.Panic.sub (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::extract_if::ExtractIf"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::extract_if::ExtractIf",
                                   "old_len"
+                                |)
                               |),
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::extract_if::ExtractIf"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::extract_if::ExtractIf",
                                   "idx"
+                                |)
                               |)
                             |)
                           |) in
@@ -613,23 +648,26 @@ Module vec.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::extract_if::ExtractIf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::extract_if::ExtractIf",
                           "vec"
+                        |)
                       |);
                       BinOp.Panic.sub (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::extract_if::ExtractIf"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::extract_if::ExtractIf",
                             "old_len"
+                          |)
                         |),
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::extract_if::ExtractIf"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::extract_if::ExtractIf",
                             "del"
+                          |)
                         |)
                       |)
                     ]

--- a/CoqOfRust/alloc/vec/in_place_collect.v
+++ b/CoqOfRust/alloc/vec/in_place_collect.v
@@ -59,17 +59,17 @@ Module vec.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
                           |) in
                         let step_merge := M.copy (| γ1_0 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "core::option::Option::Some",
                             0
@@ -413,24 +413,27 @@ Module vec.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| inner |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| inner |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "buf"
+                                |)
                               |)
                             ]
                           |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| inner |))
-                              "alloc::vec::into_iter::IntoIter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| inner |),
+                              "alloc::vec::into_iter::IntoIter",
                               "ptr"
+                            |)
                           |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| inner |))
-                              "alloc::vec::into_iter::IntoIter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| inner |),
+                              "alloc::vec::into_iter::IntoIter",
                               "cap"
+                            |)
                           |);
                           M.rust_cast
                             (M.call_closure (|
@@ -441,27 +444,30 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| inner |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| inner |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "buf"
+                                  |)
                                 |)
                               ]
                             |));
                           M.rust_cast
                             (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| inner |))
-                                "alloc::vec::into_iter::IntoIter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| inner |),
+                                "alloc::vec::into_iter::IntoIter",
                                 "end"
+                              |)
                             |));
                           BinOp.Panic.div (|
                             BinOp.Panic.mul (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| inner |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| inner |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "cap"
+                                |)
                               |),
                               M.call_closure (|
                                 M.get_function (| "core::mem::size_of", [ Ty.associated ] |),
@@ -478,12 +484,12 @@ Module vec.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
-                          let γ0_3 := M.get_tuple_field γ 3 in
-                          let γ0_4 := M.get_tuple_field γ 4 in
-                          let γ0_5 := M.get_tuple_field γ 5 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                          let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                          let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                          let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
                           let src_buf := M.copy (| γ0_0 |) in
                           let src_ptr := M.copy (| γ0_1 |) in
                           let src_cap := M.copy (| γ0_2 |) in
@@ -556,10 +562,11 @@ Module vec.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| src |))
-                                                        "alloc::vec::into_iter::IntoIter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| src |),
+                                                        "alloc::vec::into_iter::IntoIter",
                                                         "buf"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -569,8 +576,9 @@ Module vec.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let left_val := M.copy (| γ0_0 |) in
                                               let right_val := M.copy (| γ0_1 |) in
                                               M.match_operator (|
@@ -649,10 +657,11 @@ Module vec.
                                         (M.alloc (|
                                           BinOp.Pure.ne
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| src |))
-                                                "alloc::vec::into_iter::IntoIter"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| src |),
+                                                "alloc::vec::into_iter::IntoIter",
                                                 "ptr"
+                                              |)
                                             |))
                                             (M.read (| src_ptr |))
                                         |)) in
@@ -699,10 +708,11 @@ Module vec.
                                                                       ]
                                                                     |)))
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| src |))
-                                                                      "alloc::vec::into_iter::IntoIter"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| src |),
+                                                                      "alloc::vec::into_iter::IntoIter",
                                                                       "ptr"
+                                                                    |)
                                                                   |)))
                                                             |)) in
                                                         let _ :=
@@ -826,8 +836,10 @@ Module vec.
                                                   [
                                                     fun γ =>
                                                       ltac:(M.monadic
-                                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                                        (let γ0_0 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                        let γ0_1 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                         let left_val := M.copy (| γ0_0 |) in
                                                         let right_val := M.copy (| γ0_1 |) in
                                                         M.match_operator (|
@@ -917,8 +929,10 @@ Module vec.
                                                   [
                                                     fun γ =>
                                                       ltac:(M.monadic
-                                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                                        (let γ0_0 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                        let γ0_1 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                         let left_val := M.copy (| γ0_0 |) in
                                                         let right_val := M.copy (| γ0_1 |) in
                                                         M.match_operator (|
@@ -1093,7 +1107,7 @@ Module vec.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Ok",
                                                 0
@@ -1169,8 +1183,10 @@ Module vec.
                                                   [
                                                     fun γ =>
                                                       ltac:(M.monadic
-                                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                                        (let γ0_0 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                        let γ0_1 :=
+                                                          M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                         let left_val := M.copy (| γ0_0 |) in
                                                         let right_val := M.copy (| γ0_1 |) in
                                                         M.match_operator (|
@@ -1354,10 +1370,11 @@ Module vec.
                                                                       (* MutToConstPointer *)
                                                                       (M.pointer_coercion
                                                                         (M.read (|
-                                                                          M.get_struct_record_field
-                                                                            sink
-                                                                            "alloc::vec::in_place_drop::InPlaceDrop"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            sink,
+                                                                            "alloc::vec::in_place_drop::InPlaceDrop",
                                                                             "dst"
+                                                                          |)
                                                                         |))))
                                                                     (M.read (| src_end |)))
                                                               |)) in
@@ -1414,10 +1431,11 @@ Module vec.
                                             M.get_function (| "core::ptr::write", [ T ] |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  sink
-                                                  "alloc::vec::in_place_drop::InPlaceDrop"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  sink,
+                                                  "alloc::vec::in_place_drop::InPlaceDrop",
                                                   "dst"
+                                                |)
                                               |);
                                               M.read (| item |)
                                             ]
@@ -1425,10 +1443,11 @@ Module vec.
                                         |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            sink
-                                            "alloc::vec::in_place_drop::InPlaceDrop"
-                                            "dst",
+                                          M.SubPointer.get_struct_record_field (|
+                                            sink,
+                                            "alloc::vec::in_place_drop::InPlaceDrop",
+                                            "dst"
+                                          |),
                                           M.call_closure (|
                                             M.get_associated_function (|
                                               Ty.apply (Ty.path "*mut") [ T ],
@@ -1437,10 +1456,11 @@ Module vec.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  sink
-                                                  "alloc::vec::in_place_drop::InPlaceDrop"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  sink,
+                                                  "alloc::vec::in_place_drop::InPlaceDrop",
                                                   "dst"
+                                                |)
                                               |);
                                               Value.Integer Integer.Usize 1
                                             ]
@@ -1551,8 +1571,8 @@ Module vec.
                   M.get_associated_function (| Ty.apply (Ty.path "*mut") [ T ], "sub_ptr", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::Deref",
                             Ty.apply
@@ -1580,9 +1600,10 @@ Module vec.
                               |)
                             |)
                           ]
-                        |))
-                        "alloc::vec::in_place_drop::InPlaceDrop"
+                        |),
+                        "alloc::vec::in_place_drop::InPlaceDrop",
                         "dst"
+                      |)
                     |);
                     (* MutToConstPointer *) M.pointer_coercion (M.read (| dst_buf |))
                   ]
@@ -1703,7 +1724,7 @@ Module vec.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1818,10 +1839,11 @@ Module vec.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              drop_guard
-                                              "alloc::vec::in_place_drop::InPlaceDrop"
-                                              "dst",
+                                            M.SubPointer.get_struct_record_field (|
+                                              drop_guard,
+                                              "alloc::vec::in_place_drop::InPlaceDrop",
+                                              "dst"
+                                            |),
                                             M.call_closure (|
                                               M.get_associated_function (|
                                                 Ty.apply (Ty.path "*mut") [ T ],

--- a/CoqOfRust/alloc/vec/in_place_drop.v
+++ b/CoqOfRust/alloc/vec/in_place_drop.v
@@ -30,18 +30,20 @@ Module vec.
               M.get_associated_function (| Ty.apply (Ty.path "*mut") [ T ], "sub_ptr", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::in_place_drop::InPlaceDrop"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::in_place_drop::InPlaceDrop",
                     "dst"
+                  |)
                 |);
                 (* MutToConstPointer *)
                 M.pointer_coercion
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::in_place_drop::InPlaceDrop"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::in_place_drop::InPlaceDrop",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -83,10 +85,11 @@ Module vec.
                         M.get_function (| "core::slice::raw::from_raw_parts_mut", [ T ] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::in_place_drop::InPlaceDrop"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::in_place_drop::InPlaceDrop",
                               "inner"
+                            |)
                           |);
                           M.call_closure (|
                             M.get_associated_function (|
@@ -153,22 +156,25 @@ Module vec.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::in_place_drop::InPlaceDstBufDrop"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::in_place_drop::InPlaceDstBufDrop",
                           "ptr"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::in_place_drop::InPlaceDstBufDrop"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::in_place_drop::InPlaceDstBufDrop",
                           "len"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::in_place_drop::InPlaceDstBufDrop"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::in_place_drop::InPlaceDstBufDrop",
                           "cap"
+                        |)
                       |)
                     ]
                   |)

--- a/CoqOfRust/alloc/vec/into_iter.v
+++ b/CoqOfRust/alloc/vec/into_iter.v
@@ -105,10 +105,11 @@ Module vec.
               M.get_function (| "core::slice::raw::from_raw_parts", [ T ] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
                     "ptr"
+                  |)
                 |);
                 M.call_closure (|
                   M.get_trait_method (|
@@ -175,10 +176,11 @@ Module vec.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::vec::into_iter::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::into_iter::IntoIter",
                   "alloc"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -204,10 +206,11 @@ Module vec.
               [
                 M.rust_cast
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::into_iter::IntoIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::into_iter::IntoIter",
                       "ptr"
+                    |)
                   |));
                 M.call_closure (|
                   M.get_trait_method (|
@@ -273,18 +276,20 @@ Module vec.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
-                    "cap",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
+                    "cap"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
-                    "buf",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
+                    "buf"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ],
@@ -307,10 +312,11 @@ Module vec.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
-                    "ptr",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
+                    "ptr"
+                  |),
                   (* MutToConstPointer *)
                   M.pointer_coercion
                     (M.call_closure (|
@@ -321,20 +327,22 @@ Module vec.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::into_iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::into_iter::IntoIter",
                             "buf"
+                          |)
                         |)
                       ]
                     |))
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
-                    "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
+                    "end"
+                  |),
                   (* MutToConstPointer *)
                   M.pointer_coercion
                     (M.call_closure (|
@@ -345,10 +353,11 @@ Module vec.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::into_iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::into_iter::IntoIter",
                             "buf"
+                          |)
                         |)
                       ]
                     |))
@@ -391,15 +400,17 @@ Module vec.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::into_iter::IntoIter"
-                    "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::into_iter::IntoIter",
+                    "end"
+                  |),
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::into_iter::IntoIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::into_iter::IntoIter",
                       "ptr"
+                    |)
                   |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -470,8 +481,8 @@ Module vec.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::deref::Deref",
                               Ty.apply
@@ -482,9 +493,10 @@ Module vec.
                               []
                             |),
                             [ this ]
-                          |))
-                          "alloc::vec::into_iter::IntoIter"
+                          |),
+                          "alloc::vec::into_iter::IntoIter",
                           "buf"
+                        |)
                       |)
                     ]
                   |)
@@ -550,8 +562,8 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.call_closure (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.call_closure (|
                                             M.get_trait_method (|
                                               "core::ops::deref::Deref",
                                               Ty.apply
@@ -566,9 +578,10 @@ Module vec.
                                               []
                                             |),
                                             [ this ]
-                                          |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                          |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "ptr"
+                                        |)
                                       |);
                                       (* MutToConstPointer *) M.pointer_coercion (M.read (| buf |))
                                     ]
@@ -582,8 +595,8 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.call_closure (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.call_closure (|
                                             M.get_trait_method (|
                                               "core::ops::deref::Deref",
                                               Ty.apply
@@ -598,9 +611,10 @@ Module vec.
                                               []
                                             |),
                                             [ this ]
-                                          |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                          |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "end"
+                                        |)
                                       |);
                                       (* MutToConstPointer *) M.pointer_coercion (M.read (| buf |))
                                     ]
@@ -612,8 +626,8 @@ Module vec.
                 |) in
               let cap :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.call_closure (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.call_closure (|
                       M.get_trait_method (|
                         "core::ops::deref::Deref",
                         Ty.apply
@@ -624,9 +638,10 @@ Module vec.
                         []
                       |),
                       [ this ]
-                    |))
-                    "alloc::vec::into_iter::IntoIter"
+                    |),
+                    "alloc::vec::into_iter::IntoIter",
                     "cap"
+                  |)
                 |) in
               let alloc :=
                 M.alloc (|
@@ -637,8 +652,8 @@ Module vec.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.call_closure (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::deref::DerefMut",
                             Ty.apply
@@ -649,9 +664,10 @@ Module vec.
                             []
                           |),
                           [ this ]
-                        |))
-                        "alloc::vec::into_iter::IntoIter"
+                        |),
+                        "alloc::vec::into_iter::IntoIter",
                         "alloc"
+                      |)
                     ]
                   |)
                 |) in
@@ -779,16 +795,18 @@ Module vec.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "ptr"
+                                |)
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "end"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -810,10 +828,11 @@ Module vec.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
-                                    "end",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
+                                    "end"
+                                  |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "*const") [ T ],
@@ -822,10 +841,11 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "end"
+                                        |)
                                       |);
                                       Value.Integer Integer.Usize 1
                                     ]
@@ -845,17 +865,19 @@ Module vec.
                             ltac:(M.monadic
                               (let old :=
                                 M.copy (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
-                                    "ptr",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
+                                    "ptr"
+                                  |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "*const") [ T ],
@@ -864,10 +886,11 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "ptr"
+                                        |)
                                       |);
                                       Value.Integer Integer.Usize 1
                                     ]
@@ -931,10 +954,11 @@ Module vec.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::vec::into_iter::IntoIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::vec::into_iter::IntoIter",
                                         "end"
+                                      |)
                                     |)
                                   ]
                                 |);
@@ -946,10 +970,11 @@ Module vec.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::vec::into_iter::IntoIter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::vec::into_iter::IntoIter",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -967,16 +992,18 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "end"
+                                  |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1049,10 +1076,11 @@ Module vec.
                     [
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::into_iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::into_iter::IntoIter",
                             "ptr"
+                          |)
                         |));
                       M.read (| step_size |)
                     ]
@@ -1070,10 +1098,11 @@ Module vec.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
+                              "end"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "*const") [ T ],
@@ -1082,10 +1111,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "end"
+                                  |)
                                 |);
                                 M.read (| step_size |)
                               ]
@@ -1096,10 +1126,11 @@ Module vec.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
-                              "ptr",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
+                              "ptr"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "*const") [ T ],
@@ -1108,10 +1139,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |);
                                 M.read (| step_size |)
                               ]
@@ -1355,10 +1387,11 @@ Module vec.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::into_iter::IntoIter"
-                                          "end",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::into_iter::IntoIter",
+                                          "end"
+                                        |),
                                         M.call_closure (|
                                           M.get_associated_function (|
                                             Ty.apply (Ty.path "*const") [ T ],
@@ -1367,10 +1400,11 @@ Module vec.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::vec::into_iter::IntoIter"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::vec::into_iter::IntoIter",
                                                 "end"
+                                              |)
                                             |);
                                             M.read (|
                                               M.get_constant (|
@@ -1450,10 +1484,11 @@ Module vec.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::vec::into_iter::IntoIter"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::vec::into_iter::IntoIter",
                                                 "ptr"
+                                              |)
                                             |);
                                             M.rust_cast
                                               (M.call_closure (|
@@ -1526,10 +1561,11 @@ Module vec.
                               M.get_function (| "core::intrinsics::copy_nonoverlapping", [ T ] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |);
                                 M.rust_cast
                                   (M.call_closure (|
@@ -1554,10 +1590,11 @@ Module vec.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
-                              "ptr",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
+                              "ptr"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "*const") [ T ],
@@ -1566,10 +1603,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |);
                                 M.read (|
                                   M.get_constant (| "alloc::vec::into_iter::next_chunk::N" |)
@@ -1665,10 +1703,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "ptr"
+                                  |)
                                 |);
                                 M.read (| i |)
                               ]
@@ -1738,16 +1777,18 @@ Module vec.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "end"
+                                |)
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::into_iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::into_iter::IntoIter",
                                   "ptr"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -1769,10 +1810,11 @@ Module vec.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
-                                    "end",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
+                                    "end"
+                                  |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "*const") [ T ],
@@ -1781,10 +1823,11 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "end"
+                                        |)
                                       |);
                                       Value.Integer Integer.Usize 1
                                     ]
@@ -1804,10 +1847,11 @@ Module vec.
                             ltac:(M.monadic
                               (let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
-                                    "end",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
+                                    "end"
+                                  |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "*const") [ T ],
@@ -1816,10 +1860,11 @@ Module vec.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::into_iter::IntoIter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::into_iter::IntoIter",
                                           "end"
+                                        |)
                                       |);
                                       Value.Integer Integer.Usize 1
                                     ]
@@ -1833,10 +1878,11 @@ Module vec.
                                       M.get_function (| "core::ptr::read", [ T ] |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::into_iter::IntoIter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::into_iter::IntoIter",
                                             "end"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -1909,10 +1955,11 @@ Module vec.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
+                              "end"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "*const") [ T ],
@@ -1921,10 +1968,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "end"
+                                  |)
                                 |);
                                 M.read (| step_size |)
                               ]
@@ -1935,10 +1983,11 @@ Module vec.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
+                              "end"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "*const") [ T ],
@@ -1947,10 +1996,11 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::into_iter::IntoIter",
                                     "end"
+                                  |)
                                 |);
                                 M.read (| step_size |)
                               ]
@@ -1966,10 +2016,11 @@ Module vec.
                     [
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::into_iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::into_iter::IntoIter",
                             "end"
+                          |)
                         |));
                       M.read (| step_size |)
                     ]
@@ -2053,16 +2104,18 @@ Module vec.
             (let self := M.alloc (| self |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::vec::into_iter::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::into_iter::IntoIter",
                   "ptr"
+                |)
               |))
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "alloc::vec::into_iter::IntoIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::into_iter::IntoIter",
                   "end"
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -2252,10 +2305,11 @@ Module vec.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "alloc::vec::into_iter::IntoIter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::into_iter::IntoIter",
                               "alloc"
+                            |)
                           ]
                         |)
                       ]
@@ -2330,10 +2384,11 @@ Module vec.
                         |),
                         [
                           M.read (|
-                            M.get_struct_tuple_field
-                              guard
-                              "alloc::vec::into_iter::drop::DropGuard"
+                            M.SubPointer.get_struct_tuple_field (|
+                              guard,
+                              "alloc::vec::into_iter::drop::DropGuard",
                               0
+                            |)
                           |)
                         ]
                       |)

--- a/CoqOfRust/alloc/vec/is_zero.v
+++ b/CoqOfRust/alloc/vec/is_zero.v
@@ -1028,14 +1028,14 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
-                      let γ1_3 := M.get_tuple_field γ 3 in
-                      let γ1_4 := M.get_tuple_field γ 4 in
-                      let γ1_5 := M.get_tuple_field γ 5 in
-                      let γ1_6 := M.get_tuple_field γ 6 in
-                      let γ1_7 := M.get_tuple_field γ 7 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ1_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ1_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ1_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ1_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ1_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
                       let value_A := M.alloc (| γ1_0 |) in
                       let value_B := M.alloc (| γ1_1 |) in
                       let value_C := M.alloc (| γ1_2 |) in
@@ -1189,13 +1189,13 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
-                      let γ1_3 := M.get_tuple_field γ 3 in
-                      let γ1_4 := M.get_tuple_field γ 4 in
-                      let γ1_5 := M.get_tuple_field γ 5 in
-                      let γ1_6 := M.get_tuple_field γ 6 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ1_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ1_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ1_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ1_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
                       let value_B := M.alloc (| γ1_0 |) in
                       let value_C := M.alloc (| γ1_1 |) in
                       let value_D := M.alloc (| γ1_2 |) in
@@ -1335,12 +1335,12 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
-                      let γ1_3 := M.get_tuple_field γ 3 in
-                      let γ1_4 := M.get_tuple_field γ 4 in
-                      let γ1_5 := M.get_tuple_field γ 5 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ1_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ1_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ1_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
                       let value_C := M.alloc (| γ1_0 |) in
                       let value_D := M.alloc (| γ1_1 |) in
                       let value_E := M.alloc (| γ1_2 |) in
@@ -1466,11 +1466,11 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
-                      let γ1_3 := M.get_tuple_field γ 3 in
-                      let γ1_4 := M.get_tuple_field γ 4 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ1_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ1_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
                       let value_D := M.alloc (| γ1_0 |) in
                       let value_E := M.alloc (| γ1_1 |) in
                       let value_F := M.alloc (| γ1_2 |) in
@@ -1582,10 +1582,10 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
-                      let γ1_3 := M.get_tuple_field γ 3 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ1_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                       let value_E := M.alloc (| γ1_0 |) in
                       let value_F := M.alloc (| γ1_1 |) in
                       let value_G := M.alloc (| γ1_2 |) in
@@ -1683,9 +1683,9 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
-                      let γ1_2 := M.get_tuple_field γ 2 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ1_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                       let value_F := M.alloc (| γ1_0 |) in
                       let value_G := M.alloc (| γ1_1 |) in
                       let value_H := M.alloc (| γ1_2 |) in
@@ -1769,8 +1769,8 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
-                      let γ1_1 := M.get_tuple_field γ 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let value_G := M.alloc (| γ1_0 |) in
                       let value_H := M.alloc (| γ1_1 |) in
                       M.alloc (|
@@ -1840,7 +1840,7 @@ Module vec.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
-                      let γ1_0 := M.get_tuple_field γ 0 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
                       let value_H := M.alloc (| γ1_0 |) in
                       M.alloc (|
                         M.call_closure (|
@@ -2871,7 +2871,13 @@ Module vec.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_trait_method (| "alloc::vec::is_zero::IsZero", T, [], "is_zero", [] |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2902,7 +2908,13 @@ Module vec.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_trait_method (| "alloc::vec::is_zero::IsZero", T, [], "is_zero", [] |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.

--- a/CoqOfRust/alloc/vec/mod.v
+++ b/CoqOfRust/alloc/vec/mod.v
@@ -460,7 +460,8 @@ Module vec.
               "capacity",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+            [ M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::vec::Vec", "buf" |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -491,9 +492,17 @@ Module vec.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "buf"
+                    |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |);
                     M.read (| additional |)
                   ]
@@ -530,9 +539,17 @@ Module vec.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "buf"
+                    |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |);
                     M.read (| additional |)
                   ]
@@ -566,8 +583,18 @@ Module vec.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
-              M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::vec::Vec",
+                "buf"
+              |);
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |)
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -597,8 +624,18 @@ Module vec.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
-              M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::vec::Vec",
+                "buf"
+              |);
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |)
+              |);
               M.read (| additional |)
             ]
           |)))
@@ -644,7 +681,11 @@ Module vec.
                               [ M.read (| self |) ]
                             |))
                             (M.read (|
-                              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::vec::Vec",
+                                "len"
+                              |)
                             |))
                         |)) in
                     let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -657,9 +698,17 @@ Module vec.
                             []
                           |),
                           [
-                            M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::Vec",
+                              "buf"
+                            |);
                             M.read (|
-                              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::vec::Vec",
+                                "len"
+                              |)
                             |)
                           ]
                         |)
@@ -720,15 +769,20 @@ Module vec.
                             []
                           |),
                           [
-                            M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::Vec",
+                              "buf"
+                            |);
                             M.call_closure (|
                               M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::Vec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::Vec",
                                     "len"
+                                  |)
                                 |);
                                 M.read (| min_capacity |)
                               ]
@@ -798,8 +852,8 @@ Module vec.
                     [ Ty.apply (Ty.path "alloc::raw_vec::RawVec") [ T; A ] ]
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::Deref",
                           Ty.apply
@@ -810,9 +864,10 @@ Module vec.
                           []
                         |),
                         [ me ]
-                      |))
-                      "alloc::vec::Vec"
+                      |),
+                      "alloc::vec::Vec",
                       "buf"
+                    |)
                   ]
                 |)
               |) in
@@ -919,10 +974,11 @@ Module vec.
                                 BinOp.Pure.gt
                                   (M.read (| len |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::Vec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::Vec",
                                       "len"
+                                    |)
                                   |))
                               |)) in
                           let _ :=
@@ -937,7 +993,11 @@ Module vec.
                   M.alloc (|
                     BinOp.Panic.sub (|
                       M.read (|
-                        M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::Vec",
+                          "len"
+                        |)
                       |),
                       M.read (| len |)
                     |)
@@ -971,7 +1031,11 @@ Module vec.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "len"
+                    |),
                     M.read (| len |)
                   |) in
                 let _ :=
@@ -1071,7 +1135,13 @@ Module vec.
                 "ptr",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "buf"
+                |)
+              ]
             |))))
       | _, _ => M.impossible
       end.
@@ -1099,7 +1169,8 @@ Module vec.
               "ptr",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+            [ M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::vec::Vec", "buf" |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1125,7 +1196,8 @@ Module vec.
               "allocator",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+            [ M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::vec::Vec", "buf" |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1205,7 +1277,11 @@ Module vec.
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |),
                 M.read (| new_len |)
               |) in
             M.alloc (| Value.Tuple [] |)
@@ -1436,10 +1512,11 @@ Module vec.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::Vec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::Vec",
                                     "buf"
+                                  |)
                                 ]
                               |))
                           |)) in
@@ -2414,10 +2491,11 @@ Module vec.
                                   (M.alloc (|
                                     BinOp.Pure.lt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          gap
-                                          "alloc::vec::dedup_by::FillGapOnDrop"
+                                        M.SubPointer.get_struct_record_field (|
+                                          gap,
+                                          "alloc::vec::dedup_by::FillGapOnDrop",
                                           "read"
+                                        |)
                                       |))
                                       (M.read (| len |))
                                   |)) in
@@ -2437,10 +2515,11 @@ Module vec.
                                     [
                                       M.read (| start |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          gap
-                                          "alloc::vec::dedup_by::FillGapOnDrop"
+                                        M.SubPointer.get_struct_record_field (|
+                                          gap,
+                                          "alloc::vec::dedup_by::FillGapOnDrop",
                                           "read"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -2463,10 +2542,11 @@ Module vec.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              gap
-                                              "alloc::vec::dedup_by::FillGapOnDrop"
+                                            M.SubPointer.get_struct_record_field (|
+                                              gap,
+                                              "alloc::vec::dedup_by::FillGapOnDrop",
                                               "write"
+                                            |)
                                           |);
                                           Value.Integer Integer.Usize 1
                                         ]
@@ -2509,10 +2589,11 @@ Module vec.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            gap
-                                            "alloc::vec::dedup_by::FillGapOnDrop"
-                                            "read" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            gap,
+                                            "alloc::vec::dedup_by::FillGapOnDrop",
+                                            "read"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -2541,10 +2622,11 @@ Module vec.
                                             [
                                               M.read (| start |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  gap
-                                                  "alloc::vec::dedup_by::FillGapOnDrop"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  gap,
+                                                  "alloc::vec::dedup_by::FillGapOnDrop",
                                                   "write"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -2566,10 +2648,11 @@ Module vec.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            gap
-                                            "alloc::vec::dedup_by::FillGapOnDrop"
-                                            "write" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            gap,
+                                            "alloc::vec::dedup_by::FillGapOnDrop",
+                                            "write"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -2579,10 +2662,11 @@ Module vec.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            gap
-                                            "alloc::vec::dedup_by::FillGapOnDrop"
-                                            "read" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            gap,
+                                            "alloc::vec::dedup_by::FillGapOnDrop",
+                                            "read"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -2619,13 +2703,18 @@ Module vec.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field gap "alloc::vec::dedup_by::FillGapOnDrop" "vec"
+                          M.SubPointer.get_struct_record_field (|
+                            gap,
+                            "alloc::vec::dedup_by::FillGapOnDrop",
+                            "vec"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            gap
-                            "alloc::vec::dedup_by::FillGapOnDrop"
+                          M.SubPointer.get_struct_record_field (|
+                            gap,
+                            "alloc::vec::dedup_by::FillGapOnDrop",
                             "write"
+                          |)
                         |)
                       ]
                     |)
@@ -2683,10 +2772,11 @@ Module vec.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::Vec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::Vec",
                                   "len"
+                                |)
                               |))
                               (M.call_closure (|
                                 M.get_associated_function (|
@@ -2695,10 +2785,11 @@ Module vec.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "alloc::vec::Vec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "alloc::vec::Vec",
                                     "buf"
+                                  |)
                                 ]
                               |))
                           |)) in
@@ -2712,12 +2803,17 @@ Module vec.
                               []
                             |),
                             [
-                              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::vec::Vec",
+                                "buf"
+                              |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::Vec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::Vec",
                                   "len"
+                                |)
                               |)
                             ]
                           |)
@@ -2740,7 +2836,11 @@ Module vec.
                       [ M.read (| self |) ]
                     |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |)
                   ]
                 |)
@@ -2753,7 +2853,12 @@ Module vec.
                 |)
               |) in
             let _ :=
-              let β := M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" in
+              let β :=
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |) in
               M.write (|
                 β,
                 BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2801,10 +2906,11 @@ Module vec.
                               (M.alloc (|
                                 BinOp.Pure.eq
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::Vec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::Vec",
                                       "len"
+                                    |)
                                   |))
                                   (M.call_closure (|
                                     M.get_associated_function (|
@@ -2813,10 +2919,11 @@ Module vec.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "alloc::vec::Vec"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "alloc::vec::Vec",
                                         "buf"
+                                      |)
                                     ]
                                   |))
                               |)) in
@@ -2851,7 +2958,11 @@ Module vec.
                             [ M.read (| self |) ]
                           |);
                           M.read (|
-                            M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "alloc::vec::Vec",
+                              "len"
+                            |)
                           |)
                         ]
                       |)
@@ -2865,7 +2976,11 @@ Module vec.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2911,7 +3026,11 @@ Module vec.
                         (M.alloc (|
                           BinOp.Pure.eq
                             (M.read (|
-                              M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::vec::Vec",
+                                "len"
+                              |)
                             |))
                             (Value.Integer Integer.Usize 0)
                         |)) in
@@ -2921,7 +3040,11 @@ Module vec.
                   ltac:(M.monadic
                     (let _ :=
                       let β :=
-                        M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::Vec",
+                          "len"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2933,10 +3056,11 @@ Module vec.
                           [
                             BinOp.Pure.lt
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "alloc::vec::Vec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "alloc::vec::Vec",
                                   "len"
+                                |)
                               |))
                               (M.call_closure (|
                                 M.get_associated_function (|
@@ -3128,7 +3252,12 @@ Module vec.
                 |)
               |) in
             let _ :=
-              let β := M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" in
+              let β :=
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |) in
               M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| count |) |) |) in
             M.alloc (| Value.Tuple [] |)
           |)))
@@ -3203,13 +3332,13 @@ Module vec.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "start"
                       |) in
                     let γ0_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "end"
@@ -3334,7 +3463,11 @@ Module vec.
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |),
                 Value.Integer Integer.Usize 0
               |) in
             let _ :=
@@ -3367,7 +3500,9 @@ Module vec.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| M.read (| self |), "alloc::vec::Vec", "len" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -3566,7 +3701,11 @@ Module vec.
                   M.alloc (|
                     BinOp.Panic.sub (|
                       M.read (|
-                        M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::Vec",
+                          "len"
+                        |)
                       |),
                       M.read (| at_ |)
                     |)
@@ -3837,8 +3976,8 @@ Module vec.
                     ]
                   |);
                   M.read (|
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::Deref",
                           Ty.apply
@@ -3849,9 +3988,10 @@ Module vec.
                           []
                         |),
                         [ me ]
-                      |))
-                      "alloc::vec::Vec"
+                      |),
+                      "alloc::vec::Vec",
                       "len"
+                    |)
                   |)
                 ]
               |)
@@ -3902,7 +4042,11 @@ Module vec.
                       [ M.read (| self |) ]
                     |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |)
                   ]
                 |));
@@ -3913,9 +4057,21 @@ Module vec.
                     "capacity",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "buf"
+                    |)
+                  ]
                 |),
-                M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::Vec",
+                    "len"
+                  |)
+                |)
               |)
             ]
           |)))
@@ -3955,9 +4111,9 @@ Module vec.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                     let init := M.copy (| γ0_0 |) in
                     let spare := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| init |); M.read (| spare |) ] |)))
@@ -4020,7 +4176,11 @@ Module vec.
                   [
                     M.read (| ptr |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |)
                   ]
                 |)
@@ -4045,9 +4205,21 @@ Module vec.
                       "capacity",
                       []
                     |),
-                    [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "buf" ]
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "buf"
+                      |)
+                    ]
                   |),
-                  M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "len"
+                    |)
+                  |)
                 |)
               |) in
             let initialized :=
@@ -4057,7 +4229,11 @@ Module vec.
                   [
                     M.read (| ptr |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |)
                   ]
                 |)
@@ -4077,7 +4253,11 @@ Module vec.
                 [
                   M.read (| initialized |);
                   M.read (| spare |);
-                  M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::Vec",
+                    "len"
+                  |)
                 ]
             |)
           |)))
@@ -4373,7 +4553,13 @@ Module vec.
                     "new",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "len"
+                    |)
+                  ]
                 |)
               |) in
             let _ :=
@@ -4426,7 +4612,7 @@ Module vec.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -4638,7 +4824,7 @@ Module vec.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -4696,8 +4882,8 @@ Module vec.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let lower := M.copy (| γ0_0 |) in
                                           let _ :=
                                             M.alloc (|
@@ -4852,8 +5038,8 @@ Module vec.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let low := M.copy (| γ0_0 |) in
                     let high := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -4863,7 +5049,7 @@ Module vec.
                           ltac:(M.monadic
                             (let γ := high in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -4887,8 +5073,10 @@ Module vec.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let left_val := M.copy (| γ0_0 |) in
                                                 let right_val := M.copy (| γ0_1 |) in
                                                 M.match_operator (|
@@ -5049,10 +5237,11 @@ Module vec.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "alloc::vec::Vec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "alloc::vec::Vec",
                                       "len"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -5337,10 +5526,10 @@ Module vec.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let ptr := M.copy (| γ0_0 |) in
                     let len := M.copy (| γ0_1 |) in
                     let cap := M.copy (| γ0_2 |) in
@@ -5422,8 +5611,8 @@ Module vec.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let new_len := M.copy (| γ0_0 |) in
                             let new_cap := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -5560,9 +5749,9 @@ Module vec.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                     let this := M.copy (| γ0_0 |) in
                     let spare := M.copy (| γ0_1 |) in
                     let len := M.copy (| γ0_2 |) in
@@ -5695,8 +5884,10 @@ Module vec.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let src := M.copy (| γ0_0 |) in
                                                 let dst := M.copy (| γ0_1 |) in
                                                 M.call_closure (|
@@ -5838,8 +6029,8 @@ Module vec.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let init := M.copy (| γ0_0 |) in
                       let spare := M.copy (| γ0_1 |) in
                       let source :=
@@ -5889,7 +6080,12 @@ Module vec.
                 ]
               |) in
             let _ :=
-              let β := M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" in
+              let β :=
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |) in
               M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| count |) |) |) in
             M.alloc (| Value.Tuple [] |)
           |)))
@@ -5934,7 +6130,13 @@ Module vec.
                 |),
                 [ M.read (| self |) ]
               |);
-              M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |)
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -5975,7 +6177,13 @@ Module vec.
                 |),
                 [ M.read (| self |) ]
               |);
-              M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::Vec",
+                  "len"
+                |)
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -6515,8 +6723,8 @@ Module vec.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::Deref",
                           Ty.apply
@@ -6527,9 +6735,10 @@ Module vec.
                           []
                         |),
                         [ me ]
-                      |))
-                      "alloc::vec::Vec"
+                      |),
+                      "alloc::vec::Vec",
                       "buf"
+                    |)
                   ]
                 |)
               |) in
@@ -7074,7 +7283,13 @@ Module vec.
                     |),
                     [ M.read (| self |) ]
                   |);
-                  M.read (| M.get_struct_record_field (M.read (| self |)) "alloc::vec::Vec" "len" |)
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::Vec",
+                      "len"
+                    |)
+                  |)
                 ]
               |)
             ]

--- a/CoqOfRust/alloc/vec/set_len_on_drop.v
+++ b/CoqOfRust/alloc/vec/set_len_on_drop.v
@@ -47,10 +47,11 @@ Module vec.
             M.read (|
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::set_len_on_drop::SetLenOnDrop"
-                    "local_len" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::set_len_on_drop::SetLenOnDrop",
+                    "local_len"
+                  |) in
                 M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| increment |) |) |) in
               M.alloc (| Value.Tuple [] |)
             |)))
@@ -71,10 +72,11 @@ Module vec.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "alloc::vec::set_len_on_drop::SetLenOnDrop"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "alloc::vec::set_len_on_drop::SetLenOnDrop",
                 "local_len"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -99,16 +101,18 @@ Module vec.
               let _ :=
                 M.write (|
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::set_len_on_drop::SetLenOnDrop"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::set_len_on_drop::SetLenOnDrop",
                       "len"
+                    |)
                   |),
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::set_len_on_drop::SetLenOnDrop"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::set_len_on_drop::SetLenOnDrop",
                       "local_len"
+                    |)
                   |)
                 |) in
               M.alloc (| Value.Tuple [] |)

--- a/CoqOfRust/alloc/vec/spec_from_iter.v
+++ b/CoqOfRust/alloc/vec/spec_from_iter.v
@@ -98,15 +98,20 @@ Module vec.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    iterator
-                                    "alloc::vec::into_iter::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    iterator,
+                                    "alloc::vec::into_iter::IntoIter",
                                     "buf"
+                                  |)
                                 |)
                               ]
                             |))))
                         (M.read (|
-                          M.get_struct_record_field iterator "alloc::vec::into_iter::IntoIter" "ptr"
+                          M.SubPointer.get_struct_record_field (|
+                            iterator,
+                            "alloc::vec::into_iter::IntoIter",
+                            "ptr"
+                          |)
                         |))
                     |) in
                   let _ :=
@@ -136,10 +141,11 @@ Module vec.
                                         |))
                                         (BinOp.Panic.div (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              iterator
-                                              "alloc::vec::into_iter::IntoIter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              iterator,
+                                              "alloc::vec::into_iter::IntoIter",
                                               "cap"
+                                            |)
                                           |),
                                           Value.Integer Integer.Usize 2
                                         |))))
@@ -188,8 +194,8 @@ Module vec.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.call_closure (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.call_closure (|
                                                           M.get_trait_method (|
                                                             "core::ops::deref::Deref",
                                                             Ty.apply
@@ -209,9 +215,10 @@ Module vec.
                                                             []
                                                           |),
                                                           [ it ]
-                                                        |))
-                                                        "alloc::vec::into_iter::IntoIter"
+                                                        |),
+                                                        "alloc::vec::into_iter::IntoIter",
                                                         "ptr"
+                                                      |)
                                                     |);
                                                     M.call_closure (|
                                                       M.get_associated_function (|
@@ -223,8 +230,8 @@ Module vec.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.call_closure (|
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.call_closure (|
                                                               M.get_trait_method (|
                                                                 "core::ops::deref::Deref",
                                                                 Ty.apply
@@ -245,9 +252,10 @@ Module vec.
                                                                 []
                                                               |),
                                                               [ it ]
-                                                            |))
-                                                            "alloc::vec::into_iter::IntoIter"
+                                                            |),
+                                                            "alloc::vec::into_iter::IntoIter",
                                                             "buf"
+                                                          |)
                                                         |)
                                                       ]
                                                     |);
@@ -311,8 +319,8 @@ Module vec.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.call_closure (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.call_closure (|
                                                   M.get_trait_method (|
                                                     "core::ops::deref::Deref",
                                                     Ty.apply
@@ -329,9 +337,10 @@ Module vec.
                                                     []
                                                   |),
                                                   [ it ]
-                                                |))
-                                                "alloc::vec::into_iter::IntoIter"
+                                                |),
+                                                "alloc::vec::into_iter::IntoIter",
                                                 "buf"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -365,8 +374,8 @@ Module vec.
                                           ]
                                         |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.call_closure (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.call_closure (|
                                               M.get_trait_method (|
                                                 "core::ops::deref::Deref",
                                                 Ty.apply
@@ -381,9 +390,10 @@ Module vec.
                                                 []
                                               |),
                                               [ it ]
-                                            |))
-                                            "alloc::vec::into_iter::IntoIter"
+                                            |),
+                                            "alloc::vec::into_iter::IntoIter",
                                             "cap"
+                                          |)
                                         |)
                                       ]
                                     |)

--- a/CoqOfRust/alloc/vec/spec_from_iter_nested.v
+++ b/CoqOfRust/alloc/vec/spec_from_iter_nested.v
@@ -86,7 +86,7 @@ Module vec.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -108,8 +108,8 @@ Module vec.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let lower := M.copy (| γ0_0 |) in
                                       let initial_capacity :=
                                         M.alloc (|
@@ -263,10 +263,10 @@ Module vec.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_1,
                               "core::option::Option::Some",
                               0

--- a/CoqOfRust/alloc/vec/splice.v
+++ b/CoqOfRust/alloc/vec/splice.v
@@ -38,18 +38,20 @@ Module vec.
                 M.read (| Value.String "drain" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::splice::Splice"
-                    "drain");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::splice::Splice",
+                    "drain"
+                  |));
                 M.read (| Value.String "replace_with" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "alloc::vec::splice::Splice"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "alloc::vec::splice::Splice",
                       "replace_with"
+                    |)
                   |))
               ]
             |)))
@@ -91,7 +93,13 @@ Module vec.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::splice::Splice" "drain" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::splice::Splice",
+                  "drain"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -115,7 +123,13 @@ Module vec.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::splice::Splice" "drain" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::splice::Splice",
+                  "drain"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -157,7 +171,13 @@ Module vec.
                 "next_back",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::splice::Splice" "drain" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "alloc::vec::splice::Splice",
+                  "drain"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -264,10 +284,11 @@ Module vec.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "alloc::vec::splice::Splice"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "alloc::vec::splice::Splice",
                                 "drain"
+                              |)
                             ]
                           |);
                           M.get_function (| "core::mem::drop", [ Ty.associated ] |)
@@ -276,13 +297,15 @@ Module vec.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "alloc::vec::splice::Splice"
-                          "drain")
-                        "alloc::vec::drain::Drain"
-                        "iter",
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "alloc::vec::splice::Splice",
+                          "drain"
+                        |),
+                        "alloc::vec::drain::Drain",
+                        "iter"
+                      |),
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply (Ty.path "slice") [ Ty.associated ],
@@ -303,13 +326,15 @@ Module vec.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::splice::Splice"
-                                          "drain")
-                                        "alloc::vec::drain::Drain"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::splice::Splice",
+                                          "drain"
+                                        |),
+                                        "alloc::vec::drain::Drain",
                                         "tail_len"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -342,13 +367,15 @@ Module vec.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "alloc::vec::splice::Splice"
-                                                  "drain")
-                                                "alloc::vec::drain::Drain"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "alloc::vec::splice::Splice",
+                                                  "drain"
+                                                |),
+                                                "alloc::vec::drain::Drain",
                                                 "vec"
+                                              |)
                                             ]
                                           |);
                                           M.call_closure (|
@@ -360,10 +387,11 @@ Module vec.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "alloc::vec::splice::Splice"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "alloc::vec::splice::Splice",
                                                 "replace_with"
+                                              |)
                                             ]
                                           |)
                                         ]
@@ -395,14 +423,16 @@ Module vec.
                                         [ I ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::splice::Splice"
-                                          "drain";
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "alloc::vec::splice::Splice"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::splice::Splice",
+                                          "drain"
+                                        |);
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "alloc::vec::splice::Splice",
                                           "replace_with"
+                                        |)
                                       ]
                                     |))
                                 |)) in
@@ -425,18 +455,19 @@ Module vec.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::splice::Splice"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::splice::Splice",
                             "replace_with"
+                          |)
                         ]
                       |)
                     |),
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let lower_bound := M.copy (| γ0_0 |) in
                           let _upper_bound := M.copy (| γ0_1 |) in
                           let _ :=
@@ -468,10 +499,11 @@ Module vec.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "alloc::vec::splice::Splice"
-                                              "drain";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "alloc::vec::splice::Splice",
+                                              "drain"
+                                            |);
                                             M.read (| lower_bound |)
                                           ]
                                         |)
@@ -494,14 +526,16 @@ Module vec.
                                                         [ I ]
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::vec::splice::Splice"
-                                                          "drain";
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "alloc::vec::splice::Splice"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::vec::splice::Splice",
+                                                          "drain"
+                                                        |);
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "alloc::vec::splice::Splice",
                                                           "replace_with"
+                                                        |)
                                                       ]
                                                     |))
                                                 |)) in
@@ -556,10 +590,11 @@ Module vec.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::splice::Splice"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::splice::Splice",
                                             "replace_with"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -606,10 +641,11 @@ Module vec.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::splice::Splice"
-                                            "drain";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::splice::Splice",
+                                            "drain"
+                                          |);
                                           M.call_closure (|
                                             M.get_trait_method (|
                                               "core::iter::traits::exact_size::ExactSizeIterator",
@@ -640,10 +676,11 @@ Module vec.
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "alloc::vec::splice::Splice"
-                                            "drain";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "alloc::vec::splice::Splice",
+                                            "drain"
+                                          |);
                                           collected
                                         ]
                                       |)
@@ -741,8 +778,10 @@ Module vec.
                                                 [
                                                   fun γ =>
                                                     ltac:(M.monadic
-                                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                                      (let γ0_0 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                      let γ0_1 :=
+                                                        M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                       let left_val := M.copy (| γ0_0 |) in
                                                       let right_val := M.copy (| γ0_1 |) in
                                                       M.match_operator (|
@@ -873,23 +912,29 @@ Module vec.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::drain::Drain"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::drain::Drain",
                             "vec"
+                          |)
                         ]
                       |)
                     |) in
                   let range_start :=
                     M.copy (|
-                      M.get_struct_record_field (M.read (| vec |)) "alloc::vec::Vec" "len"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| vec |),
+                        "alloc::vec::Vec",
+                        "len"
+                      |)
                     |) in
                   let range_end :=
                     M.copy (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::vec::drain::Drain"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
                         "tail_start"
+                      |)
                     |) in
                   let range_slice :=
                     M.alloc (|
@@ -962,7 +1007,7 @@ Module vec.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -987,7 +1032,7 @@ Module vec.
                                                         |)
                                                       |) in
                                                     let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -1008,10 +1053,11 @@ Module vec.
                                                       |) in
                                                     let _ :=
                                                       let β :=
-                                                        M.get_struct_record_field
-                                                          (M.read (| vec |))
-                                                          "alloc::vec::Vec"
-                                                          "len" in
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| vec |),
+                                                          "alloc::vec::Vec",
+                                                          "len"
+                                                        |) in
                                                       M.write (|
                                                         β,
                                                         BinOp.Panic.add (|
@@ -1080,7 +1126,12 @@ Module vec.
                       "as_mut",
                       []
                     |),
-                    [ M.get_struct_record_field (M.read (| self |)) "alloc::vec::drain::Drain" "vec"
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
+                        "vec"
+                      |)
                     ]
                   |)
                 |) in
@@ -1088,16 +1139,18 @@ Module vec.
                 M.alloc (|
                   BinOp.Panic.add (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::vec::drain::Drain"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
                         "tail_start"
+                      |)
                     |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::vec::drain::Drain"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
                         "tail_len"
+                      |)
                     |)
                   |)
                 |) in
@@ -1110,7 +1163,11 @@ Module vec.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| vec |)) "alloc::vec::Vec" "buf";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| vec |),
+                        "alloc::vec::Vec",
+                        "buf"
+                      |);
                       M.read (| len |);
                       M.read (| additional |)
                     ]
@@ -1120,10 +1177,11 @@ Module vec.
                 M.alloc (|
                   BinOp.Panic.add (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "alloc::vec::drain::Drain"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "alloc::vec::drain::Drain",
                         "tail_start"
+                      |)
                     |),
                     M.read (| additional |)
                   |)
@@ -1143,10 +1201,11 @@ Module vec.
                           [ M.read (| vec |) ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::drain::Drain"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::drain::Drain",
                             "tail_start"
+                          |)
                         |)
                       ]
                     |)
@@ -1176,10 +1235,11 @@ Module vec.
                         M.read (| src |);
                         M.read (| dst |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "alloc::vec::drain::Drain"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "alloc::vec::drain::Drain",
                             "tail_len"
+                          |)
                         |)
                       ]
                     |)
@@ -1187,10 +1247,11 @@ Module vec.
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "alloc::vec::drain::Drain"
-                    "tail_start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "alloc::vec::drain::Drain",
+                    "tail_start"
+                  |),
                   M.read (| new_tail_start |)
                 |) in
               M.alloc (| Value.Tuple [] |)

--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -1,3 +1,7 @@
+alloc/
+core/
+examples/axiomatized/
+move/
 alloc/boxed.v
 core/any.v
 core/array/mod.v

--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -1,3 +1,5 @@
+examples/default/examples/ink_contracts/proofs/erc20.v
+examples/default/examples/ink_contracts/proofs/erc721.v
 move/
 alloc/boxed.v
 core/any.v
@@ -7,7 +9,6 @@ core/error.v
 core/escape.v
 core/iter/adapters/flatten.v
 core/net/ip_addr.v
-examples/default/examples/ink_contracts/proofs/erc20.v
 examples/axiomatized/examples/custom/provided_method.v
 examples/axiomatized/examples/rust_book/traits/traits.v
 examples/axiomatized/examples/subtle.v

--- a/CoqOfRust/blacklist.txt
+++ b/CoqOfRust/blacklist.txt
@@ -1,6 +1,3 @@
-alloc/
-core/
-examples/axiomatized/
 move/
 alloc/boxed.v
 core/any.v

--- a/CoqOfRust/core/alloc/layout.v
+++ b/CoqOfRust/core/alloc/layout.v
@@ -94,18 +94,20 @@ Module alloc.
                 M.read (| Value.String "size" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::alloc::layout::Layout"
-                    "size");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::alloc::layout::Layout",
+                    "size"
+                  |));
                 M.read (| Value.String "align" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::alloc::layout::Layout"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::alloc::layout::Layout",
                       "align"
+                    |)
                   |))
               ]
             |)))
@@ -144,13 +146,18 @@ Module alloc.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::alloc::layout::Layout" "size"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::alloc::layout::Layout",
+                    "size"
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::alloc::layout::Layout"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::alloc::layout::Layout",
                     "size"
+                  |)
                 |)),
               ltac:(M.monadic
                 (M.call_closure (|
@@ -162,14 +169,16 @@ Module alloc.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::alloc::layout::Layout"
-                      "align";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::alloc::layout::Layout"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::alloc::layout::Layout",
                       "align"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::alloc::layout::Layout",
+                      "align"
+                    |)
                   ]
                 |)))
             |)))
@@ -251,10 +260,11 @@ Module alloc.
                       [ __H ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::alloc::layout::Layout"
-                        "size";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::alloc::layout::Layout",
+                        "size"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -269,10 +279,11 @@ Module alloc.
                     [ __H ]
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::alloc::layout::Layout"
-                      "align";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::alloc::layout::Layout",
+                      "align"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -533,7 +544,11 @@ Module alloc.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::alloc::layout::Layout" "size"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::alloc::layout::Layout",
+                "size"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -558,10 +573,11 @@ Module alloc.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::alloc::layout::Layout"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::alloc::layout::Layout",
                     "align"
+                  |)
                 |)
               ]
             |)))
@@ -594,8 +610,8 @@ Module alloc.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let size := M.copy (| γ0_0 |) in
                       let align := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -646,8 +662,8 @@ Module alloc.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let size := M.copy (| γ0_0 |) in
                       let align := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -699,8 +715,8 @@ Module alloc.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let size := M.copy (| γ0_0 |) in
                       let align := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -1055,7 +1071,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1098,7 +1114,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1135,10 +1151,11 @@ Module alloc.
                                 [
                                   M.read (| alloc_size |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::alloc::layout::Layout"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::alloc::layout::Layout",
                                       "align"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -1149,7 +1166,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1192,7 +1209,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1245,13 +1262,18 @@ Module alloc.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::alloc::layout::Layout"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::alloc::layout::Layout",
                               "align"
+                            |)
                           |);
                           M.read (|
-                            M.get_struct_record_field next "core::alloc::layout::Layout" "align"
+                            M.SubPointer.get_struct_record_field (|
+                              next,
+                              "core::alloc::layout::Layout",
+                              "align"
+                            |)
                           |)
                         ]
                       |)
@@ -1327,7 +1349,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1370,7 +1392,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1430,7 +1452,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1473,7 +1495,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1516,7 +1538,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1559,7 +1581,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1647,7 +1669,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1686,7 +1708,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1706,10 +1728,11 @@ Module alloc.
                       [
                         M.read (| size |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::alloc::layout::Layout"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::alloc::layout::Layout",
                             "align"
+                          |)
                         |)
                       ]
                     |)
@@ -1795,7 +1818,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1834,7 +1857,7 @@ Module alloc.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1854,10 +1877,11 @@ Module alloc.
                       [
                         M.read (| new_size |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::alloc::layout::Layout"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::alloc::layout::Layout",
                             "align"
+                          |)
                         |)
                       ]
                     |)

--- a/CoqOfRust/core/alloc/mod.v
+++ b/CoqOfRust/core/alloc/mod.v
@@ -220,7 +220,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -261,7 +261,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -447,7 +447,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -488,7 +488,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -685,7 +685,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -726,7 +726,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -924,7 +924,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -965,7 +965,7 @@ Module alloc.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0

--- a/CoqOfRust/core/any.v
+++ b/CoqOfRust/core/any.v
@@ -784,7 +784,11 @@ Module any.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::any::TypeId" "t"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::any::TypeId",
+                    "t"
+                  |)
                 |))
             ]
           |)))
@@ -856,8 +860,16 @@ Module any.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::any::TypeId" "t";
-              M.get_struct_record_field (M.read (| other |)) "core::any::TypeId" "t"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::any::TypeId",
+                "t"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "core::any::TypeId",
+                "t"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -884,8 +896,16 @@ Module any.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::Ord", Ty.path "u128", [], "cmp", [] |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::any::TypeId" "t";
-              M.get_struct_record_field (M.read (| other |)) "core::any::TypeId" "t"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::any::TypeId",
+                "t"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "core::any::TypeId",
+                "t"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -914,8 +934,16 @@ Module any.
           (let self := M.alloc (| self |) in
           let other := M.alloc (| other |) in
           BinOp.Pure.eq
-            (M.read (| M.get_struct_record_field (M.read (| self |)) "core::any::TypeId" "t" |))
-            (M.read (| M.get_struct_record_field (M.read (| other |)) "core::any::TypeId" "t" |))))
+            (M.read (|
+              M.SubPointer.get_struct_record_field (| M.read (| self |), "core::any::TypeId", "t" |)
+            |))
+            (M.read (|
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "core::any::TypeId",
+                "t"
+              |)
+            |))))
       | _, _ => M.impossible
       end.
     
@@ -988,7 +1016,11 @@ Module any.
                     M.alloc (|
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_record_field (M.read (| self |)) "core::any::TypeId" "t"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::any::TypeId",
+                            "t"
+                          |)
                         |))
                     |);
                     M.read (| state |)

--- a/CoqOfRust/core/array/drain.v
+++ b/CoqOfRust/core/array/drain.v
@@ -111,7 +111,13 @@ Module array.
                     "as_mut_slice",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::array::drain::Drain" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::array::drain::Drain",
+                      0
+                    |)
+                  ]
                 |)
               ]
             |)))
@@ -173,10 +179,11 @@ Module array.
                                   []
                                 |),
                                 [
-                                  M.get_struct_tuple_field
-                                    (M.read (| self |))
-                                    "core::array::drain::Drain"
+                                  M.SubPointer.get_struct_tuple_field (|
+                                    M.read (| self |),
+                                    "core::array::drain::Drain",
                                     0
+                                  |)
                                 ]
                               |)
                             ]
@@ -186,7 +193,7 @@ Module array.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -217,7 +224,7 @@ Module array.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -319,7 +326,13 @@ Module array.
                 "len",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::array::drain::Drain" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::array::drain::Drain",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -374,7 +387,13 @@ Module array.
                       "next_unchecked",
                       []
                     |),
-                    [ M.get_struct_tuple_field (M.read (| self |)) "core::array::drain::Drain" 0 ]
+                    [
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::array::drain::Drain",
+                        0
+                      |)
+                    ]
                   |)
                 |) in
               M.alloc (|

--- a/CoqOfRust/core/array/equality.v
+++ b/CoqOfRust/core/array/equality.v
@@ -105,7 +105,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -126,7 +126,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -174,7 +174,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -195,7 +195,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -256,7 +256,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -277,7 +277,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -325,7 +325,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -346,7 +346,7 @@ Module array.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0

--- a/CoqOfRust/core/array/iter.v
+++ b/CoqOfRust/core/array/iter.v
@@ -161,10 +161,18 @@ Module array.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field initialized "core::ops::range::Range" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          initialized,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field initialized "core::ops::range::Range" "end"
+                        M.SubPointer.get_struct_record_field (|
+                          initialized,
+                          "core::ops::range::Range",
+                          "end"
+                        |)
                       |)
                     ]
                   |)
@@ -265,10 +273,11 @@ Module array.
                     [
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::array::iter::IntoIter"
-                          "data");
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::array::iter::IntoIter",
+                          "data"
+                        |));
                       M.call_closure (|
                         M.get_trait_method (|
                           "core::clone::Clone",
@@ -278,10 +287,11 @@ Module array.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::iter::IntoIter",
                             "alive"
+                          |)
                         ]
                       |)
                     ]
@@ -334,10 +344,11 @@ Module array.
                     [
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::array::iter::IntoIter"
-                          "data");
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::array::iter::IntoIter",
+                          "data"
+                        |));
                       M.call_closure (|
                         M.get_trait_method (|
                           "core::clone::Clone",
@@ -347,10 +358,11 @@ Module array.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::iter::IntoIter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::iter::IntoIter",
                             "alive"
+                          |)
                         ]
                       |)
                     ]
@@ -421,10 +433,11 @@ Module array.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::array::iter::IntoIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::array::iter::IntoIter",
                       "alive"
+                    |)
                   ]
                 |);
                 M.closure
@@ -460,10 +473,11 @@ Module array.
                                       [
                                         (* Unsize *)
                                         M.pointer_coercion
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::array::iter::IntoIter"
-                                            "data");
+                                          (M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::array::iter::IntoIter",
+                                            "data"
+                                          |));
                                         M.read (| idx |)
                                       ]
                                     |)
@@ -539,7 +553,13 @@ Module array.
             let fold := M.alloc (| fold |) in
             M.read (|
               let data :=
-                M.alloc (| M.get_struct_record_field self "core::array::iter::IntoIter" "data" |) in
+                M.alloc (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::array::iter::IntoIter",
+                    "data"
+                  |)
+                |) in
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (|
@@ -554,7 +574,13 @@ Module array.
                   [
                     Value.StructTuple
                       "core::iter::adapters::by_ref_sized::ByRefSized"
-                      [ M.get_struct_record_field self "core::array::iter::IntoIter" "alive" ];
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::array::iter::IntoIter",
+                          "alive"
+                        |)
+                      ];
                     M.read (| init |);
                     M.closure
                       (fun γ =>
@@ -714,10 +740,11 @@ Module array.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::array::iter::IntoIter"
-                        "alive";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::array::iter::IntoIter",
+                        "alive"
+                      |);
                       M.read (| n |)
                     ]
                   |)
@@ -750,10 +777,11 @@ Module array.
                       [
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::iter::IntoIter"
-                            "data");
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::iter::IntoIter",
+                            "data"
+                          |));
                         M.read (| range_to_drop |)
                       ]
                     |)
@@ -869,10 +897,11 @@ Module array.
                               [
                                 (* Unsize *)
                                 M.pointer_coercion
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::array::iter::IntoIter"
-                                    "data")
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::array::iter::IntoIter",
+                                    "data"
+                                  |))
                               ]
                             |);
                             M.call_closure (|
@@ -882,10 +911,11 @@ Module array.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::array::iter::IntoIter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::array::iter::IntoIter",
                                   "alive"
+                                |)
                               ]
                             |)
                           ]
@@ -962,10 +992,11 @@ Module array.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::array::iter::IntoIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::array::iter::IntoIter",
                       "alive"
+                    |)
                   ]
                 |);
                 M.closure
@@ -1001,10 +1032,11 @@ Module array.
                                       [
                                         (* Unsize *)
                                         M.pointer_coercion
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::array::iter::IntoIter"
-                                            "data");
+                                          (M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::array::iter::IntoIter",
+                                            "data"
+                                          |));
                                         M.read (| idx |)
                                       ]
                                     |)
@@ -1043,7 +1075,13 @@ Module array.
             let rfold := M.alloc (| rfold |) in
             M.read (|
               let data :=
-                M.alloc (| M.get_struct_record_field self "core::array::iter::IntoIter" "data" |) in
+                M.alloc (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::array::iter::IntoIter",
+                    "data"
+                  |)
+                |) in
               M.alloc (|
                 M.call_closure (|
                   M.get_trait_method (|
@@ -1058,7 +1096,13 @@ Module array.
                   [
                     Value.StructTuple
                       "core::iter::adapters::by_ref_sized::ByRefSized"
-                      [ M.get_struct_record_field self "core::array::iter::IntoIter" "alive" ];
+                      [
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::array::iter::IntoIter",
+                          "alive"
+                        |)
+                      ];
                     M.read (| init |);
                     M.closure
                       (fun γ =>
@@ -1170,10 +1214,11 @@ Module array.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::array::iter::IntoIter"
-                        "alive";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::array::iter::IntoIter",
+                        "alive"
+                      |);
                       M.read (| n |)
                     ]
                   |)
@@ -1206,10 +1251,11 @@ Module array.
                       [
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::iter::IntoIter"
-                            "data");
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::iter::IntoIter",
+                            "data"
+                          |));
                         M.read (| range_to_drop |)
                       ]
                     |)
@@ -1346,7 +1392,12 @@ Module array.
                 "len",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::array::iter::IntoIter" "alive"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::array::iter::IntoIter",
+                  "alive"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1371,7 +1422,12 @@ Module array.
                 "is_empty",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::array::iter::IntoIter" "alive"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::array::iter::IntoIter",
+                  "alive"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1546,7 +1602,11 @@ Module array.
                                 |),
                                 [ M.read (| self |) ]
                               |);
-                              M.get_struct_record_field new "core::array::iter::IntoIter" "data"
+                              M.SubPointer.get_struct_record_field (|
+                                new,
+                                "core::array::iter::IntoIter",
+                                "data"
+                              |)
                             ]
                           |)
                         ]
@@ -1592,13 +1652,13 @@ Module array.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let src := M.copy (| γ1_0 |) in
                                         let dst := M.copy (| γ1_1 |) in
                                         let _ :=
@@ -1628,10 +1688,11 @@ Module array.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              new
-                                              "core::array::iter::IntoIter"
-                                              "alive",
+                                            M.SubPointer.get_struct_record_field (|
+                                              new,
+                                              "core::array::iter::IntoIter",
+                                              "alive"
+                                            |),
                                             M.call_closure (|
                                               M.get_associated_function (|
                                                 Ty.path "core::ops::index_range::IndexRange",
@@ -1647,10 +1708,11 @@ Module array.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        new
-                                                        "core::array::iter::IntoIter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        new,
+                                                        "core::array::iter::IntoIter",
                                                         "alive"
+                                                      |)
                                                     ]
                                                   |),
                                                   Value.Integer Integer.Usize 1

--- a/CoqOfRust/core/array/mod.v
+++ b/CoqOfRust/core/array/mod.v
@@ -16,8 +16,8 @@ Module array.
       ltac:(M.monadic
         (let cb := M.alloc (| cb |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.alloc (|
+          M.SubPointer.get_struct_tuple_field (|
+            M.alloc (|
               M.call_closure (|
                 M.get_function (|
                   "core::array::try_from_fn",
@@ -37,9 +37,10 @@ Module array.
                   |)
                 ]
               |)
-            |))
-            "core::ops::try_trait::NeverShortCircuit"
+            |),
+            "core::ops::try_trait::NeverShortCircuit",
             0
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -89,7 +90,7 @@ Module array.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
+                    M.SubPointer.get_struct_tuple_field (|
                       γ,
                       "core::ops::control_flow::ControlFlow::Break",
                       0
@@ -110,7 +111,7 @@ Module array.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
+                    M.SubPointer.get_struct_tuple_field (|
                       γ,
                       "core::ops::control_flow::ControlFlow::Continue",
                       0
@@ -217,7 +218,11 @@ Module array.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::array::TryFromSliceError" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::array::TryFromSliceError",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -4436,8 +4441,8 @@ Module array.
           (let self := M.alloc (| self |) in
           let f := M.alloc (| f |) in
           M.read (|
-            M.get_struct_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_struct_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "array") [ T ],
@@ -4459,9 +4464,10 @@ Module array.
                     |)
                   ]
                 |)
-              |))
-              "core::ops::try_trait::NeverShortCircuit"
+              |),
+              "core::ops::try_trait::NeverShortCircuit",
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -4799,8 +4805,8 @@ Module array.
       ltac:(M.monadic
         (let iter := M.alloc (| iter |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.alloc (|
+          M.SubPointer.get_struct_tuple_field (|
+            M.alloc (|
               M.call_closure (|
                 M.get_function (|
                   "core::array::try_from_trusted_iterator",
@@ -4838,9 +4844,10 @@ Module array.
                   |)
                 ]
               |)
-            |))
-            "core::ops::try_trait::NeverShortCircuit"
+            |),
+            "core::ops::try_trait::NeverShortCircuit",
             0
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -4883,8 +4890,8 @@ Module array.
                           UnOp.Pure.not
                             (BinOp.Pure.ge
                               (M.read (|
-                                M.get_tuple_field
-                                  (M.alloc (|
+                                M.SubPointer.get_tuple_field (|
+                                  M.alloc (|
                                     M.call_closure (|
                                       M.get_trait_method (|
                                         "core::iter::traits::iterator::Iterator",
@@ -4895,8 +4902,9 @@ Module array.
                                       |),
                                       [ iter ]
                                     |)
-                                  |))
+                                  |),
                                   0
+                                |)
                               |))
                               (M.read (|
                                 M.get_constant (| "core::array::try_from_trusted_iterator::N" |)
@@ -5028,10 +5036,11 @@ Module array.
                                 (M.alloc (|
                                   BinOp.Pure.lt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        guard
-                                        "core::array::Guard"
+                                      M.SubPointer.get_struct_record_field (|
+                                        guard,
+                                        "core::array::Guard",
                                         "initialized"
+                                      |)
                                     |))
                                     (M.call_closure (|
                                       M.get_associated_function (|
@@ -5047,10 +5056,11 @@ Module array.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            guard
-                                            "core::array::Guard"
+                                          M.SubPointer.get_struct_record_field (|
+                                            guard,
+                                            "core::array::Guard",
                                             "array_mut"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -5094,10 +5104,11 @@ Module array.
                                                 Value.Tuple
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        guard
-                                                        "core::array::Guard"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        guard,
+                                                        "core::array::Guard",
                                                         "initialized"
+                                                      |)
                                                     |)
                                                   ]
                                               ]
@@ -5111,7 +5122,7 @@ Module array.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -5149,7 +5160,7 @@ Module array.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -5264,16 +5275,18 @@ Module array.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::Guard"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::Guard",
                             "array_mut"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::array::Guard"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::array::Guard",
                             "initialized"
+                          |)
                         |)
                       ]
                     |);
@@ -5283,15 +5296,20 @@ Module array.
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "core::array::Guard" "initialized",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::array::Guard",
+                  "initialized"
+                |),
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "unchecked_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::array::Guard"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::array::Guard",
                         "initialized"
+                      |)
                     |);
                     Value.Integer Integer.Usize 1
                   ]
@@ -5349,10 +5367,11 @@ Module array.
                                       UnOp.Pure.not
                                         (BinOp.Pure.le
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::array::Guard"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::array::Guard",
                                               "initialized"
+                                            |)
                                           |))
                                           (M.call_closure (|
                                             M.get_associated_function (|
@@ -5368,10 +5387,11 @@ Module array.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::array::Guard"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::array::Guard",
                                                   "array_mut"
+                                                |)
                                               |)
                                             ]
                                           |)))
@@ -5426,20 +5446,22 @@ Module array.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::array::Guard"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::array::Guard",
                                 "array_mut"
+                              |)
                             |);
                             Value.StructRecord
                               "core::ops::range::RangeTo"
                               [
                                 ("end_",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::array::Guard"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::array::Guard",
                                       "initialized"
+                                    |)
                                   |))
                               ]
                           ]
@@ -5514,11 +5536,7 @@ Module array.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (|
                     Value.StructTuple
                       "core::result::Result::Ok"
@@ -5536,11 +5554,7 @@ Module array.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let initialized := M.copy (| γ0_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -5620,7 +5634,11 @@ Module array.
                             (M.alloc (|
                               BinOp.Pure.lt
                                 (M.read (|
-                                  M.get_struct_record_field guard "core::array::Guard" "initialized"
+                                  M.SubPointer.get_struct_record_field (|
+                                    guard,
+                                    "core::array::Guard",
+                                    "initialized"
+                                  |)
                                 |))
                                 (M.call_closure (|
                                   M.get_associated_function (|
@@ -5636,10 +5654,11 @@ Module array.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        guard
-                                        "core::array::Guard"
+                                      M.SubPointer.get_struct_record_field (|
+                                        guard,
+                                        "core::array::Guard",
                                         "array_mut"
+                                      |)
                                     |)
                                   ]
                                 |))
@@ -5663,7 +5682,7 @@ Module array.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/core/ascii.v
+++ b/CoqOfRust/core/ascii.v
@@ -29,7 +29,13 @@ Module ascii.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::ascii::EscapeDefault",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -103,7 +109,13 @@ Module ascii.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "next", [] |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::ascii::EscapeDefault",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -128,7 +140,13 @@ Module ascii.
                     "len",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::ascii::EscapeDefault",
+                      0
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -152,7 +170,7 @@ Module ascii.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field self "core::ascii::EscapeDefault" 0 ]
+            [ M.SubPointer.get_struct_tuple_field (| self, "core::ascii::EscapeDefault", 0 |) ]
           |)))
       | _, _ => M.impossible
       end.
@@ -173,7 +191,7 @@ Module ascii.
               "next_back",
               []
             |),
-            [ M.get_struct_tuple_field self "core::ascii::EscapeDefault" 0 ]
+            [ M.SubPointer.get_struct_tuple_field (| self, "core::ascii::EscapeDefault", 0 |) ]
           |)))
       | _, _ => M.impossible
       end.
@@ -196,7 +214,11 @@ Module ascii.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::ascii::EscapeDefault",
+                0
+              |);
               M.read (| n |)
             ]
           |)))
@@ -238,7 +260,13 @@ Module ascii.
               "next_back",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::ascii::EscapeDefault",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -261,7 +289,11 @@ Module ascii.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::ascii::EscapeDefault",
+                0
+              |);
               M.read (| n |)
             ]
           |)))
@@ -295,7 +327,13 @@ Module ascii.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::ascii::EscapeDefault",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -343,7 +381,13 @@ Module ascii.
                   "as_str",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::ascii::EscapeDefault" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::ascii::EscapeDefault",
+                    0
+                  |)
+                ]
               |)
             ]
           |)))

--- a/CoqOfRust/core/ascii/ascii_char.v
+++ b/CoqOfRust/core/ascii/ascii_char.v
@@ -1469,7 +1469,7 @@ Module ascii.
                                   ltac:(M.monadic
                                     (let hi :=
                                       M.copy (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.get_constant (|
                                             "core::ascii::ascii_char::fmt::HEX_DIGITS"
                                           |),
@@ -1494,7 +1494,7 @@ Module ascii.
                                       |) in
                                     let lo :=
                                       M.copy (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.get_constant (|
                                             "core::ascii::ascii_char::fmt::HEX_DIGITS"
                                           |),
@@ -1540,8 +1540,8 @@ Module ascii.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let buf := M.copy (| γ0_0 |) in
                           let len := M.copy (| γ0_1 |) in
                           let _ :=
@@ -1575,7 +1575,7 @@ Module ascii.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1611,7 +1611,7 @@ Module ascii.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1695,7 +1695,7 @@ Module ascii.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -1744,7 +1744,7 @@ Module ascii.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                   0
@@ -1788,7 +1788,7 @@ Module ascii.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                   0

--- a/CoqOfRust/core/asserting.v
+++ b/CoqOfRust/core/asserting.v
@@ -103,13 +103,21 @@ Module asserting.
           M.read (|
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| to |)) "core::asserting::Capture" "elem",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| to |),
+                  "core::asserting::Capture",
+                  "elem"
+                |),
                 Value.StructTuple
                   "core::option::Option::Some"
                   [
                     M.read (|
                       M.read (|
-                        M.get_struct_tuple_field (M.read (| self |)) "core::asserting::Wrapper" 0
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "core::asserting::Wrapper",
+                          0
+                        |)
                       |)
                     |)
                   ]
@@ -152,7 +160,11 @@ Module asserting.
           let f := M.alloc (| f |) in
           M.read (|
             M.match_operator (|
-              M.get_struct_record_field (M.read (| self |)) "core::asserting::Capture" "elem",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::asserting::Capture",
+                "elem"
+              |),
               [
                 fun γ =>
                   ltac:(M.monadic
@@ -169,7 +181,7 @@ Module asserting.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0

--- a/CoqOfRust/core/async_iter/from_iter.v
+++ b/CoqOfRust/core/async_iter/from_iter.v
@@ -28,10 +28,11 @@ Module async_iter.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::async_iter::from_iter::FromIter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::async_iter::from_iter::FromIter",
                         "iter"
+                      |)
                     ]
                   |))
               ]))
@@ -72,10 +73,11 @@ Module async_iter.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::async_iter::from_iter::FromIter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::async_iter::from_iter::FromIter",
                       "iter"
+                    |)
                   |))
               ]
             |)))
@@ -163,8 +165,8 @@ Module async_iter.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.call_closure (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::deref::DerefMut",
                           Ty.apply
@@ -179,9 +181,10 @@ Module async_iter.
                           []
                         |),
                         [ self ]
-                      |))
-                      "core::async_iter::from_iter::FromIter"
+                      |),
+                      "core::async_iter::from_iter::FromIter",
                       "iter"
+                    |)
                   ]
                 |)
               ]))
@@ -208,10 +211,11 @@ Module async_iter.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::async_iter::from_iter::FromIter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::async_iter::from_iter::FromIter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/cell.v
+++ b/CoqOfRust/core/cell.v
@@ -652,7 +652,12 @@ Module cell.
                             "get",
                             []
                           |),
-                          [ M.get_struct_record_field (M.read (| self |)) "core::cell::Cell" "value"
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::cell::Cell",
+                              "value"
+                            |)
                           ]
                         |);
                         M.call_closure (|
@@ -662,10 +667,11 @@ Module cell.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| other |))
-                              "core::cell::Cell"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| other |),
+                              "core::cell::Cell",
                               "value"
+                            |)
                           ]
                         |)
                       ]
@@ -704,7 +710,13 @@ Module cell.
                   "get",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::cell::Cell" "value" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::cell::Cell",
+                    "value"
+                  |)
+                ]
               |);
               M.read (| val |)
             ]
@@ -733,7 +745,11 @@ Module cell.
               "into_inner",
               []
             |),
-            [ M.read (| M.get_struct_record_field self "core::cell::Cell" "value" |) ]
+            [
+              M.read (|
+                M.SubPointer.get_struct_record_field (| self, "core::cell::Cell", "value" |)
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -761,7 +777,13 @@ Module cell.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::cell::Cell" "value" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::cell::Cell",
+                  "value"
+                |)
+              ]
             |)
           |)))
       | _, _ => M.impossible
@@ -848,7 +870,13 @@ Module cell.
               "get",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::Cell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::Cell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -874,7 +902,13 @@ Module cell.
               "get_mut",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::Cell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::Cell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1383,7 +1417,11 @@ Module cell.
               "into_inner",
               []
             |),
-            [ M.read (| M.get_struct_record_field self "core::cell::RefCell" "value" |) ]
+            [
+              M.read (|
+                M.SubPointer.get_struct_record_field (| self, "core::cell::RefCell", "value" |)
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1599,21 +1637,13 @@ Module cell.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let b := M.copy (| γ0_0 |) in
                     b));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let err := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1670,14 +1700,20 @@ Module cell.
               M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "core::cell::BorrowRef", "new", [] |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefCell" "borrow" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::cell::RefCell",
+                      "borrow"
+                    |)
+                  ]
                 |)
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1699,10 +1735,11 @@ Module cell.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::cell::RefCell"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::cell::RefCell",
                                   "value"
+                                |)
                               ]
                             |)
                           ]
@@ -1764,21 +1801,13 @@ Module cell.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let b := M.copy (| γ0_0 |) in
                     b));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let err := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1831,14 +1860,20 @@ Module cell.
               M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "core::cell::BorrowRefMut", "new", [] |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefCell" "borrow" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::cell::RefCell",
+                      "borrow"
+                    |)
+                  ]
                 |)
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1860,10 +1895,11 @@ Module cell.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::cell::RefCell"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::cell::RefCell",
                                   "value"
+                                |)
                               ]
                             |)
                           ]
@@ -1916,7 +1952,13 @@ Module cell.
               "get",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefCell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::RefCell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1942,7 +1984,13 @@ Module cell.
               "get_mut",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefCell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::RefCell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1972,7 +2020,13 @@ Module cell.
                     "get_mut",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefCell" "borrow" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::cell::RefCell",
+                      "borrow"
+                    |)
+                  ]
                 |),
                 M.read (| M.get_constant (| "core::cell::UNUSED" |) |)
               |) in
@@ -2039,10 +2093,11 @@ Module cell.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::cell::RefCell"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::cell::RefCell",
                                       "borrow"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2060,10 +2115,11 @@ Module cell.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::cell::RefCell"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::cell::RefCell",
                                 "value"
+                              |)
                             ]
                           |)
                         ]
@@ -2959,7 +3015,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::cell::BorrowRef" "borrow"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRef",
+                        "borrow"
+                      |)
                     |)
                   ]
                 |)
@@ -3021,7 +3081,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::cell::BorrowRef" "borrow"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRef",
+                        "borrow"
+                      |)
                     |);
                     BinOp.Panic.sub (| M.read (| borrow |), Value.Integer Integer.Isize 1 |)
                   ]
@@ -3072,7 +3136,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::cell::BorrowRef" "borrow"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRef",
+                        "borrow"
+                      |)
                     |)
                   ]
                 |)
@@ -3164,7 +3232,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::cell::BorrowRef" "borrow"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRef",
+                        "borrow"
+                      |)
                     |);
                     BinOp.Panic.add (| M.read (| borrow |), Value.Integer Integer.Isize 1 |)
                   ]
@@ -3176,7 +3248,11 @@ Module cell.
                 [
                   ("borrow",
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::cell::BorrowRef" "borrow"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRef",
+                        "borrow"
+                      |)
                     |))
                 ]
             |)
@@ -3227,7 +3303,13 @@ Module cell.
               "as_ref",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::Ref" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::Ref",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3261,7 +3343,11 @@ Module cell.
             [
               ("value",
                 M.read (|
-                  M.get_struct_record_field (M.read (| orig |)) "core::cell::Ref" "value"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| orig |),
+                    "core::cell::Ref",
+                    "value"
+                  |)
                 |));
               ("borrow",
                 M.call_closure (|
@@ -3272,7 +3358,13 @@ Module cell.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| orig |)) "core::cell::Ref" "borrow" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| orig |),
+                      "core::cell::Ref",
+                      "borrow"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -3337,7 +3429,10 @@ Module cell.
                     |)
                   ]
                 |));
-              ("borrow", M.read (| M.get_struct_record_field orig "core::cell::Ref" "borrow" |))
+              ("borrow",
+                M.read (|
+                  M.SubPointer.get_struct_record_field (| orig, "core::cell::Ref", "borrow" |)
+                |))
             ]))
       | _, _ => M.impossible
       end.
@@ -3395,7 +3490,7 @@ Module cell.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -3421,7 +3516,11 @@ Module cell.
                                 |));
                               ("borrow",
                                 M.read (|
-                                  M.get_struct_record_field orig "core::cell::Ref" "borrow"
+                                  M.SubPointer.get_struct_record_field (|
+                                    orig,
+                                    "core::cell::Ref",
+                                    "borrow"
+                                  |)
                                 |))
                             ]
                         ]
@@ -3493,8 +3592,8 @@ Module cell.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     let borrow :=
@@ -3507,7 +3606,13 @@ Module cell.
                             "clone",
                             []
                           |),
-                          [ M.get_struct_record_field orig "core::cell::Ref" "borrow" ]
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              orig,
+                              "core::cell::Ref",
+                              "borrow"
+                            |)
+                          ]
                         |)
                       |) in
                     M.alloc (|
@@ -3545,7 +3650,11 @@ Module cell.
                                 |));
                               ("borrow",
                                 M.read (|
-                                  M.get_struct_record_field orig "core::cell::Ref" "borrow"
+                                  M.SubPointer.get_struct_record_field (|
+                                    orig,
+                                    "core::cell::Ref",
+                                    "borrow"
+                                  |)
                                 |))
                             ]
                         ]
@@ -3582,7 +3691,11 @@ Module cell.
               M.alloc (|
                 M.call_closure (|
                   M.get_function (| "core::mem::forget", [ Ty.path "core::cell::BorrowRef" ] |),
-                  [ M.read (| M.get_struct_record_field orig "core::cell::Ref" "borrow" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (| orig, "core::cell::Ref", "borrow" |)
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -3592,7 +3705,7 @@ Module cell.
                   "as_ref",
                   []
                 |),
-                [ M.get_struct_record_field orig "core::cell::Ref" "value" ]
+                [ M.SubPointer.get_struct_record_field (| orig, "core::cell::Ref", "value" |) ]
               |)
             |)
           |)))
@@ -3724,7 +3837,13 @@ Module cell.
                 [
                   ("value", M.read (| value |));
                   ("borrow",
-                    M.read (| M.get_struct_record_field orig "core::cell::RefMut" "borrow" |));
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        orig,
+                        "core::cell::RefMut",
+                        "borrow"
+                      |)
+                    |));
                   ("marker", Value.StructTuple "core::marker::PhantomData" [])
                 ]
             |)
@@ -3791,7 +3910,7 @@ Module cell.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -3817,7 +3936,11 @@ Module cell.
                                 |));
                               ("borrow",
                                 M.read (|
-                                  M.get_struct_record_field orig "core::cell::RefMut" "borrow"
+                                  M.SubPointer.get_struct_record_field (|
+                                    orig,
+                                    "core::cell::RefMut",
+                                    "borrow"
+                                  |)
                                 |));
                               ("marker", Value.StructTuple "core::marker::PhantomData" [])
                             ]
@@ -3866,7 +3989,8 @@ Module cell.
               M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "core::cell::BorrowRefMut", "clone", [] |),
-                  [ M.get_struct_record_field orig "core::cell::RefMut" "borrow" ]
+                  [ M.SubPointer.get_struct_record_field (| orig, "core::cell::RefMut", "borrow" |)
+                  ]
                 |)
               |) in
             M.match_operator (|
@@ -3900,8 +4024,8 @@ Module cell.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -3940,7 +4064,11 @@ Module cell.
                                 |));
                               ("borrow",
                                 M.read (|
-                                  M.get_struct_record_field orig "core::cell::RefMut" "borrow"
+                                  M.SubPointer.get_struct_record_field (|
+                                    orig,
+                                    "core::cell::RefMut",
+                                    "borrow"
+                                  |)
                                 |));
                               ("marker", Value.StructTuple "core::marker::PhantomData" [])
                             ]
@@ -3979,7 +4107,15 @@ Module cell.
               M.alloc (|
                 M.call_closure (|
                   M.get_function (| "core::mem::forget", [ Ty.path "core::cell::BorrowRefMut" ] |),
-                  [ M.read (| M.get_struct_record_field orig "core::cell::RefMut" "borrow" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        orig,
+                        "core::cell::RefMut",
+                        "borrow"
+                      |)
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -3989,7 +4125,7 @@ Module cell.
                   "as_mut",
                   []
                 |),
-                [ M.get_struct_record_field orig "core::cell::RefMut" "value" ]
+                [ M.SubPointer.get_struct_record_field (| orig, "core::cell::RefMut", "value" |) ]
               |)
             |)
           |)))
@@ -4038,10 +4174,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::BorrowRefMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRefMut",
                         "borrow"
+                      |)
                     |)
                   ]
                 |)
@@ -4103,10 +4240,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::BorrowRefMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRefMut",
                         "borrow"
+                      |)
                     |);
                     BinOp.Panic.add (| M.read (| borrow |), Value.Integer Integer.Isize 1 |)
                   ]
@@ -4230,10 +4368,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::BorrowRefMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRefMut",
                         "borrow"
+                      |)
                     |)
                   ]
                 |)
@@ -4325,10 +4464,11 @@ Module cell.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::BorrowRefMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRefMut",
                         "borrow"
+                      |)
                     |);
                     BinOp.Panic.sub (| M.read (| borrow |), Value.Integer Integer.Isize 1 |)
                   ]
@@ -4340,10 +4480,11 @@ Module cell.
                 [
                   ("borrow",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::BorrowRefMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::BorrowRefMut",
                         "borrow"
+                      |)
                     |))
                 ]
             |)
@@ -4391,7 +4532,13 @@ Module cell.
               "as_ref",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefMut" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::RefMut",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4427,7 +4574,13 @@ Module cell.
               "as_mut",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::RefMut" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::RefMut",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4546,7 +4699,9 @@ Module cell.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "core::cell::UnsafeCell" "value" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "core::cell::UnsafeCell", "value" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -4604,7 +4759,11 @@ Module cell.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.get_struct_record_field (M.read (| self |)) "core::cell::UnsafeCell" "value"))
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "core::cell::UnsafeCell",
+            "value"
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -4793,7 +4952,15 @@ Module cell.
               "into_inner",
               []
             |),
-            [ M.read (| M.get_struct_record_field self "core::cell::SyncUnsafeCell" "value" |) ]
+            [
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "core::cell::SyncUnsafeCell",
+                  "value"
+                |)
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4818,7 +4985,13 @@ Module cell.
               "get",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::SyncUnsafeCell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::SyncUnsafeCell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4842,7 +5015,13 @@ Module cell.
               "get_mut",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::cell::SyncUnsafeCell" "value" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::cell::SyncUnsafeCell",
+                "value"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.

--- a/CoqOfRust/core/cell/lazy.v
+++ b/CoqOfRust/core/cell/lazy.v
@@ -106,7 +106,11 @@ Module cell.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field this "core::cell::lazy::LazyCell" "state"
+                        M.SubPointer.get_struct_record_field (|
+                          this,
+                          "core::cell::lazy::LazyCell",
+                          "state"
+                        |)
                       |)
                     ]
                   |)
@@ -115,7 +119,7 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Init",
                           0
@@ -127,7 +131,7 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Uninit",
                           0
@@ -211,10 +215,11 @@ Module cell.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| this |))
-                        "core::cell::lazy::LazyCell"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "core::cell::lazy::LazyCell",
                         "state"
+                      |)
                     ]
                   |)
                 |) in
@@ -225,7 +230,7 @@ Module cell.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Init",
                           0
@@ -236,7 +241,7 @@ Module cell.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Uninit",
                           0
@@ -340,10 +345,11 @@ Module cell.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| this |))
-                        "core::cell::lazy::LazyCell"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| this |),
+                        "core::cell::lazy::LazyCell",
                         "state"
+                      |)
                     ]
                   |)
                 |) in
@@ -361,7 +367,7 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Uninit",
                           0
@@ -400,10 +406,11 @@ Module cell.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| this |))
-                                    "core::cell::lazy::LazyCell"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| this |),
+                                    "core::cell::lazy::LazyCell",
                                     "state"
+                                  |)
                                 ]
                               |);
                               Value.StructTuple
@@ -423,10 +430,11 @@ Module cell.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| this |))
-                                "core::cell::lazy::LazyCell"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| this |),
+                                "core::cell::lazy::LazyCell",
                                 "state"
+                              |)
                             ]
                           |)
                         |) in
@@ -437,7 +445,7 @@ Module cell.
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::cell::lazy::State::Init",
                                   0
@@ -486,10 +494,11 @@ Module cell.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::cell::lazy::LazyCell"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::cell::lazy::LazyCell",
                         "state"
+                      |)
                     ]
                   |)
                 |) in
@@ -500,7 +509,7 @@ Module cell.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::cell::lazy::State::Init",
                           0
@@ -651,7 +660,7 @@ Module cell.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0

--- a/CoqOfRust/core/cell/once.v
+++ b/CoqOfRust/core/cell/once.v
@@ -79,10 +79,11 @@ Module cell.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::cell::once::OnceCell"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::cell::once::OnceCell",
                       "inner"
+                    |)
                   ]
                 |)
               ]
@@ -121,10 +122,11 @@ Module cell.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::cell::once::OnceCell"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::cell::once::OnceCell",
                       "inner"
+                    |)
                   ]
                 |)
               ]
@@ -167,7 +169,7 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -178,13 +180,13 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let value := M.copy (| γ1_1 |) in
                       M.alloc (|
                         Value.StructTuple "core::result::Result::Err" [ M.read (| value |) ]
@@ -241,7 +243,7 @@ Module cell.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -272,10 +274,11 @@ Module cell.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::cell::once::OnceCell"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::cell::once::OnceCell",
                             "inner"
+                          |)
                         ]
                       |)
                     |) in
@@ -370,7 +373,7 @@ Module cell.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -440,7 +443,7 @@ Module cell.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -488,7 +491,7 @@ Module cell.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -521,7 +524,7 @@ Module cell.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -548,7 +551,7 @@ Module cell.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::result::Result::Ok",
                               0
@@ -614,7 +617,15 @@ Module cell.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::cell::once::OnceCell" "inner" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::cell::once::OnceCell",
+                    "inner"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -739,7 +750,7 @@ Module cell.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -863,7 +874,7 @@ Module cell.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -890,7 +901,7 @@ Module cell.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -899,7 +910,7 @@ Module cell.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0

--- a/CoqOfRust/core/char/convert.v
+++ b/CoqOfRust/core/char/convert.v
@@ -29,11 +29,7 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let c := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| c |) ]
@@ -41,11 +37,7 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (| Value.StructTuple "core::option::Option::None" [] |)))
               ]
             |)
@@ -401,10 +393,11 @@ Module char.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::char::convert::ParseCharError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::char::convert::ParseCharError",
                         "kind"
+                      |)
                     ]
                   |))
               ]))
@@ -442,10 +435,11 @@ Module char.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::char::convert::ParseCharError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::char::convert::ParseCharError",
                       "kind"
+                    |)
                   |))
               ]
             |)))
@@ -490,14 +484,16 @@ Module char.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::char::convert::ParseCharError"
-                  "kind";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::char::convert::ParseCharError"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::char::convert::ParseCharError",
                   "kind"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::char::convert::ParseCharError",
+                  "kind"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -749,10 +745,11 @@ Module char.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::char::convert::ParseCharError"
-                  "kind",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::char::convert::ParseCharError",
+                  "kind"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -876,8 +873,8 @@ Module char.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         Value.StructTuple
                           "core::result::Result::Err"
@@ -894,10 +891,10 @@ Module char.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
@@ -1118,10 +1115,11 @@ Module char.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::char::convert::CharTryFromError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::char::convert::CharTryFromError",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -1166,14 +1164,16 @@ Module char.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::char::convert::CharTryFromError"
-                  0;
-                M.get_struct_tuple_field
-                  (M.read (| other |))
-                  "core::char::convert::CharTryFromError"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::char::convert::CharTryFromError",
                   0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::char::convert::CharTryFromError",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/char/decode.v
+++ b/CoqOfRust/core/char/decode.v
@@ -29,10 +29,11 @@ Module char.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::char::decode::DecodeUtf16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::char::decode::DecodeUtf16",
                         "iter"
+                      |)
                     ]
                   |));
                 ("buf",
@@ -45,10 +46,11 @@ Module char.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::char::decode::DecodeUtf16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::char::decode::DecodeUtf16",
                         "buf"
+                      |)
                     ]
                   |))
               ]))
@@ -88,18 +90,20 @@ Module char.
                 M.read (| Value.String "iter" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::char::decode::DecodeUtf16"
-                    "iter");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::char::decode::DecodeUtf16",
+                    "iter"
+                  |));
                 M.read (| Value.String "buf" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::char::decode::DecodeUtf16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::char::decode::DecodeUtf16",
                       "buf"
+                    |)
                   |))
               ]
             |)))
@@ -145,10 +149,11 @@ Module char.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::char::decode::DecodeUtf16Error"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::char::decode::DecodeUtf16Error",
                       "code"
+                    |)
                   |))
               ]
             |)))
@@ -179,10 +184,11 @@ Module char.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "u16", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::char::decode::DecodeUtf16Error"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::char::decode::DecodeUtf16Error",
                         "code"
+                      |)
                     ]
                   |))
               ]))
@@ -258,16 +264,18 @@ Module char.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::char::decode::DecodeUtf16Error"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::char::decode::DecodeUtf16Error",
                   "code"
+                |)
               |))
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::char::decode::DecodeUtf16Error"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::char::decode::DecodeUtf16Error",
                   "code"
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -372,10 +380,11 @@ Module char.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::char::decode::DecodeUtf16"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::char::decode::DecodeUtf16",
                                 "buf"
+                              |)
                             ]
                           |)
                         |),
@@ -383,7 +392,7 @@ Module char.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -412,10 +421,11 @@ Module char.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::char::decode::DecodeUtf16"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::char::decode::DecodeUtf16",
                                             "iter"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -425,7 +435,7 @@ Module char.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -466,7 +476,7 @@ Module char.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -563,10 +573,11 @@ Module char.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::char::decode::DecodeUtf16"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::char::decode::DecodeUtf16",
                                                 "iter"
+                                              |)
                                             ]
                                           |)
                                         |),
@@ -574,7 +585,7 @@ Module char.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -634,10 +645,11 @@ Module char.
                                                 M.read (|
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::char::decode::DecodeUtf16"
-                                                        "buf",
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::char::decode::DecodeUtf16",
+                                                        "buf"
+                                                      |),
                                                       Value.StructTuple
                                                         "core::option::Option::Some"
                                                         [ M.read (| u2 |) ]
@@ -757,26 +769,28 @@ Module char.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::char::decode::DecodeUtf16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::char::decode::DecodeUtf16",
                         "iter"
+                      |)
                     ]
                   |)
                 |),
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let low := M.copy (| γ0_0 |) in
                       let high := M.copy (| γ0_1 |) in
                       M.match_operator (|
                         M.match_operator (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::char::decode::DecodeUtf16"
-                            "buf",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::char::decode::DecodeUtf16",
+                            "buf"
+                          |),
                           [
                             fun γ =>
                               ltac:(M.monadic
@@ -787,7 +801,7 @@ Module char.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -817,7 +831,7 @@ Module char.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -861,7 +875,7 @@ Module char.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -876,8 +890,8 @@ Module char.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let low_buf := M.copy (| γ0_0 |) in
                               let high_buf := M.copy (| γ0_1 |) in
                               let low :=
@@ -987,10 +1001,11 @@ Module char.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::char::decode::DecodeUtf16Error"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::char::decode::DecodeUtf16Error",
                 "code"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -1037,10 +1052,11 @@ Module char.
                                 [ Ty.path "u16" ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::char::decode::DecodeUtf16Error"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::char::decode::DecodeUtf16Error",
                                   "code"
+                                |)
                               ]
                             |)
                           ]

--- a/CoqOfRust/core/char/methods.v
+++ b/CoqOfRust/core/char/methods.v
@@ -460,10 +460,11 @@ Module char.
                       (let _ :=
                         M.is_constant_or_break_match (| M.read (| γ |), Value.UnicodeChar 34 |) in
                       let γ :=
-                        M.get_struct_record_field
-                          args
-                          "core::char::methods::EscapeDebugExtArgs"
-                          "escape_double_quote" in
+                        M.SubPointer.get_struct_record_field (|
+                          args,
+                          "core::char::methods::EscapeDebugExtArgs",
+                          "escape_double_quote"
+                        |) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         M.call_closure (|
@@ -481,10 +482,11 @@ Module char.
                       (let _ :=
                         M.is_constant_or_break_match (| M.read (| γ |), Value.UnicodeChar 39 |) in
                       let γ :=
-                        M.get_struct_record_field
-                          args
-                          "core::char::methods::EscapeDebugExtArgs"
-                          "escape_single_quote" in
+                        M.SubPointer.get_struct_record_field (|
+                          args,
+                          "core::char::methods::EscapeDebugExtArgs",
+                          "escape_single_quote"
+                        |) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         M.call_closure (|
@@ -499,10 +501,11 @@ Module char.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ :=
-                        M.get_struct_record_field
-                          args
-                          "core::char::methods::EscapeDebugExtArgs"
-                          "escape_grapheme_extended" in
+                        M.SubPointer.get_struct_record_field (|
+                          args,
+                          "core::char::methods::EscapeDebugExtArgs",
+                          "escape_grapheme_extended"
+                        |) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let γ :=
                         M.alloc (|
@@ -2153,32 +2156,32 @@ Module char.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
                           Value.Integer Integer.Usize 1
                         |) in
                       let γ0_1 := M.read (| γ0_1 |) in
-                      let γ2_0 := M.get_slice_index_or_break_match (| γ0_1, 0 |) in
-                      let γ2_rest := M.get_slice_rest_or_break_match (| γ0_1, 1, 0 |) in
+                      let γ2_0 := M.SubPointer.get_slice_index (| γ0_1, 0 |) in
+                      let γ2_rest := M.SubPointer.get_slice_rest (| γ0_1, 1, 0 |) in
                       let a := M.alloc (| γ2_0 |) in
                       let _ := M.write (| M.read (| a |), M.rust_cast (M.read (| code |)) |) in
                       M.alloc (| Value.Tuple [] |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
                           Value.Integer Integer.Usize 2
                         |) in
                       let γ0_1 := M.read (| γ0_1 |) in
-                      let γ2_0 := M.get_slice_index_or_break_match (| γ0_1, 0 |) in
-                      let γ2_1 := M.get_slice_index_or_break_match (| γ0_1, 1 |) in
-                      let γ2_rest := M.get_slice_rest_or_break_match (| γ0_1, 2, 0 |) in
+                      let γ2_0 := M.SubPointer.get_slice_index (| γ0_1, 0 |) in
+                      let γ2_1 := M.SubPointer.get_slice_index (| γ0_1, 1 |) in
+                      let γ2_rest := M.SubPointer.get_slice_rest (| γ0_1, 2, 0 |) in
                       let a := M.alloc (| γ2_0 |) in
                       let b := M.alloc (| γ2_1 |) in
                       let _ :=
@@ -2207,18 +2210,18 @@ Module char.
                       M.alloc (| Value.Tuple [] |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
                           Value.Integer Integer.Usize 3
                         |) in
                       let γ0_1 := M.read (| γ0_1 |) in
-                      let γ2_0 := M.get_slice_index_or_break_match (| γ0_1, 0 |) in
-                      let γ2_1 := M.get_slice_index_or_break_match (| γ0_1, 1 |) in
-                      let γ2_2 := M.get_slice_index_or_break_match (| γ0_1, 2 |) in
-                      let γ2_rest := M.get_slice_rest_or_break_match (| γ0_1, 3, 0 |) in
+                      let γ2_0 := M.SubPointer.get_slice_index (| γ0_1, 0 |) in
+                      let γ2_1 := M.SubPointer.get_slice_index (| γ0_1, 1 |) in
+                      let γ2_2 := M.SubPointer.get_slice_index (| γ0_1, 2 |) in
+                      let γ2_rest := M.SubPointer.get_slice_rest (| γ0_1, 3, 0 |) in
                       let a := M.alloc (| γ2_0 |) in
                       let b := M.alloc (| γ2_1 |) in
                       let c := M.alloc (| γ2_2 |) in
@@ -2261,19 +2264,19 @@ Module char.
                       M.alloc (| Value.Tuple [] |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
                           Value.Integer Integer.Usize 4
                         |) in
                       let γ0_1 := M.read (| γ0_1 |) in
-                      let γ2_0 := M.get_slice_index_or_break_match (| γ0_1, 0 |) in
-                      let γ2_1 := M.get_slice_index_or_break_match (| γ0_1, 1 |) in
-                      let γ2_2 := M.get_slice_index_or_break_match (| γ0_1, 2 |) in
-                      let γ2_3 := M.get_slice_index_or_break_match (| γ0_1, 3 |) in
-                      let γ2_rest := M.get_slice_rest_or_break_match (| γ0_1, 4, 0 |) in
+                      let γ2_0 := M.SubPointer.get_slice_index (| γ0_1, 0 |) in
+                      let γ2_1 := M.SubPointer.get_slice_index (| γ0_1, 1 |) in
+                      let γ2_2 := M.SubPointer.get_slice_index (| γ0_1, 2 |) in
+                      let γ2_3 := M.SubPointer.get_slice_index (| γ0_1, 3 |) in
+                      let γ2_rest := M.SubPointer.get_slice_rest (| γ0_1, 4, 0 |) in
                       let a := M.alloc (| γ2_0 |) in
                       let b := M.alloc (| γ2_1 |) in
                       let c := M.alloc (| γ2_2 |) in

--- a/CoqOfRust/core/char/mod.v
+++ b/CoqOfRust/core/char/mod.v
@@ -129,7 +129,13 @@ Module char.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeUnicode",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -165,7 +171,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeUnicode",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -253,7 +263,13 @@ Module char.
             [
               M.call_closure (|
                 M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "next", [] |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeUnicode",
+                    0
+                  |)
+                ]
               |);
               M.get_trait_method (|
                 "core::convert::From",
@@ -287,7 +303,13 @@ Module char.
                     "len",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::char::EscapeUnicode",
+                      0
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -311,7 +333,7 @@ Module char.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field self "core::char::EscapeUnicode" 0 ]
+            [ M.SubPointer.get_struct_tuple_field (| self, "core::char::EscapeUnicode", 0 |) ]
           |)))
       | _, _ => M.impossible
       end.
@@ -339,7 +361,7 @@ Module char.
                   "next_back",
                   []
                 |),
-                [ M.get_struct_tuple_field self "core::char::EscapeUnicode" 0 ]
+                [ M.SubPointer.get_struct_tuple_field (| self, "core::char::EscapeUnicode", 0 |) ]
               |);
               M.get_trait_method (|
                 "core::convert::From",
@@ -371,7 +393,11 @@ Module char.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::EscapeUnicode",
+                0
+              |);
               M.read (| n |)
             ]
           |)))
@@ -409,7 +435,13 @@ Module char.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::EscapeUnicode",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -457,7 +489,13 @@ Module char.
                   "as_str",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeUnicode" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeUnicode",
+                    0
+                  |)
+                ]
               |)
             ]
           |)))
@@ -499,7 +537,13 @@ Module char.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDefault",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -535,7 +579,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDefault",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -638,7 +686,11 @@ Module char.
           (let esc := M.alloc (| esc |) in
           Value.StructTuple
             "core::char::EscapeDefault"
-            [ M.read (| M.get_struct_tuple_field esc "core::char::EscapeUnicode" 0 |) ]))
+            [
+              M.read (|
+                M.SubPointer.get_struct_tuple_field (| esc, "core::char::EscapeUnicode", 0 |)
+              |)
+            ]))
       | _, _ => M.impossible
       end.
     
@@ -670,7 +722,13 @@ Module char.
             [
               M.call_closure (|
                 M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "next", [] |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDefault",
+                    0
+                  |)
+                ]
               |);
               M.get_trait_method (|
                 "core::convert::From",
@@ -704,7 +762,13 @@ Module char.
                     "len",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::char::EscapeDefault",
+                      0
+                    |)
+                  ]
                 |)
               |) in
             M.alloc (|
@@ -728,7 +792,7 @@ Module char.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field self "core::char::EscapeDefault" 0 ]
+            [ M.SubPointer.get_struct_tuple_field (| self, "core::char::EscapeDefault", 0 |) ]
           |)))
       | _, _ => M.impossible
       end.
@@ -756,7 +820,7 @@ Module char.
                   "next_back",
                   []
                 |),
-                [ M.get_struct_tuple_field self "core::char::EscapeDefault" 0 ]
+                [ M.SubPointer.get_struct_tuple_field (| self, "core::char::EscapeDefault", 0 |) ]
               |);
               M.get_trait_method (|
                 "core::convert::From",
@@ -788,7 +852,11 @@ Module char.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::EscapeDefault",
+                0
+              |);
               M.read (| n |)
             ]
           |)))
@@ -826,7 +894,13 @@ Module char.
           (let self := M.alloc (| self |) in
           M.call_closure (|
             M.get_associated_function (| Ty.path "core::escape::EscapeIterInner", "len", [] |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::EscapeDefault",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -874,7 +948,13 @@ Module char.
                   "as_str",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDefault" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDefault",
+                    0
+                  |)
+                ]
               |)
             ]
           |)))
@@ -916,7 +996,13 @@ Module char.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDebug",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -952,7 +1038,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::EscapeDebug",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -1004,7 +1094,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Bytes",
                         0
@@ -1030,7 +1120,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Char",
                         0
@@ -1084,7 +1174,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Bytes",
                         0
@@ -1108,7 +1198,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Char",
                         0
@@ -1221,7 +1311,11 @@ Module char.
             [
               Value.StructTuple
                 "core::char::EscapeDebugInner::Bytes"
-                [ M.read (| M.get_struct_tuple_field esc "core::char::EscapeUnicode" 0 |) ]
+                [
+                  M.read (|
+                    M.SubPointer.get_struct_tuple_field (| esc, "core::char::EscapeUnicode", 0 |)
+                  |)
+                ]
             ]))
       | _, _ => M.impossible
       end.
@@ -1253,7 +1347,11 @@ Module char.
               |) in
             let _ :=
               M.write (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0,
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::char::EscapeDebug",
+                  0
+                |),
                 Value.StructTuple "core::char::EscapeDebugInner::Bytes" [ M.read (| bytes |) ]
               |) in
             M.alloc (| Value.Tuple [] |)
@@ -1288,12 +1386,16 @@ Module char.
           (let self := M.alloc (| self |) in
           M.read (|
             M.match_operator (|
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0,
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::EscapeDebug",
+                0
+              |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Bytes",
                         0
@@ -1328,7 +1430,7 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Char",
                         0
@@ -1444,14 +1546,18 @@ Module char.
           M.read (|
             M.match_operator (|
               M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::char::EscapeDebug",
+                  0
+                |)
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Bytes",
                         0
@@ -1471,7 +1577,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Char",
                         0
@@ -1522,14 +1628,18 @@ Module char.
           M.read (|
             M.match_operator (|
               M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::char::EscapeDebug" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::char::EscapeDebug",
+                  0
+                |)
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Bytes",
                         0
@@ -1559,7 +1669,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::EscapeDebugInner::Char",
                         0
@@ -1620,7 +1730,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::ToLowercase",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -1655,7 +1769,13 @@ Module char.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::ToLowercase",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -1693,7 +1813,13 @@ Module char.
               "next",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToLowercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1716,7 +1842,13 @@ Module char.
               "size_hint",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToLowercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1755,7 +1887,13 @@ Module char.
               "next_back",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToLowercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1819,7 +1957,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::ToUppercase",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -1854,7 +1996,13 @@ Module char.
                   "clone",
                   []
                 |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::ToUppercase",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -1892,7 +2040,13 @@ Module char.
               "next",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToUppercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1915,7 +2069,13 @@ Module char.
               "size_hint",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToUppercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -1954,7 +2114,13 @@ Module char.
               "next_back",
               []
             |),
-            [ M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0 ]
+            [
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToUppercase",
+                0
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -2037,19 +2203,19 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         0
                       |) in
                     let γ1_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         1
                       |) in
                     let γ1_2 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         2
@@ -2077,13 +2243,13 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         0
                       |) in
                     let γ1_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         1
@@ -2109,7 +2275,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::One",
                         0
@@ -2173,19 +2339,19 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         0
                       |) in
                     let γ1_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         1
                       |) in
                     let γ1_2 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         2
@@ -2233,13 +2399,13 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         0
                       |) in
                     let γ1_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         1
@@ -2276,7 +2442,7 @@ Module char.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::One",
                         0
@@ -2348,7 +2514,7 @@ Module char.
                         (M.alloc (|
                           BinOp.Pure.eq
                             (M.read (|
-                              M.get_array_field (|
+                              M.SubPointer.get_array_field (|
                                 chars,
                                 M.alloc (| Value.Integer Integer.Usize 2 |)
                               |)
@@ -2366,7 +2532,7 @@ Module char.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_array_field (|
+                                      M.SubPointer.get_array_field (|
                                         chars,
                                         M.alloc (| Value.Integer Integer.Usize 1 |)
                                       |)
@@ -2380,7 +2546,7 @@ Module char.
                                 "core::char::CaseMappingIter::One"
                                 [
                                   M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       chars,
                                       M.alloc (| Value.Integer Integer.Usize 0 |)
                                     |)
@@ -2394,13 +2560,13 @@ Module char.
                                 "core::char::CaseMappingIter::Two"
                                 [
                                   M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       chars,
                                       M.alloc (| Value.Integer Integer.Usize 0 |)
                                     |)
                                   |);
                                   M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       chars,
                                       M.alloc (| Value.Integer Integer.Usize 1 |)
                                     |)
@@ -2416,19 +2582,19 @@ Module char.
                         "core::char::CaseMappingIter::Three"
                         [
                           M.read (|
-                            M.get_array_field (|
+                            M.SubPointer.get_array_field (|
                               chars,
                               M.alloc (| Value.Integer Integer.Usize 0 |)
                             |)
                           |);
                           M.read (|
-                            M.get_array_field (|
+                            M.SubPointer.get_array_field (|
                               chars,
                               M.alloc (| Value.Integer Integer.Usize 1 |)
                             |)
                           |);
                           M.read (|
-                            M.get_array_field (|
+                            M.SubPointer.get_array_field (|
                               chars,
                               M.alloc (| Value.Integer Integer.Usize 2 |)
                             |)
@@ -2481,19 +2647,19 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         0
                       |) in
                     let γ0_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         1
                       |) in
                     let γ0_2 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         2
@@ -2514,13 +2680,13 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         0
                       |) in
                     let γ0_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         1
@@ -2538,7 +2704,7 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::One",
                         0
@@ -2594,7 +2760,7 @@ Module char.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::One",
                             0
@@ -2665,19 +2831,19 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         0
                       |) in
                     let γ0_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         1
                       |) in
                     let γ0_2 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Three",
                         2
@@ -2698,13 +2864,13 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         0
                       |) in
                     let γ0_1 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::Two",
                         1
@@ -2722,7 +2888,7 @@ Module char.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::char::CaseMappingIter::One",
                         0
@@ -2787,19 +2953,19 @@ Module char.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::Three",
                             0
                           |) in
                         let γ0_1 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::Three",
                             1
                           |) in
                         let γ0_2 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::Three",
                             2
@@ -2838,7 +3004,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -2874,7 +3040,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2914,7 +3080,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -2950,7 +3116,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2974,13 +3140,13 @@ Module char.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::Two",
                             0
                           |) in
                         let γ0_1 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::Two",
                             1
@@ -3018,7 +3184,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -3054,7 +3220,7 @@ Module char.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -3078,7 +3244,7 @@ Module char.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::char::CaseMappingIter::One",
                             0
@@ -3139,7 +3305,11 @@ Module char.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::ToLowercase" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToLowercase",
+                0
+              |);
               M.read (| f |)
             ]
           |)))
@@ -3177,7 +3347,11 @@ Module char.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::ToUppercase" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::ToUppercase",
+                0
+              |);
               M.read (| f |)
             ]
           |)))
@@ -3221,7 +3395,11 @@ Module char.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::char::TryFromCharError" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::char::TryFromCharError",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -3297,8 +3475,16 @@ Module char.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", Ty.tuple [], [ Ty.tuple [] ], "eq", [] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::char::TryFromCharError" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "core::char::TryFromCharError" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::char::TryFromCharError",
+                0
+              |);
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| other |),
+                "core::char::TryFromCharError",
+                0
+              |)
             ]
           |)))
       | _, _ => M.impossible

--- a/CoqOfRust/core/cmp.v
+++ b/CoqOfRust/core/cmp.v
@@ -663,8 +663,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -742,7 +742,13 @@ Module cmp.
               M.read (| Value.String "Reverse" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0 |))
+                (M.alloc (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::cmp::Reverse",
+                    0
+                  |)
+                |))
             ]
           |)))
       | _, _ => M.impossible
@@ -812,7 +818,7 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::hash::Hash", T, [], "hash", [ __H ] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0;
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |);
               M.read (| state |)
             ]
           |)))
@@ -846,8 +852,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "partial_cmp", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -868,8 +874,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -890,8 +896,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "le", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -912,8 +918,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "gt", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -934,8 +940,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "ge", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -975,8 +981,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
             [
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -1010,7 +1016,13 @@ Module cmp.
             [
               M.call_closure (|
                 M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
-                [ M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0 ]
+                [
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::cmp::Reverse",
+                    0
+                  |)
+                ]
               |)
             ]))
       | _, _ => M.impossible
@@ -1031,8 +1043,8 @@ Module cmp.
           M.call_closure (|
             M.get_trait_method (| "core::clone::Clone", T, [], "clone_from", [] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::cmp::Reverse" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "core::cmp::Reverse" 0
+              M.SubPointer.get_struct_tuple_field (| M.read (| self |), "core::cmp::Reverse", 0 |);
+              M.SubPointer.get_struct_tuple_field (| M.read (| other |), "core::cmp::Reverse", 0 |)
             ]
           |)))
       | _, _ => M.impossible
@@ -1229,7 +1241,7 @@ Module cmp.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1269,7 +1281,7 @@ Module cmp.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1322,7 +1334,7 @@ Module cmp.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1362,7 +1374,7 @@ Module cmp.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2650,8 +2662,8 @@ Module cmp.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool false |) in
                       let _ :=
@@ -2659,8 +2671,8 @@ Module cmp.
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool false |) in
                       let _ :=
@@ -2672,8 +2684,8 @@ Module cmp.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                       let _ :=
@@ -2685,8 +2697,8 @@ Module cmp.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                       let _ :=
@@ -2796,8 +2808,8 @@ Module cmp.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool false |) in
                       let _ :=
@@ -2805,8 +2817,8 @@ Module cmp.
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool false |) in
                       let _ :=
@@ -2818,8 +2830,8 @@ Module cmp.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                       let _ :=
@@ -2831,8 +2843,8 @@ Module cmp.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let _ :=
                         M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.Bool true |) in
                       let _ :=

--- a/CoqOfRust/core/error.v
+++ b/CoqOfRust/core/error.v
@@ -555,7 +555,7 @@ Module error.
                 ]
               |)
             |) in
-          M.get_struct_tuple_field tagged "core::error::TaggedOption" 0
+          M.SubPointer.get_struct_tuple_field (| tagged, "core::error::TaggedOption", 0 |)
         |)))
     | _, _ => M.impossible
     end.
@@ -740,12 +740,17 @@ Module error.
                               "downcast_mut",
                               [ I ]
                             |),
-                            [ M.get_struct_tuple_field (M.read (| self |)) "core::error::Request" 0
+                            [
+                              M.SubPointer.get_struct_tuple_field (|
+                                M.read (| self |),
+                                "core::error::Request",
+                                0
+                              |)
                             ]
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -753,14 +758,18 @@ Module error.
                       let res := M.copy (| γ0_0 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ3_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::error::TaggedOption",
                           0
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_tuple_field (M.read (| res |)) "core::error::TaggedOption" 0,
+                          M.SubPointer.get_struct_tuple_field (|
+                            M.read (| res |),
+                            "core::error::TaggedOption",
+                            0
+                          |),
                           Value.StructTuple "core::option::Option::Some" [ M.read (| value |) ]
                         |) in
                       M.alloc (| Value.Tuple [] |)));
@@ -806,12 +815,17 @@ Module error.
                               "downcast_mut",
                               [ I ]
                             |),
-                            [ M.get_struct_tuple_field (M.read (| self |)) "core::error::Request" 0
+                            [
+                              M.SubPointer.get_struct_tuple_field (|
+                                M.read (| self |),
+                                "core::error::Request",
+                                0
+                              |)
                             ]
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -819,14 +833,18 @@ Module error.
                       let res := M.copy (| γ0_0 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ3_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::error::TaggedOption",
                           0
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_tuple_field (M.read (| res |)) "core::error::TaggedOption" 0,
+                          M.SubPointer.get_struct_tuple_field (|
+                            M.read (| res |),
+                            "core::error::TaggedOption",
+                            0
+                          |),
                           Value.StructTuple
                             "core::option::Option::Some"
                             [
@@ -933,21 +951,27 @@ Module error.
                     "downcast",
                     [ I ]
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::error::Request" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::error::Request",
+                      0
+                    |)
+                  ]
                 |)
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::error::TaggedOption",
                         0
@@ -1060,7 +1084,11 @@ Module error.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::error::tags::Value" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::error::tags::Value",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -1122,10 +1150,11 @@ Module error.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::error::tags::MaybeSizedValue"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::error::tags::MaybeSizedValue",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -1187,7 +1216,11 @@ Module error.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::error::tags::Ref" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::error::tags::Ref",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -1521,7 +1554,13 @@ Module error.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::error::Source" "current" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::error::Source",
+                      "current"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -1558,7 +1597,11 @@ Module error.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::error::Source" "current"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::error::Source",
+                    "current"
+                  |)
                 |))
             ]
           |)))
@@ -1595,11 +1638,19 @@ Module error.
           M.read (|
             let current :=
               M.copy (|
-                M.get_struct_record_field (M.read (| self |)) "core::error::Source" "current"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::error::Source",
+                  "current"
+                |)
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| self |)) "core::error::Source" "current",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::error::Source",
+                  "current"
+                |),
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
@@ -1618,7 +1669,11 @@ Module error.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::error::Source" "current"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::error::Source",
+                        "current"
+                      |)
                     |);
                     M.get_trait_method (|
                       "core::error::Error",

--- a/CoqOfRust/core/escape.v
+++ b/CoqOfRust/core/escape.v
@@ -165,7 +165,7 @@ Module escape.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -209,7 +209,7 @@ Module escape.
                           ltac:(M.monadic
                             (let hi :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                                   M.alloc (|
                                     M.call_closure (|
@@ -232,7 +232,7 @@ Module escape.
                               |) in
                             let lo :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                                   M.alloc (|
                                     M.call_closure (|
@@ -276,8 +276,8 @@ Module escape.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let data := M.copy (| γ0_0 |) in
                   let len := M.copy (| γ0_1 |) in
                   let _ := M.write (| M.read (| output |), M.read (| data |) |) in
@@ -348,7 +348,7 @@ Module escape.
         M.read (|
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 9 |)
               |),
@@ -357,12 +357,12 @@ Module escape.
           let ch := M.alloc (| M.rust_cast (M.read (| ch |)) |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 3 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -375,12 +375,12 @@ Module escape.
             |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 4 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -393,12 +393,12 @@ Module escape.
             |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 5 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -411,12 +411,12 @@ Module escape.
             |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 6 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -429,12 +429,12 @@ Module escape.
             |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 7 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -447,12 +447,12 @@ Module escape.
             |) in
           let _ :=
             M.write (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| output |),
                 M.alloc (| Value.Integer Integer.Usize 8 |)
               |),
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::escape::HEX_DIGITS" |),
                   M.alloc (|
                     M.rust_cast
@@ -601,10 +601,11 @@ Module escape.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::escape::EscapeIterInner"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::escape::EscapeIterInner",
                       "data"
+                    |)
                   ]
                 |));
               ("alive",
@@ -617,10 +618,11 @@ Module escape.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::escape::EscapeIterInner"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::escape::EscapeIterInner",
                       "alive"
+                    |)
                   ]
                 |))
             ]))
@@ -657,18 +659,20 @@ Module escape.
               M.read (| Value.String "data" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::escape::EscapeIterInner"
-                  "data");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::escape::EscapeIterInner",
+                  "data"
+                |));
               M.read (| Value.String "alive" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::escape::EscapeIterInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::escape::EscapeIterInner",
                     "alive"
+                  |)
                 |))
             ]
           |)))
@@ -722,16 +726,18 @@ Module escape.
                                         (LogicalOp.and (|
                                           BinOp.Pure.le
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                alive
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                alive,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                alive
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                alive,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |)),
                                           ltac:(M.monadic
                                             (BinOp.Pure.le
@@ -745,10 +751,11 @@ Module escape.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      alive
-                                                      "core::ops::range::Range"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      alive,
+                                                      "core::ops::range::Range",
                                                       "end"
+                                                    |)
                                                   |)
                                                 ]
                                               |))
@@ -914,7 +921,11 @@ Module escape.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::escape::EscapeIterInner" "data";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::escape::EscapeIterInner",
+                "data"
+              |);
               Value.StructRecord
                 "core::ops::range::Range"
                 [
@@ -929,13 +940,15 @@ Module escape.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::escape::EscapeIterInner"
-                              "alive")
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::escape::EscapeIterInner",
+                              "alive"
+                            |),
+                            "core::ops::range::Range",
                             "start"
+                          |)
                         |)
                       ]
                     |));
@@ -950,13 +963,15 @@ Module escape.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::escape::EscapeIterInner"
-                              "alive")
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::escape::EscapeIterInner",
+                              "alive"
+                            |),
+                            "core::ops::range::Range",
                             "end"
+                          |)
                         |)
                       ]
                     |))
@@ -1021,22 +1036,26 @@ Module escape.
             [
               BinOp.Panic.sub (|
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::escape::EscapeIterInner"
-                      "alive")
-                    "core::ops::range::Range"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::escape::EscapeIterInner",
+                      "alive"
+                    |),
+                    "core::ops::range::Range",
                     "end"
+                  |)
                 |),
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::escape::EscapeIterInner"
-                      "alive")
-                    "core::ops::range::Range"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::escape::EscapeIterInner",
+                      "alive"
+                    |),
+                    "core::ops::range::Range",
                     "start"
+                  |)
                 |)
               |)
             ]
@@ -1072,10 +1091,11 @@ Module escape.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::escape::EscapeIterInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::escape::EscapeIterInner",
                     "alive"
+                  |)
                 ]
               |);
               M.closure
@@ -1097,11 +1117,12 @@ Module escape.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_array_field (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::escape::EscapeIterInner"
-                                        "data",
+                                    M.SubPointer.get_array_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::escape::EscapeIterInner",
+                                        "data"
+                                      |),
                                       M.alloc (|
                                         M.call_closure (|
                                           M.get_trait_method (|
@@ -1155,10 +1176,11 @@ Module escape.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::escape::EscapeIterInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::escape::EscapeIterInner",
                     "alive"
+                  |)
                 ]
               |);
               M.closure
@@ -1180,11 +1202,12 @@ Module escape.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_array_field (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::escape::EscapeIterInner"
-                                        "data",
+                                    M.SubPointer.get_array_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::escape::EscapeIterInner",
+                                        "data"
+                                      |),
                                       M.alloc (|
                                         M.call_closure (|
                                           M.get_trait_method (|
@@ -1232,7 +1255,11 @@ Module escape.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::escape::EscapeIterInner" "alive";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::escape::EscapeIterInner",
+                "alive"
+              |);
               M.read (| n |)
             ]
           |)))
@@ -1261,7 +1288,11 @@ Module escape.
               []
             |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::escape::EscapeIterInner" "alive";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::escape::EscapeIterInner",
+                "alive"
+              |);
               M.read (| n |)
             ]
           |)))

--- a/CoqOfRust/core/ffi/c_str.v
+++ b/CoqOfRust/core/ffi/c_str.v
@@ -29,7 +29,11 @@ Module ffi.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::ffi::c_str::CStr" "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::c_str::CStr",
+                  "inner"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -73,10 +77,11 @@ Module ffi.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ffi::c_str::FromBytesWithNulError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ffi::c_str::FromBytesWithNulError",
                         "kind"
+                      |)
                     ]
                   |))
               ]))
@@ -121,14 +126,16 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ffi::c_str::FromBytesWithNulError"
-                  "kind";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::ffi::c_str::FromBytesWithNulError"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::c_str::FromBytesWithNulError",
                   "kind"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::ffi::c_str::FromBytesWithNulError",
+                  "kind"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -203,10 +210,11 @@ Module ffi.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ffi::c_str::FromBytesWithNulError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ffi::c_str::FromBytesWithNulError",
                       "kind"
+                    |)
                   |))
               ]
             |)))
@@ -258,7 +266,7 @@ Module ffi.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                           0
@@ -354,11 +362,11 @@ Module ffi.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                                   0
@@ -366,7 +374,7 @@ Module ffi.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                                   0
@@ -451,7 +459,7 @@ Module ffi.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                           0
@@ -569,10 +577,11 @@ Module ffi.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ffi::c_str::FromBytesWithNulError"
-                  "kind",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::c_str::FromBytesWithNulError",
+                  "kind"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -620,10 +629,11 @@ Module ffi.
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", Ty.tuple [], [], "clone", [] |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::ffi::c_str::FromBytesUntilNulError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::ffi::c_str::FromBytesUntilNulError",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -668,14 +678,16 @@ Module ffi.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::ffi::c_str::FromBytesUntilNulError"
-                  0;
-                M.get_struct_tuple_field
-                  (M.read (| other |))
-                  "core::ffi::c_str::FromBytesUntilNulError"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::ffi::c_str::FromBytesUntilNulError",
                   0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::ffi::c_str::FromBytesUntilNulError",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -749,10 +761,11 @@ Module ffi.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::ffi::c_str::FromBytesUntilNulError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::ffi::c_str::FromBytesUntilNulError",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -986,7 +999,7 @@ Module ffi.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1022,7 +1035,7 @@ Module ffi.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1038,12 +1051,13 @@ Module ffi.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ :=
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ffi::c_str::FromBytesWithNulError"
-                                "kind" in
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ffi::c_str::FromBytesWithNulError",
+                                "kind"
+                              |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ffi::c_str::FromBytesWithNulErrorKind::InteriorNul",
                                 0
@@ -1110,7 +1124,7 @@ Module ffi.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -1146,7 +1160,7 @@ Module ffi.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -1270,7 +1284,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1366,7 +1380,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1406,7 +1420,7 @@ Module ffi.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1541,7 +1555,13 @@ Module ffi.
                 "as_ptr",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::ffi::c_str::CStr" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::c_str::CStr",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1565,7 +1585,13 @@ Module ffi.
                   "len",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::ffi::c_str::CStr" "inner" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ffi::c_str::CStr",
+                    "inner"
+                  |)
+                ]
               |),
               Value.Integer Integer.Usize 1
             |)))
@@ -1595,7 +1621,13 @@ Module ffi.
                     "as_ptr",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::ffi::c_str::CStr" "inner" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ffi::c_str::CStr",
+                      "inner"
+                    |)
+                  ]
                 |)
               |))
               (Value.Integer Integer.I8 0)))
@@ -1677,7 +1709,11 @@ Module ffi.
               (M.read (|
                 M.use
                   (M.alloc (|
-                    M.get_struct_record_field (M.read (| self |)) "core::ffi::c_str::CStr" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ffi::c_str::CStr",
+                      "inner"
+                    |)
                   |))
               |))))
         | _, _ => M.impossible
@@ -1906,10 +1942,11 @@ Module ffi.
                           (M.alloc (|
                             BinOp.Pure.lt
                               (M.read (|
-                                M.get_struct_record_field
-                                  index
-                                  "core::ops::range::RangeFrom"
+                                M.SubPointer.get_struct_record_field (|
+                                  index,
+                                  "core::ops::range::RangeFrom",
                                   "start"
+                                |)
                               |))
                               (M.call_closure (|
                                 M.get_associated_function (|
@@ -1948,10 +1985,11 @@ Module ffi.
                                   [
                                     ("start",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          index
-                                          "core::ops::range::RangeFrom"
+                                        M.SubPointer.get_struct_record_field (|
+                                          index,
+                                          "core::ops::range::RangeFrom",
                                           "start"
+                                        |)
                                       |))
                                   ]
                               ]
@@ -2015,10 +2053,11 @@ Module ffi.
                                               [ Ty.path "usize" ]
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                index
-                                                "core::ops::range::RangeFrom"
+                                              M.SubPointer.get_struct_record_field (|
+                                                index,
+                                                "core::ops::range::RangeFrom",
                                                 "start"
+                                              |)
                                             ]
                                           |)
                                         ]

--- a/CoqOfRust/core/ffi/mod.v
+++ b/CoqOfRust/core/ffi/mod.v
@@ -207,30 +207,44 @@ Module ffi.
               M.read (| Value.String "gp_offset" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| self |)) "core::ffi::VaListImpl" "gp_offset");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::VaListImpl",
+                  "gp_offset"
+                |));
               M.read (| Value.String "fp_offset" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| self |)) "core::ffi::VaListImpl" "fp_offset");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::VaListImpl",
+                  "fp_offset"
+                |));
               M.read (| Value.String "overflow_arg_area" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ffi::VaListImpl"
-                  "overflow_arg_area");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::VaListImpl",
+                  "overflow_arg_area"
+                |));
               M.read (| Value.String "reg_save_area" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ffi::VaListImpl"
-                  "reg_save_area");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::VaListImpl",
+                  "reg_save_area"
+                |));
               M.read (| Value.String "_marker" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ffi::VaListImpl" "_marker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ffi::VaListImpl",
+                    "_marker"
+                  |)
                 |))
             ]
           |)))
@@ -281,12 +295,20 @@ Module ffi.
               M.read (| Value.String "inner" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field (M.read (| self |)) "core::ffi::VaList" "inner");
+                (M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ffi::VaList",
+                  "inner"
+                |));
               M.read (| Value.String "_marker" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ffi::VaList" "_marker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ffi::VaList",
+                    "_marker"
+                  |)
                 |))
             ]
           |)))
@@ -434,7 +456,13 @@ Module ffi.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "core::ffi::VaList" "inner" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::ffi::VaList",
+              "inner"
+            |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -460,7 +488,13 @@ Module ffi.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "core::ffi::VaList" "inner" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::ffi::VaList",
+              "inner"
+            |)
+          |)))
       | _, _ => M.impossible
       end.
     

--- a/CoqOfRust/core/fmt/builders.v
+++ b/CoqOfRust/core/fmt/builders.v
@@ -208,7 +208,7 @@ Module fmt.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -222,15 +222,17 @@ Module fmt.
                                                     ltac:(M.monadic
                                                       (let γ :=
                                                         M.use
-                                                          (M.get_struct_record_field
-                                                            (M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::fmt::builders::PadAdapter"
+                                                          (M.SubPointer.get_struct_record_field (|
+                                                            M.read (|
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::fmt::builders::PadAdapter",
                                                                 "state"
-                                                            |))
-                                                            "core::fmt::builders::PadAdapterState"
-                                                            "on_newline") in
+                                                              |)
+                                                            |),
+                                                            "core::fmt::builders::PadAdapterState",
+                                                            "on_newline"
+                                                          |)) in
                                                       let _ :=
                                                         M.is_constant_or_break_match (|
                                                           M.read (| γ |),
@@ -267,10 +269,11 @@ Module fmt.
                                                                   |),
                                                                   [
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "core::fmt::builders::PadAdapter"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "core::fmt::builders::PadAdapter",
                                                                         "buf"
+                                                                      |)
                                                                     |);
                                                                     M.read (| Value.String "    " |)
                                                                   ]
@@ -282,7 +285,7 @@ Module fmt.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                     γ,
                                                                     "core::ops::control_flow::ControlFlow::Break",
                                                                     0
@@ -326,7 +329,7 @@ Module fmt.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                     γ,
                                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                                     0
@@ -342,15 +345,17 @@ Module fmt.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_struct_record_field
-                                                  (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::fmt::builders::PadAdapter"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::fmt::builders::PadAdapter",
                                                       "state"
-                                                  |))
-                                                  "core::fmt::builders::PadAdapterState"
-                                                  "on_newline",
+                                                    |)
+                                                  |),
+                                                  "core::fmt::builders::PadAdapterState",
+                                                  "on_newline"
+                                                |),
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.path "str",
@@ -385,10 +390,11 @@ Module fmt.
                                                         |),
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::PadAdapter"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::PadAdapter",
                                                               "buf"
+                                                            |)
                                                           |);
                                                           M.read (| s |)
                                                         ]
@@ -400,7 +406,7 @@ Module fmt.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Break",
                                                           0
@@ -441,7 +447,7 @@ Module fmt.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                           0
@@ -489,15 +495,17 @@ Module fmt.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::fmt::builders::PadAdapter"
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::fmt::builders::PadAdapter",
                                       "state"
-                                  |))
-                                  "core::fmt::builders::PadAdapterState"
-                                  "on_newline") in
+                                    |)
+                                  |),
+                                  "core::fmt::builders::PadAdapterState",
+                                  "on_newline"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
@@ -524,10 +532,11 @@ Module fmt.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::fmt::builders::PadAdapter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::fmt::builders::PadAdapter",
                                               "buf"
+                                            |)
                                           |);
                                           M.read (| Value.String "    " |)
                                         ]
@@ -539,7 +548,7 @@ Module fmt.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -575,7 +584,7 @@ Module fmt.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -590,15 +599,17 @@ Module fmt.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::fmt::builders::PadAdapter"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::fmt::builders::PadAdapter",
                             "state"
-                        |))
-                        "core::fmt::builders::PadAdapterState"
-                        "on_newline",
+                          |)
+                        |),
+                        "core::fmt::builders::PadAdapterState",
+                        "on_newline"
+                      |),
                       BinOp.Pure.eq (M.read (| c |)) (Value.UnicodeChar 10)
                     |) in
                   M.alloc (|
@@ -612,10 +623,11 @@ Module fmt.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::fmt::builders::PadAdapter"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::fmt::builders::PadAdapter",
                             "buf"
+                          |)
                         |);
                         M.read (| c |)
                       ]
@@ -791,10 +803,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugStruct"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugStruct",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -812,10 +825,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugStruct"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugStruct",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -862,10 +876,11 @@ Module fmt.
                                                               (M.alloc (|
                                                                 UnOp.Pure.not
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "core::fmt::builders::DebugStruct"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "core::fmt::builders::DebugStruct",
                                                                       "has_fields"
+                                                                    |)
                                                                   |))
                                                               |)) in
                                                           let _ :=
@@ -900,10 +915,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugStruct"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugStruct",
                                                                             "fmt"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           Value.String " {
@@ -918,7 +934,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -967,7 +983,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -1012,10 +1028,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugStruct"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugStruct",
                                                             "fmt"
+                                                          |)
                                                         |);
                                                         slot;
                                                         state
@@ -1054,7 +1071,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1097,7 +1114,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1139,7 +1156,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1182,7 +1199,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1238,7 +1255,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1281,7 +1298,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1312,10 +1329,11 @@ Module fmt.
                                                           ltac:(M.monadic
                                                             (let γ :=
                                                               M.use
-                                                                (M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
-                                                                  "has_fields") in
+                                                                (M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
+                                                                  "has_fields"
+                                                                |)) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ |),
@@ -1355,10 +1373,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| prefix |)
                                                             ]
@@ -1370,7 +1389,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1413,7 +1432,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1447,10 +1466,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| name |)
                                                             ]
@@ -1462,7 +1482,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1505,7 +1525,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1539,10 +1559,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| Value.String ": " |)
                                                             ]
@@ -1554,7 +1575,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -1597,7 +1618,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -1627,10 +1648,11 @@ Module fmt.
                                                       Value.Tuple
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugStruct"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugStruct",
                                                               "fmt"
+                                                            |)
                                                           |)
                                                         ]
                                                     ]
@@ -1648,10 +1670,11 @@ Module fmt.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugStruct"
-                    "has_fields",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugStruct",
+                    "has_fields"
+                  |),
                   Value.Bool true
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -1689,10 +1712,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugStruct"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugStruct",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -1710,10 +1734,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugStruct"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugStruct",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -1733,10 +1758,11 @@ Module fmt.
                                               ltac:(M.monadic
                                                 (let γ :=
                                                   M.use
-                                                    (M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::fmt::builders::DebugStruct"
-                                                      "has_fields") in
+                                                    (M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::fmt::builders::DebugStruct",
+                                                      "has_fields"
+                                                    |)) in
                                                 let _ :=
                                                   M.is_constant_or_break_match (|
                                                     M.read (| γ |),
@@ -1796,10 +1822,11 @@ Module fmt.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::builders::DebugStruct"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::builders::DebugStruct",
                                                                     "fmt"
+                                                                  |)
                                                                 |);
                                                                 slot;
                                                                 state
@@ -1845,7 +1872,7 @@ Module fmt.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::ops::control_flow::ControlFlow::Break",
                                                                       0
@@ -1891,7 +1918,7 @@ Module fmt.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                                       0
@@ -1909,10 +1936,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| Value.String "}" |)
                                                             ]
@@ -1929,10 +1957,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugStruct"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugStruct",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| Value.String ", .. }" |)
                                                             ]
@@ -1951,10 +1980,11 @@ Module fmt.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::fmt::builders::DebugStruct"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::fmt::builders::DebugStruct",
                                                           "fmt"
+                                                        |)
                                                       |);
                                                       M.read (| Value.String " { .. }" |)
                                                     ]
@@ -1970,10 +2000,11 @@ Module fmt.
                     ]
                   |)
                 |) in
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::fmt::builders::DebugStruct"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::fmt::builders::DebugStruct",
                 "result"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2005,18 +2036,20 @@ Module fmt.
                       ltac:(M.monadic
                         (let γ :=
                           M.use
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::builders::DebugStruct"
-                              "has_fields") in
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::builders::DebugStruct",
+                              "has_fields"
+                            |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::builders::DebugStruct"
-                              "result",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::builders::DebugStruct",
+                              "result"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -2034,10 +2067,11 @@ Module fmt.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::fmt::builders::DebugStruct"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::fmt::builders::DebugStruct",
                                     "result"
+                                  |)
                                 |);
                                 M.closure
                                   (fun γ =>
@@ -2082,10 +2116,11 @@ Module fmt.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::builders::DebugStruct"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::builders::DebugStruct",
                                                                     "fmt"
+                                                                  |)
                                                                 |);
                                                                 M.read (| Value.String "}" |)
                                                               ]
@@ -2102,10 +2137,11 @@ Module fmt.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::builders::DebugStruct"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::builders::DebugStruct",
                                                                     "fmt"
+                                                                  |)
                                                                 |);
                                                                 M.read (| Value.String " }" |)
                                                               ]
@@ -2125,10 +2161,11 @@ Module fmt.
                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
                   ]
                 |) in
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::fmt::builders::DebugStruct"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::fmt::builders::DebugStruct",
                 "result"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2149,10 +2186,11 @@ Module fmt.
               M.get_associated_function (| Ty.path "core::fmt::Formatter", "alternate", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugStruct"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugStruct",
                     "fmt"
+                  |)
                 |)
               ]
             |)))
@@ -2314,10 +2352,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugTuple"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugTuple",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -2335,10 +2374,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugTuple"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugTuple",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -2384,10 +2424,11 @@ Module fmt.
                                                               (M.alloc (|
                                                                 BinOp.Pure.eq
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "core::fmt::builders::DebugTuple"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "core::fmt::builders::DebugTuple",
                                                                       "fields"
+                                                                    |)
                                                                   |))
                                                                   (Value.Integer Integer.Usize 0)
                                                               |)) in
@@ -2423,10 +2464,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugTuple"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugTuple",
                                                                             "fmt"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           Value.String "(
@@ -2441,7 +2483,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -2490,7 +2532,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -2535,10 +2577,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugTuple"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugTuple",
                                                             "fmt"
+                                                          |)
                                                         |);
                                                         slot;
                                                         state
@@ -2592,7 +2635,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -2635,7 +2678,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -2669,10 +2712,11 @@ Module fmt.
                                                                 (M.alloc (|
                                                                   BinOp.Pure.eq
                                                                     (M.read (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "core::fmt::builders::DebugTuple"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "core::fmt::builders::DebugTuple",
                                                                         "fields"
+                                                                      |)
                                                                     |))
                                                                     (Value.Integer Integer.Usize 0)
                                                                 |)) in
@@ -2715,10 +2759,11 @@ Module fmt.
                                                             |),
                                                             [
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugTuple"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugTuple",
                                                                   "fmt"
+                                                                |)
                                                               |);
                                                               M.read (| prefix |)
                                                             ]
@@ -2730,7 +2775,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -2773,7 +2818,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -2803,10 +2848,11 @@ Module fmt.
                                                       Value.Tuple
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugTuple"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugTuple",
                                                               "fmt"
+                                                            |)
                                                           |)
                                                         ]
                                                     ]
@@ -2824,10 +2870,11 @@ Module fmt.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugTuple"
-                    "fields" in
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugTuple",
+                    "fields"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2869,10 +2916,11 @@ Module fmt.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::fmt::builders::DebugTuple"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::fmt::builders::DebugTuple",
                                     "fields"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -2880,10 +2928,11 @@ Module fmt.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::builders::DebugTuple"
-                              "result",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::builders::DebugTuple",
+                              "result"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply
@@ -2901,10 +2950,11 @@ Module fmt.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::fmt::builders::DebugTuple"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::fmt::builders::DebugTuple",
                                     "result"
+                                  |)
                                 |);
                                 M.closure
                                   (fun γ =>
@@ -2930,20 +2980,22 @@ Module fmt.
                                                                     LogicalOp.and (|
                                                                       BinOp.Pure.eq
                                                                         (M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugTuple"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugTuple",
                                                                             "fields"
+                                                                          |)
                                                                         |))
                                                                         (Value.Integer
                                                                           Integer.Usize
                                                                           1),
                                                                       ltac:(M.monadic
                                                                         (M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugTuple"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugTuple",
                                                                             "empty_name"
+                                                                          |)
                                                                         |)))
                                                                     |),
                                                                     ltac:(M.monadic
@@ -2991,10 +3043,11 @@ Module fmt.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::fmt::builders::DebugTuple"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::fmt::builders::DebugTuple",
                                                                               "fmt"
+                                                                            |)
                                                                           |);
                                                                           M.read (|
                                                                             Value.String ","
@@ -3008,7 +3061,7 @@ Module fmt.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::ops::control_flow::ControlFlow::Break",
                                                                           0
@@ -3057,7 +3110,7 @@ Module fmt.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                                           0
@@ -3082,10 +3135,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugTuple"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugTuple",
                                                             "fmt"
+                                                          |)
                                                         |);
                                                         M.read (| Value.String ")" |)
                                                       ]
@@ -3103,10 +3157,11 @@ Module fmt.
                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
                   ]
                 |) in
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::fmt::builders::DebugTuple"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::fmt::builders::DebugTuple",
                 "result"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3127,10 +3182,11 @@ Module fmt.
               M.get_associated_function (| Ty.path "core::fmt::Formatter", "alternate", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugTuple"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugTuple",
                     "fmt"
+                  |)
                 |)
               ]
             |)))
@@ -3193,10 +3249,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugInner"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugInner",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -3214,10 +3271,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugInner",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -3263,10 +3321,11 @@ Module fmt.
                                                               (M.alloc (|
                                                                 UnOp.Pure.not
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "core::fmt::builders::DebugInner"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "core::fmt::builders::DebugInner",
                                                                       "has_fields"
+                                                                    |)
                                                                   |))
                                                               |)) in
                                                           let _ :=
@@ -3301,10 +3360,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugInner"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugInner",
                                                                             "fmt"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           Value.String "
@@ -3319,7 +3379,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -3368,7 +3428,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -3413,10 +3473,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugInner"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugInner",
                                                             "fmt"
+                                                          |)
                                                         |);
                                                         slot;
                                                         state
@@ -3470,7 +3531,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -3513,7 +3574,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -3543,10 +3604,11 @@ Module fmt.
                                                         ltac:(M.monadic
                                                           (let γ :=
                                                             M.use
-                                                              (M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::fmt::builders::DebugInner"
-                                                                "has_fields") in
+                                                              (M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::fmt::builders::DebugInner",
+                                                                "has_fields"
+                                                              |)) in
                                                           let _ :=
                                                             M.is_constant_or_break_match (|
                                                               M.read (| γ |),
@@ -3577,10 +3639,11 @@ Module fmt.
                                                                     |),
                                                                     [
                                                                       M.read (|
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::fmt::builders::DebugInner"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::fmt::builders::DebugInner",
                                                                           "fmt"
+                                                                        |)
                                                                       |);
                                                                       M.read (| Value.String ", " |)
                                                                     ]
@@ -3592,7 +3655,7 @@ Module fmt.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::ops::control_flow::ControlFlow::Break",
                                                                       0
@@ -3638,7 +3701,7 @@ Module fmt.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                                       0
@@ -3673,10 +3736,11 @@ Module fmt.
                                                       Value.Tuple
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugInner"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugInner",
                                                               "fmt"
+                                                            |)
                                                           |)
                                                         ]
                                                     ]
@@ -3694,10 +3758,11 @@ Module fmt.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugInner"
-                    "has_fields",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugInner",
+                    "has_fields"
+                  |),
                   Value.Bool true
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -3721,10 +3786,11 @@ Module fmt.
               M.get_associated_function (| Ty.path "core::fmt::Formatter", "alternate", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugInner",
                     "fmt"
+                  |)
                 |)
               ]
             |)))
@@ -3812,10 +3878,11 @@ Module fmt.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::fmt::builders::DebugSet"
-                        "inner";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::builders::DebugSet",
+                        "inner"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -3876,10 +3943,11 @@ Module fmt.
                       [ F ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::fmt::builders::DebugSet"
-                        "inner";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::builders::DebugSet",
+                        "inner"
+                      |);
                       M.read (| entry_fmt |)
                     ]
                   |)
@@ -3954,7 +4022,7 @@ Module fmt.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -4015,13 +4083,15 @@ Module fmt.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::fmt::builders::DebugSet"
-                      "inner")
-                    "core::fmt::builders::DebugInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::fmt::builders::DebugSet",
+                      "inner"
+                    |),
+                    "core::fmt::builders::DebugInner",
                     "result"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -4041,13 +4111,15 @@ Module fmt.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::builders::DebugSet"
-                                          "inner")
-                                        "core::fmt::builders::DebugInner"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::builders::DebugSet",
+                                          "inner"
+                                        |),
+                                        "core::fmt::builders::DebugInner",
                                         "fmt"
+                                      |)
                                     |);
                                     M.read (| Value.String "}" |)
                                   ]
@@ -4142,10 +4214,11 @@ Module fmt.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::fmt::builders::DebugList"
-                        "inner";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::builders::DebugList",
+                        "inner"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -4206,10 +4279,11 @@ Module fmt.
                       [ F ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::fmt::builders::DebugList"
-                        "inner";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::builders::DebugList",
+                        "inner"
+                      |);
                       M.read (| entry_fmt |)
                     ]
                   |)
@@ -4284,7 +4358,7 @@ Module fmt.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -4345,13 +4419,15 @@ Module fmt.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::fmt::builders::DebugList"
-                      "inner")
-                    "core::fmt::builders::DebugInner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::fmt::builders::DebugList",
+                      "inner"
+                    |),
+                    "core::fmt::builders::DebugInner",
                     "result"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -4371,13 +4447,15 @@ Module fmt.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::builders::DebugList"
-                                          "inner")
-                                        "core::fmt::builders::DebugInner"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::builders::DebugList",
+                                          "inner"
+                                        |),
+                                        "core::fmt::builders::DebugInner",
                                         "fmt"
+                                      |)
                                     |);
                                     M.read (| Value.String "]" |)
                                   ]
@@ -4591,10 +4669,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugMap"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugMap",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -4612,10 +4691,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugMap",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -4640,10 +4720,11 @@ Module fmt.
                                                         UnOp.Pure.not
                                                           (UnOp.Pure.not
                                                             (M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::fmt::builders::DebugMap"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::fmt::builders::DebugMap",
                                                                 "has_key"
+                                                              |)
                                                             |)))
                                                       |)) in
                                                   let _ :=
@@ -4721,10 +4802,11 @@ Module fmt.
                                                                 (M.alloc (|
                                                                   UnOp.Pure.not
                                                                     (M.read (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "core::fmt::builders::DebugMap"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "core::fmt::builders::DebugMap",
                                                                         "has_fields"
+                                                                      |)
                                                                     |))
                                                                 |)) in
                                                             let _ :=
@@ -4759,10 +4841,11 @@ Module fmt.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::fmt::builders::DebugMap"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::fmt::builders::DebugMap",
                                                                               "fmt"
+                                                                            |)
                                                                           |);
                                                                           M.read (|
                                                                             Value.String "
@@ -4777,7 +4860,7 @@ Module fmt.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::ops::control_flow::ControlFlow::Break",
                                                                           0
@@ -4826,7 +4909,7 @@ Module fmt.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                                           0
@@ -4850,10 +4933,11 @@ Module fmt.
                                                     |) in
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::fmt::builders::DebugMap"
-                                                        "state",
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::fmt::builders::DebugMap",
+                                                        "state"
+                                                      |),
                                                       M.call_closure (|
                                                         M.get_trait_method (|
                                                           "core::default::Default",
@@ -4876,16 +4960,18 @@ Module fmt.
                                                         |),
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugMap",
                                                               "fmt"
+                                                            |)
                                                           |);
                                                           slot;
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugMap"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugMap",
                                                             "state"
+                                                          |)
                                                         ]
                                                       |)
                                                     |) in
@@ -4936,7 +5022,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -4980,7 +5066,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5024,7 +5110,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5068,7 +5154,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5088,10 +5174,11 @@ Module fmt.
                                                           ltac:(M.monadic
                                                             (let γ :=
                                                               M.use
-                                                                (M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::fmt::builders::DebugMap"
-                                                                  "has_fields") in
+                                                                (M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::fmt::builders::DebugMap",
+                                                                  "has_fields"
+                                                                |)) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ |),
@@ -5123,10 +5210,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::builders::DebugMap"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::builders::DebugMap",
                                                                             "fmt"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           Value.String ", "
@@ -5140,7 +5228,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -5189,7 +5277,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -5243,10 +5331,11 @@ Module fmt.
                                                                 Value.Tuple
                                                                   [
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "core::fmt::builders::DebugMap"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "core::fmt::builders::DebugMap",
                                                                         "fmt"
+                                                                      |)
                                                                     |)
                                                                   ]
                                                               ]
@@ -5258,7 +5347,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5302,7 +5391,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5336,10 +5425,11 @@ Module fmt.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::builders::DebugMap"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::builders::DebugMap",
                                                                     "fmt"
+                                                                  |)
                                                                 |);
                                                                 M.read (| Value.String ": " |)
                                                               ]
@@ -5351,7 +5441,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5395,7 +5485,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5409,10 +5499,11 @@ Module fmt.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::fmt::builders::DebugMap"
-                                              "has_key",
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::fmt::builders::DebugMap",
+                                              "has_key"
+                                            |),
                                             Value.Bool true
                                           |) in
                                         M.alloc (|
@@ -5526,10 +5617,11 @@ Module fmt.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugMap"
-                    "result",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugMap",
+                    "result"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
@@ -5547,10 +5639,11 @@ Module fmt.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::fmt::builders::DebugMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::fmt::builders::DebugMap",
                           "result"
+                        |)
                       |);
                       M.closure
                         (fun γ =>
@@ -5574,10 +5667,11 @@ Module fmt.
                                                       (M.alloc (|
                                                         UnOp.Pure.not
                                                           (M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugMap",
                                                               "has_key"
+                                                            |)
                                                           |))
                                                       |)) in
                                                   let _ :=
@@ -5660,16 +5754,18 @@ Module fmt.
                                                         |),
                                                         [
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::fmt::builders::DebugMap"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::fmt::builders::DebugMap",
                                                               "fmt"
+                                                            |)
                                                           |);
                                                           slot;
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::fmt::builders::DebugMap"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::fmt::builders::DebugMap",
                                                             "state"
+                                                          |)
                                                         ]
                                                       |)
                                                     |) in
@@ -5720,7 +5816,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5764,7 +5860,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5809,7 +5905,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5853,7 +5949,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5905,10 +6001,11 @@ Module fmt.
                                                                 Value.Tuple
                                                                   [
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        (M.read (| self |))
-                                                                        "core::fmt::builders::DebugMap"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        M.read (| self |),
+                                                                        "core::fmt::builders::DebugMap",
                                                                         "fmt"
+                                                                      |)
                                                                     |)
                                                                   ]
                                                               ]
@@ -5920,7 +6017,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -5964,7 +6061,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -5978,10 +6075,11 @@ Module fmt.
                                           |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::fmt::builders::DebugMap"
-                                              "has_key",
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::fmt::builders::DebugMap",
+                                              "has_key"
+                                            |),
                                             Value.Bool false
                                           |) in
                                         M.alloc (|
@@ -5999,10 +6097,11 @@ Module fmt.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugMap"
-                    "has_fields",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugMap",
+                    "has_fields"
+                  |),
                   Value.Bool true
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -6076,13 +6175,13 @@ Module fmt.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let k := M.copy (| γ1_0 |) in
                                         let v := M.copy (| γ1_1 |) in
                                         let _ :=
@@ -6145,10 +6244,11 @@ Module fmt.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugMap",
                     "result"
+                  |)
                 |);
                 M.closure
                   (fun γ =>
@@ -6173,10 +6273,11 @@ Module fmt.
                                                   UnOp.Pure.not
                                                     (UnOp.Pure.not
                                                       (M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::fmt::builders::DebugMap"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::fmt::builders::DebugMap",
                                                           "has_key"
+                                                        |)
                                                       |)))
                                                 |)) in
                                             let _ :=
@@ -6228,10 +6329,11 @@ Module fmt.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::fmt::builders::DebugMap"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::fmt::builders::DebugMap",
                                             "fmt"
+                                          |)
                                         |);
                                         M.read (| Value.String "}" |)
                                       ]
@@ -6263,10 +6365,11 @@ Module fmt.
               M.get_associated_function (| Ty.path "core::fmt::Formatter", "alternate", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::fmt::builders::DebugMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::builders::DebugMap",
                     "fmt"
+                  |)
                 |)
               ]
             |)))
@@ -6308,7 +6411,11 @@ Module fmt.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::fmt::builders::FormatterFn" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::fmt::builders::FormatterFn",
+                  0
+                |);
                 Value.Tuple [ M.read (| f |) ]
               ]
             |)))
@@ -6349,7 +6456,11 @@ Module fmt.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::fmt::builders::FormatterFn" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::fmt::builders::FormatterFn",
+                  0
+                |);
                 Value.Tuple [ M.read (| f |) ]
               ]
             |)))

--- a/CoqOfRust/core/fmt/float.v
+++ b/CoqOfRust/core/fmt/float.v
@@ -389,12 +389,13 @@ Module fmt.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ :=
-                      M.get_struct_record_field
-                        (M.read (| fmt |))
-                        "core::fmt::Formatter"
-                        "precision" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| fmt |),
+                        "core::fmt::Formatter",
+                        "precision"
+                      |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -723,12 +724,13 @@ Module fmt.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ :=
-                      M.get_struct_record_field
-                        (M.read (| fmt |))
-                        "core::fmt::Formatter"
-                        "precision" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| fmt |),
+                        "core::fmt::Formatter",
+                        "precision"
+                      |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -834,12 +836,13 @@ Module fmt.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ :=
-                      M.get_struct_record_field
-                        (M.read (| fmt |))
-                        "core::fmt::Formatter"
-                        "precision" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| fmt |),
+                        "core::fmt::Formatter",
+                        "precision"
+                      |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0

--- a/CoqOfRust/core/fmt/mod.v
+++ b/CoqOfRust/core/fmt/mod.v
@@ -634,33 +634,54 @@ Module fmt.
                           (* Unsize *)
                           M.pointer_coercion
                             (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::fmt::Formatter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::fmt::Formatter",
                                 "buf"
+                              |)
                             |))
                         ]
                     ]
                   |)));
               ("flags",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "flags"
+                  |)
                 |));
               ("fill",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "fill"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "fill"
+                  |)
                 |));
               ("align",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "align"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "align"
+                  |)
                 |));
               ("width",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "width"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "width"
+                  |)
                 |));
               ("precision",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "precision"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "precision"
+                  |)
                 |))
             ]))
       | _, _ => M.impossible
@@ -877,7 +898,11 @@ Module fmt.
                     |)
                   |) in
                 M.match_operator (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "width",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "width"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
@@ -910,7 +935,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -946,7 +971,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -966,10 +991,11 @@ Module fmt.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Formatter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Formatter",
                                   "buf"
+                                |)
                               |);
                               M.read (| buf |)
                             ]
@@ -978,7 +1004,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1017,7 +1043,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1053,7 +1079,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1073,10 +1099,11 @@ Module fmt.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Formatter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Formatter",
                                   "buf"
+                                |)
                               |);
                               M.read (| buf |)
                             ]
@@ -1085,7 +1112,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1109,10 +1136,11 @@ Module fmt.
                             M.call_closure (|
                               M.get_function (| "core::mem::replace", [ Ty.path "char" ] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Formatter"
-                                  "fill";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Formatter",
+                                  "fill"
+                                |);
                                 Value.UnicodeChar 48
                               ]
                             |)
@@ -1125,10 +1153,11 @@ Module fmt.
                                 [ Ty.path "core::fmt::rt::Alignment" ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Formatter"
-                                  "align";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Formatter",
+                                  "align"
+                                |);
                                 Value.StructTuple "core::fmt::rt::Alignment::Right" []
                               ]
                             |)
@@ -1162,7 +1191,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1198,7 +1227,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1242,7 +1271,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1278,7 +1307,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1312,10 +1341,11 @@ Module fmt.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::Formatter",
                                           "buf"
+                                        |)
                                       |);
                                       M.read (| buf |)
                                     ]
@@ -1327,7 +1357,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1363,7 +1393,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1401,7 +1431,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1437,7 +1467,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1448,18 +1478,20 @@ Module fmt.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
-                              "fill",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
+                              "fill"
+                            |),
                             M.read (| old_fill |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
-                              "align",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
+                              "align"
+                            |),
                             M.read (| old_align |)
                           |) in
                         M.alloc (|
@@ -1468,7 +1500,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1509,7 +1541,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1545,7 +1577,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1584,7 +1616,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1620,7 +1652,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1653,10 +1685,11 @@ Module fmt.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::Formatter",
                                           "buf"
+                                        |)
                                       |);
                                       M.read (| buf |)
                                     ]
@@ -1668,7 +1701,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1704,7 +1737,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -1806,10 +1839,11 @@ Module fmt.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::fmt::Formatter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::fmt::Formatter",
                                         "width"
+                                      |)
                                     ]
                                   |),
                                   ltac:(M.monadic
@@ -1822,10 +1856,11 @@ Module fmt.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::Formatter",
                                           "precision"
+                                        |)
                                       ]
                                     |)))
                                 |)
@@ -1846,10 +1881,11 @@ Module fmt.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::Formatter",
                                           "buf"
+                                        |)
                                       |);
                                       M.read (| s |)
                                     ]
@@ -1869,12 +1905,13 @@ Module fmt.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ :=
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::fmt::Formatter"
-                                "precision" in
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::fmt::Formatter",
+                                "precision"
+                              |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -1911,13 +1948,13 @@ Module fmt.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
-                                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                    let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                     let i := M.copy (| γ1_0 |) in
                                     M.alloc (|
                                       M.call_closure (|
@@ -1958,7 +1995,11 @@ Module fmt.
                     |)
                   |) in
                 M.match_operator (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "width",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "width"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
@@ -1973,10 +2014,11 @@ Module fmt.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Formatter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Formatter",
                                   "buf"
+                                |)
                               |);
                               M.read (| s |)
                             ]
@@ -1985,7 +2027,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -2035,10 +2077,11 @@ Module fmt.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::Formatter",
                                           "buf"
+                                        |)
                                       |);
                                       M.read (| s |)
                                     ]
@@ -2088,7 +2131,7 @@ Module fmt.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2125,7 +2168,7 @@ Module fmt.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2159,10 +2202,11 @@ Module fmt.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::fmt::Formatter"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::fmt::Formatter",
                                                   "buf"
+                                                |)
                                               |);
                                               M.read (| s |)
                                             ]
@@ -2174,7 +2218,7 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -2210,7 +2254,7 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -2279,7 +2323,11 @@ Module fmt.
                 let align :=
                   M.copy (|
                     M.match_operator (|
-                      M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "align",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::Formatter",
+                        "align"
+                      |),
                       [
                         fun γ => ltac:(M.monadic default);
                         fun γ =>
@@ -2331,8 +2379,8 @@ Module fmt.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let pre_pad := M.copy (| γ0_0 |) in
                         let post_pad := M.copy (| γ0_1 |) in
                         let _ :=
@@ -2390,7 +2438,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -2424,16 +2472,18 @@ Module fmt.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::Formatter"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::Formatter",
                                                                     "buf"
+                                                                  |)
                                                                 |);
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::fmt::Formatter"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::fmt::Formatter",
                                                                     "fill"
+                                                                  |)
                                                                 |)
                                                               ]
                                                             |)
@@ -2444,7 +2494,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -2489,7 +2539,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -2517,10 +2567,11 @@ Module fmt.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::fmt::Formatter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::fmt::Formatter",
                                       "fill"
+                                    |)
                                   |);
                                   M.read (| post_pad |)
                                 ]
@@ -2595,12 +2646,13 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::fmt::Formatter"
-                            "width" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::fmt::Formatter",
+                            "width"
+                          |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -2621,17 +2673,19 @@ Module fmt.
                           |) in
                         let old_fill :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
                               "fill"
+                            |)
                           |) in
                         let old_align :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
                               "align"
+                            |)
                           |) in
                         let _ :=
                           M.match_operator (|
@@ -2658,10 +2712,11 @@ Module fmt.
                                     |) in
                                   let sign :=
                                     M.copy (|
-                                      M.get_struct_record_field
-                                        formatted
-                                        "core::num::fmt::Formatted"
+                                      M.SubPointer.get_struct_record_field (|
+                                        formatted,
+                                        "core::num::fmt::Formatted",
                                         "sign"
+                                      |)
                                     |) in
                                   let _ :=
                                     M.match_operator (|
@@ -2687,10 +2742,11 @@ Module fmt.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::fmt::Formatter"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::fmt::Formatter",
                                                     "buf"
+                                                  |)
                                                 |);
                                                 M.read (| sign |)
                                               ]
@@ -2702,7 +2758,7 @@ Module fmt.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2739,7 +2795,7 @@ Module fmt.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2750,10 +2806,11 @@ Module fmt.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        formatted
-                                        "core::num::fmt::Formatted"
-                                        "sign",
+                                      M.SubPointer.get_struct_record_field (|
+                                        formatted,
+                                        "core::num::fmt::Formatted",
+                                        "sign"
+                                      |),
                                       M.read (| Value.String "" |)
                                     |) in
                                   let _ :=
@@ -2780,18 +2837,20 @@ Module fmt.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::fmt::Formatter"
-                                        "fill",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::fmt::Formatter",
+                                        "fill"
+                                      |),
                                       Value.UnicodeChar 48
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::fmt::Formatter"
-                                        "align",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::fmt::Formatter",
+                                        "align"
+                                      |),
                                       Value.StructTuple "core::fmt::rt::Alignment::Right" []
                                     |) in
                                   M.alloc (| Value.Tuple [] |)));
@@ -2880,7 +2939,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -2920,7 +2979,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -2960,7 +3019,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -3000,7 +3059,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -3025,18 +3084,20 @@ Module fmt.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
-                              "fill",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
+                              "fill"
+                            |),
                             M.read (| old_fill |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::fmt::Formatter"
-                              "align",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::fmt::Formatter",
+                              "align"
+                            |),
                             M.read (| old_align |)
                           |) in
                         ret));
@@ -3132,10 +3193,11 @@ Module fmt.
                                     M.get_associated_function (| Ty.path "str", "is_empty", [] |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| formatted |))
-                                          "core::num::fmt::Formatted"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| formatted |),
+                                          "core::num::fmt::Formatted",
                                           "sign"
+                                        |)
                                       |)
                                     ]
                                   |))
@@ -3166,16 +3228,18 @@ Module fmt.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::fmt::Formatter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::fmt::Formatter",
                                             "buf"
+                                          |)
                                         |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| formatted |))
-                                            "core::num::fmt::Formatted"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| formatted |),
+                                            "core::num::fmt::Formatted",
                                             "sign"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -3186,7 +3250,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -3222,7 +3286,7 @@ Module fmt.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -3251,10 +3315,11 @@ Module fmt.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| formatted |))
-                                "core::num::fmt::Formatted"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| formatted |),
+                                "core::num::fmt::Formatted",
                                 "parts"
+                              |)
                             |)
                           ]
                         |)
@@ -3290,7 +3355,7 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -3302,7 +3367,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::num::fmt::Part::Zero",
                                                       0
@@ -3374,12 +3439,11 @@ Module fmt.
                                                                             |),
                                                                             [
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::fmt::Formatter"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::fmt::Formatter",
                                                                                   "buf"
+                                                                                |)
                                                                               |);
                                                                               M.read (|
                                                                                 M.get_constant (|
@@ -3395,7 +3459,7 @@ Module fmt.
                                                                       fun γ =>
                                                                         ltac:(M.monadic
                                                                           (let γ0_0 :=
-                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                               γ,
                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                               0
@@ -3445,7 +3509,7 @@ Module fmt.
                                                                       fun γ =>
                                                                         ltac:(M.monadic
                                                                           (let γ0_0 :=
-                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                               γ,
                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                               0
@@ -3547,10 +3611,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::fmt::Formatter"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::fmt::Formatter",
                                                                             "buf"
+                                                                          |)
                                                                         |);
                                                                         M.call_closure (|
                                                                           M.get_trait_method (|
@@ -3590,7 +3655,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -3639,7 +3704,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -3657,7 +3722,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::num::fmt::Part::Num",
                                                       0
@@ -3793,7 +3858,7 @@ Module fmt.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -3865,10 +3930,11 @@ Module fmt.
                                                                 (* Unsize *)
                                                                 M.pointer_coercion
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "core::fmt::Formatter"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "core::fmt::Formatter",
                                                                       "buf"
+                                                                    |)
                                                                   |));
                                                                 M.call_closure (|
                                                                   M.get_trait_method (|
@@ -3901,7 +3967,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -3945,7 +4011,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -3958,7 +4024,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::num::fmt::Part::Copy",
                                                       0
@@ -3991,10 +4057,11 @@ Module fmt.
                                                                 (* Unsize *)
                                                                 M.pointer_coercion
                                                                   (M.read (|
-                                                                    M.get_struct_record_field
-                                                                      (M.read (| self |))
-                                                                      "core::fmt::Formatter"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      M.read (| self |),
+                                                                      "core::fmt::Formatter",
                                                                       "buf"
+                                                                    |)
                                                                   |));
                                                                 M.read (| buf |)
                                                               ]
@@ -4006,7 +4073,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -4050,7 +4117,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -4098,7 +4165,11 @@ Module fmt.
             |),
             [
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "buf"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "buf"
+                |)
               |);
               M.read (| data |)
             ]
@@ -4125,7 +4196,11 @@ Module fmt.
               (* Unsize *)
               M.pointer_coercion
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "buf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "buf"
+                  |)
                 |));
               M.read (| fmt |)
             ]
@@ -4146,7 +4221,11 @@ Module fmt.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::fmt::Formatter",
+              "flags"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -4163,7 +4242,13 @@ Module fmt.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "fill" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::fmt::Formatter",
+              "fill"
+            |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -4186,7 +4271,11 @@ Module fmt.
           (let self := M.alloc (| self |) in
           M.read (|
             M.match_operator (|
-              M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "align",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::fmt::Formatter",
+                "align"
+              |),
               [
                 fun γ =>
                   ltac:(M.monadic
@@ -4230,7 +4319,11 @@ Module fmt.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "width"
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::fmt::Formatter",
+              "width"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -4248,7 +4341,11 @@ Module fmt.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "precision"
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::fmt::Formatter",
+              "precision"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -4268,7 +4365,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4293,7 +4394,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4318,7 +4423,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4343,7 +4452,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4369,7 +4482,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4395,7 +4512,11 @@ Module fmt.
           BinOp.Pure.ne
             (BinOp.Pure.bit_and
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "flags"
+                |)
               |))
               (BinOp.Panic.shl (|
                 Value.Integer Integer.U32 1,
@@ -4990,8 +5111,8 @@ Module fmt.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let left_val := M.copy (| γ0_0 |) in
                       let right_val := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -5145,13 +5266,13 @@ Module fmt.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let name := M.copy (| γ1_0 |) in
                                       let value := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -5707,7 +5828,7 @@ Module fmt.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -6192,10 +6313,11 @@ Module fmt.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::fmt::Arguments"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::fmt::Arguments",
                                 "pieces"
+                              |)
                             |)
                           ]
                         |);
@@ -6239,10 +6361,11 @@ Module fmt.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::fmt::Arguments"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::fmt::Arguments",
                                   "args"
+                                |)
                               |)
                             ]
                           |)
@@ -6272,10 +6395,11 @@ Module fmt.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::fmt::Arguments"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::fmt::Arguments",
                                                 "pieces"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -6288,12 +6412,13 @@ Module fmt.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_array_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::fmt::Arguments"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::fmt::Arguments",
                                                     "pieces"
+                                                  |)
                                                 |),
                                                 M.alloc (| Value.Integer Integer.Usize 0 |)
                                               |)
@@ -6362,18 +6487,26 @@ Module fmt.
                 Value.Tuple
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::fmt::Arguments" "pieces"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::Arguments",
+                        "pieces"
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::fmt::Arguments" "args"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::fmt::Arguments",
+                        "args"
+                      |)
                     |)
                   ]
               |),
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     M.alloc (|
@@ -6383,10 +6516,10 @@ Module fmt.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
-                    let γ2_0 := M.get_slice_index_or_break_match (| γ0_0, 0 |) in
+                    let γ2_0 := M.SubPointer.get_slice_index (| γ0_0, 0 |) in
                     let s := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     M.alloc (|
@@ -6459,7 +6592,11 @@ Module fmt.
               (* Unsize *)
               M.pointer_coercion
                 (M.read (|
-                  M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "buf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| fmt |),
+                    "core::fmt::Formatter",
+                    "buf"
+                  |)
                 |));
               M.read (| M.read (| self |) |)
             ]
@@ -6566,7 +6703,7 @@ Module fmt.
               let idx := M.alloc (| Value.Integer Integer.Usize 0 |) in
               let _ :=
                 M.match_operator (|
-                  M.get_struct_record_field args "core::fmt::Arguments" "fmt",
+                  M.SubPointer.get_struct_record_field (| args, "core::fmt::Arguments", "fmt" |),
                   [
                     fun γ =>
                       ltac:(M.monadic
@@ -6609,10 +6746,11 @@ Module fmt.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              args
-                                              "core::fmt::Arguments"
+                                            M.SubPointer.get_struct_record_field (|
+                                              args,
+                                              "core::fmt::Arguments",
                                               "args"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -6657,13 +6795,15 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
                                                   |) in
-                                                let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                                let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                                let γ1_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                                let γ1_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                                 let i := M.copy (| γ1_0 |) in
                                                 let arg := M.copy (| γ1_1 |) in
                                                 let piece :=
@@ -6679,10 +6819,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            args
-                                                            "core::fmt::Arguments"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            args,
+                                                            "core::fmt::Arguments",
                                                             "pieces"
+                                                          |)
                                                         |);
                                                         M.read (| i |)
                                                       ]
@@ -6748,10 +6889,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            formatter
-                                                                            "core::fmt::Formatter"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            formatter,
+                                                                            "core::fmt::Formatter",
                                                                             "buf"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           M.read (| piece |)
@@ -6765,7 +6907,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -6814,7 +6956,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -6861,7 +7003,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -6904,7 +7046,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -6932,7 +7074,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -7018,13 +7160,15 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
                                                   |) in
-                                                let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                                let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                                let γ1_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                                let γ1_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                                 let i := M.copy (| γ1_0 |) in
                                                 let arg := M.copy (| γ1_1 |) in
                                                 let piece :=
@@ -7040,10 +7184,11 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            args
-                                                            "core::fmt::Arguments"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            args,
+                                                            "core::fmt::Arguments",
                                                             "pieces"
+                                                          |)
                                                         |);
                                                         M.read (| i |)
                                                       ]
@@ -7109,10 +7254,11 @@ Module fmt.
                                                                       |),
                                                                       [
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            formatter
-                                                                            "core::fmt::Formatter"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            formatter,
+                                                                            "core::fmt::Formatter",
                                                                             "buf"
+                                                                          |)
                                                                         |);
                                                                         M.read (|
                                                                           M.read (| piece |)
@@ -7126,7 +7272,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                         0
@@ -7175,7 +7321,7 @@ Module fmt.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                         0
@@ -7216,10 +7362,11 @@ Module fmt.
                                                               formatter;
                                                               M.read (| arg |);
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  args
-                                                                  "core::fmt::Arguments"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  args,
+                                                                  "core::fmt::Arguments",
                                                                   "args"
+                                                                |)
                                                               |)
                                                             ]
                                                           |)
@@ -7230,7 +7377,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Break",
                                                               0
@@ -7273,7 +7420,7 @@ Module fmt.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                               0
@@ -7318,14 +7465,18 @@ Module fmt.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field args "core::fmt::Arguments" "pieces"
+                                  M.SubPointer.get_struct_record_field (|
+                                    args,
+                                    "core::fmt::Arguments",
+                                    "pieces"
+                                  |)
                                 |);
                                 M.read (| idx |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -7355,10 +7506,11 @@ Module fmt.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          formatter
-                                          "core::fmt::Formatter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          formatter,
+                                          "core::fmt::Formatter",
                                           "buf"
+                                        |)
                                       |);
                                       M.read (| M.read (| piece |) |)
                                     ]
@@ -7370,7 +7522,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -7406,7 +7558,7 @@ Module fmt.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -7457,51 +7609,85 @@ Module fmt.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "fill",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| fmt |),
+                "core::fmt::Formatter",
+                "fill"
+              |),
               M.read (|
-                M.get_struct_record_field (M.read (| arg |)) "core::fmt::rt::Placeholder" "fill"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| arg |),
+                  "core::fmt::rt::Placeholder",
+                  "fill"
+                |)
               |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "align",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| fmt |),
+                "core::fmt::Formatter",
+                "align"
+              |),
               M.read (|
-                M.get_struct_record_field (M.read (| arg |)) "core::fmt::rt::Placeholder" "align"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| arg |),
+                  "core::fmt::rt::Placeholder",
+                  "align"
+                |)
               |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "flags",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| fmt |),
+                "core::fmt::Formatter",
+                "flags"
+              |),
               M.read (|
-                M.get_struct_record_field (M.read (| arg |)) "core::fmt::rt::Placeholder" "flags"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| arg |),
+                  "core::fmt::rt::Placeholder",
+                  "flags"
+                |)
               |)
             |) in
           let _ :=
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "width",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| fmt |),
+                  "core::fmt::Formatter",
+                  "width"
+                |),
                 M.call_closure (|
                   M.get_function (| "core::fmt::getcount", [] |),
                   [
                     M.read (| args |);
-                    M.get_struct_record_field
-                      (M.read (| arg |))
-                      "core::fmt::rt::Placeholder"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| arg |),
+                      "core::fmt::rt::Placeholder",
                       "width"
+                    |)
                   ]
                 |)
               |) in
             let _ :=
               M.write (|
-                M.get_struct_record_field (M.read (| fmt |)) "core::fmt::Formatter" "precision",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| fmt |),
+                  "core::fmt::Formatter",
+                  "precision"
+                |),
                 M.call_closure (|
                   M.get_function (| "core::fmt::getcount", [] |),
                   [
                     M.read (| args |);
-                    M.get_struct_record_field
-                      (M.read (| arg |))
-                      "core::fmt::rt::Placeholder"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| arg |),
+                      "core::fmt::rt::Placeholder",
                       "precision"
+                    |)
                   ]
                 |)
               |) in
@@ -7526,10 +7712,11 @@ Module fmt.
                                     UnOp.Pure.not
                                       (BinOp.Pure.lt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| arg |))
-                                            "core::fmt::rt::Placeholder"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| arg |),
+                                            "core::fmt::rt::Placeholder",
                                             "position"
+                                          |)
                                         |))
                                         (M.call_closure (|
                                           M.get_associated_function (|
@@ -7577,10 +7764,11 @@ Module fmt.
                 [
                   M.read (| args |);
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| arg |))
-                      "core::fmt::rt::Placeholder"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| arg |),
+                      "core::fmt::rt::Placeholder",
                       "position"
+                    |)
                   |)
                 ]
               |)
@@ -7622,11 +7810,7 @@ Module fmt.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::fmt::rt::Count::Is",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::fmt::rt::Count::Is", 0 |) in
                   let n := M.copy (| γ0_0 |) in
                   M.alloc (| Value.StructTuple "core::option::Option::Some" [ M.read (| n |) ] |)));
               fun γ =>
@@ -7634,11 +7818,7 @@ Module fmt.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::fmt::rt::Count::Param",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::fmt::rt::Count::Param", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     M.match_operator (|
@@ -7786,10 +7966,11 @@ Module fmt.
                                 ("start", Value.Integer Integer.Usize 0);
                                 ("end_",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::fmt::PostPadding"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::fmt::PostPadding",
                                       "padding"
+                                    |)
                                   |))
                               ]
                           ]
@@ -7826,7 +8007,7 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7855,16 +8036,18 @@ Module fmt.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| f |))
-                                                            "core::fmt::Formatter"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| f |),
+                                                            "core::fmt::Formatter",
                                                             "buf"
+                                                          |)
                                                         |);
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            self
-                                                            "core::fmt::PostPadding"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            self,
+                                                            "core::fmt::PostPadding",
                                                             "fill"
+                                                          |)
                                                         |)
                                                       ]
                                                     |)
@@ -7875,7 +8058,7 @@ Module fmt.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -7915,7 +8098,7 @@ Module fmt.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -7965,7 +8148,11 @@ Module fmt.
             |),
             [
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "buf"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "buf"
+                |)
               |);
               M.read (| s |)
             ]
@@ -7994,7 +8181,11 @@ Module fmt.
             |),
             [
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "buf"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::Formatter",
+                  "buf"
+                |)
               |);
               M.read (| c |)
             ]
@@ -8019,7 +8210,11 @@ Module fmt.
               (* Unsize *)
               M.pointer_coercion
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::Formatter" "buf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::Formatter",
+                    "buf"
+                  |)
                 |));
               M.read (| args |)
             ]
@@ -8702,7 +8897,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -8738,7 +8933,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -8797,13 +8992,13 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
-                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let i := M.copy (| γ1_0 |) in
                                           let c := M.copy (| γ1_1 |) in
                                           let esc :=
@@ -8910,7 +9105,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                 0
@@ -8954,7 +9149,7 @@ Module fmt.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                 0
@@ -9012,7 +9207,7 @@ Module fmt.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -9064,7 +9259,7 @@ Module fmt.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                                           γ,
                                                                                           "core::ops::control_flow::ControlFlow::Break",
                                                                                           0
@@ -9117,7 +9312,7 @@ Module fmt.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                                           γ,
                                                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                                                           0
@@ -9214,7 +9409,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9250,7 +9445,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9369,7 +9564,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9405,7 +9600,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9476,7 +9671,7 @@ Module fmt.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -9512,7 +9707,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -9552,7 +9747,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -9627,10 +9822,11 @@ Module fmt.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| f |))
-                                  "core::fmt::Formatter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| f |),
+                                  "core::fmt::Formatter",
                                   "width"
+                                |)
                               ]
                             |),
                             ltac:(M.monadic
@@ -9641,10 +9837,11 @@ Module fmt.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| f |))
-                                    "core::fmt::Formatter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| f |),
+                                    "core::fmt::Formatter",
                                     "precision"
+                                  |)
                                 ]
                               |)))
                           |)
@@ -9772,11 +9969,19 @@ Module fmt.
         M.read (|
           let old_width :=
             M.copy (|
-              M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "width"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| f |),
+                "core::fmt::Formatter",
+                "width"
+              |)
             |) in
           let old_flags :=
             M.copy (|
-              M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "flags"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| f |),
+                "core::fmt::Formatter",
+                "flags"
+              |)
             |) in
           let _ :=
             M.match_operator (|
@@ -9799,7 +10004,11 @@ Module fmt.
                     let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "flags" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| f |),
+                          "core::fmt::Formatter",
+                          "flags"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Pure.bit_or
@@ -9824,10 +10033,11 @@ Module fmt.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| f |))
-                                        "core::fmt::Formatter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| f |),
+                                        "core::fmt::Formatter",
                                         "width"
+                                      |)
                                     ]
                                   |)
                                 |)) in
@@ -9835,10 +10045,11 @@ Module fmt.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| f |))
-                                  "core::fmt::Formatter"
-                                  "width",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| f |),
+                                  "core::fmt::Formatter",
+                                  "width"
+                                |),
                                 Value.StructTuple
                                   "core::option::Option::Some"
                                   [
@@ -9860,7 +10071,12 @@ Module fmt.
               ]
             |) in
           let _ :=
-            let β := M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "flags" in
+            let β :=
+              M.SubPointer.get_struct_record_field (|
+                M.read (| f |),
+                "core::fmt::Formatter",
+                "flags"
+              |) in
             M.write (|
               β,
               BinOp.Pure.bit_or
@@ -9879,12 +10095,20 @@ Module fmt.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "width",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| f |),
+                "core::fmt::Formatter",
+                "width"
+              |),
               M.read (| old_width |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| f |)) "core::fmt::Formatter" "flags",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| f |),
+                "core::fmt::Formatter",
+                "flags"
+              |),
               M.read (| old_flags |)
             |) in
           ret
@@ -10118,18 +10342,18 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
-                    let γ0_10 := M.get_tuple_field γ 10 in
-                    let γ0_11 := M.get_tuple_field γ 11 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
+                    let γ0_11 := M.SubPointer.get_tuple_field (| γ, 11 |) in
                     let value_E := M.alloc (| γ0_0 |) in
                     let value_D := M.alloc (| γ0_1 |) in
                     let value_C := M.alloc (| γ0_2 |) in
@@ -10334,17 +10558,17 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
-                    let γ0_10 := M.get_tuple_field γ 10 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
                     let value_D := M.alloc (| γ0_0 |) in
                     let value_C := M.alloc (| γ0_1 |) in
                     let value_B := M.alloc (| γ0_2 |) in
@@ -10537,16 +10761,16 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
                     let value_C := M.alloc (| γ0_0 |) in
                     let value_B := M.alloc (| γ0_1 |) in
                     let value_A := M.alloc (| γ0_2 |) in
@@ -10726,15 +10950,15 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
                     let value_B := M.alloc (| γ0_0 |) in
                     let value_A := M.alloc (| γ0_1 |) in
                     let value_Z := M.alloc (| γ0_2 |) in
@@ -10902,14 +11126,14 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
                     let value_A := M.alloc (| γ0_0 |) in
                     let value_Z := M.alloc (| γ0_1 |) in
                     let value_Y := M.alloc (| γ0_2 |) in
@@ -11065,13 +11289,13 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
                     let value_Z := M.alloc (| γ0_0 |) in
                     let value_Y := M.alloc (| γ0_1 |) in
                     let value_X := M.alloc (| γ0_2 |) in
@@ -11215,12 +11439,12 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
                     let value_Y := M.alloc (| γ0_0 |) in
                     let value_X := M.alloc (| γ0_1 |) in
                     let value_W := M.alloc (| γ0_2 |) in
@@ -11352,11 +11576,11 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
                     let value_X := M.alloc (| γ0_0 |) in
                     let value_W := M.alloc (| γ0_1 |) in
                     let value_V := M.alloc (| γ0_2 |) in
@@ -11476,10 +11700,10 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let value_W := M.alloc (| γ0_0 |) in
                     let value_V := M.alloc (| γ0_1 |) in
                     let value_U := M.alloc (| γ0_2 |) in
@@ -11587,9 +11811,9 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                     let value_V := M.alloc (| γ0_0 |) in
                     let value_U := M.alloc (| γ0_1 |) in
                     let value_T := M.alloc (| γ0_2 |) in
@@ -11685,8 +11909,8 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let value_U := M.alloc (| γ0_0 |) in
                     let value_T := M.alloc (| γ0_1 |) in
                     let _ :=
@@ -11770,7 +11994,7 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
                     let value_T := M.alloc (| γ0_0 |) in
                     let _ :=
                       M.alloc (|
@@ -12075,7 +12299,7 @@ Module fmt.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -12098,7 +12322,7 @@ Module fmt.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0

--- a/CoqOfRust/core/fmt/num.v
+++ b/CoqOfRust/core/fmt/num.v
@@ -949,7 +949,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -1168,7 +1168,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -7033,7 +7033,7 @@ Module fmt.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -7128,8 +7128,8 @@ Module fmt.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let added_precision := M.copy (| γ0_0 |) in
                         let subtracted_precision := M.copy (| γ0_1 |) in
                         let _ :=
@@ -7187,7 +7187,7 @@ Module fmt.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -7386,10 +7386,10 @@ Module fmt.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                       let n := M.copy (| γ0_0 |) in
                       let exponent := M.copy (| γ0_1 |) in
                       let trailing_zeros := M.copy (| γ0_2 |) in
@@ -10016,7 +10016,7 @@ Module fmt.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -10111,8 +10111,8 @@ Module fmt.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let added_precision := M.copy (| γ0_0 |) in
                       let subtracted_precision := M.copy (| γ0_1 |) in
                       let _ :=
@@ -10168,7 +10168,7 @@ Module fmt.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -10366,10 +10366,10 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let n := M.copy (| γ0_0 |) in
                     let exponent := M.copy (| γ0_1 |) in
                     let trailing_zeros := M.copy (| γ0_2 |) in
@@ -12608,8 +12608,8 @@ Module fmt.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let n := M.copy (| γ0_0 |) in
                     let rem := M.copy (| γ0_1 |) in
                     let _ :=
@@ -12701,8 +12701,8 @@ Module fmt.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let n := M.copy (| γ0_0 |) in
                                       let rem := M.copy (| γ0_1 |) in
                                       let _ :=

--- a/CoqOfRust/core/fmt/rt.v
+++ b/CoqOfRust/core/fmt/rt.v
@@ -792,11 +792,19 @@ Module fmt.
             let f := M.alloc (| f |) in
             M.call_closure (|
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::fmt::rt::Argument" "formatter"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::fmt::rt::Argument",
+                  "formatter"
+                |)
               |),
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::fmt::rt::Argument" "value"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::fmt::rt::Argument",
+                    "value"
+                  |)
                 |);
                 M.read (| f |)
               ]
@@ -838,10 +846,11 @@ Module fmt.
                             BinOp.Pure.eq
                               (M.rust_cast
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::fmt::rt::Argument"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::fmt::rt::Argument",
                                     "formatter"
+                                  |)
                                 |)))
                               (M.rust_cast
                                 (M.read (|
@@ -859,10 +868,11 @@ Module fmt.
                                   M.use
                                     (M.alloc (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::fmt::rt::Argument"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::fmt::rt::Argument",
                                           "value"
+                                        |)
                                       |)
                                     |))
                                 |))

--- a/CoqOfRust/core/future/join.v
+++ b/CoqOfRust/core/future/join.v
@@ -55,7 +55,7 @@ Module future.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::future::join::MaybeDone::Done",
                           0
@@ -77,7 +77,7 @@ Module future.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::future::join::MaybeDone::Done",
                                   0
@@ -185,7 +185,7 @@ Module future.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::future::join::MaybeDone::Future",
                                 0
@@ -222,7 +222,7 @@ Module future.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::task::poll::Poll::Ready",
                                             0
@@ -272,7 +272,7 @@ Module future.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::future::join::MaybeDone::Done",
                                 0

--- a/CoqOfRust/core/future/mod.v
+++ b/CoqOfRust/core/future/mod.v
@@ -33,7 +33,11 @@ Module future.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_tuple_field (M.read (| self |)) "core::future::ResumeTy" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::future::ResumeTy",
+                    0
+                  |)
                 |))
             ]
           |)))
@@ -134,7 +138,11 @@ Module future.
                 "as_ptr",
                 []
               |),
-              [ M.read (| M.get_struct_tuple_field cx "core::future::ResumeTy" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| cx, "core::future::ResumeTy", 0 |)
+                |)
+              ]
             |)
           ]
         |)))

--- a/CoqOfRust/core/future/poll_fn.v
+++ b/CoqOfRust/core/future/poll_fn.v
@@ -114,8 +114,8 @@ Module future.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.call_closure (|
+                M.SubPointer.get_struct_record_field (|
+                  M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
                         (Ty.path "core::pin::Pin")
@@ -128,9 +128,10 @@ Module future.
                       []
                     |),
                     [ M.read (| self |) ]
-                  |))
-                  "core::future::poll_fn::PollFn"
-                  "f";
+                  |),
+                  "core::future::poll_fn::PollFn",
+                  "f"
+                |);
                 Value.Tuple [ M.read (| cx |) ]
               ]
             |)))

--- a/CoqOfRust/core/future/ready.v
+++ b/CoqOfRust/core/future/ready.v
@@ -33,7 +33,11 @@ Module future.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::future::ready::Ready" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::future::ready::Ready",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -70,7 +74,13 @@ Module future.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::future::ready::Ready" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::future::ready::Ready",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -132,8 +142,8 @@ Module future.
                         []
                       |),
                       [
-                        M.get_struct_tuple_field
-                          (M.call_closure (|
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::deref::DerefMut",
                               Ty.apply
@@ -148,9 +158,10 @@ Module future.
                               []
                             |),
                             [ self ]
-                          |))
-                          "core::future::ready::Ready"
+                          |),
+                          "core::future::ready::Ready",
                           0
+                        |)
                       ]
                     |);
                     M.read (| Value.String "`Ready` polled after completion" |)
@@ -191,7 +202,9 @@ Module future.
                 []
               |),
               [
-                M.read (| M.get_struct_tuple_field self "core::future::ready::Ready" 0 |);
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::future::ready::Ready", 0 |)
+                |);
                 M.read (| Value.String "Called `into_inner()` on `Ready` after completion" |)
               ]
             |)))

--- a/CoqOfRust/core/hash/mod.v
+++ b/CoqOfRust/core/hash/mod.v
@@ -52,7 +52,7 @@ Module hash.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -2118,7 +2118,7 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let _ :=
                         M.alloc (|
@@ -2165,8 +2165,8 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let _ :=
@@ -2221,9 +2221,9 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2286,10 +2286,10 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2360,11 +2360,11 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2443,12 +2443,12 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2535,13 +2535,13 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2636,14 +2636,14 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
-                      let γ0_7 := M.get_tuple_field γ 7 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2746,15 +2746,15 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
-                      let γ0_7 := M.get_tuple_field γ 7 in
-                      let γ0_8 := M.get_tuple_field γ 8 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                      let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2866,16 +2866,16 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
-                      let γ0_7 := M.get_tuple_field γ 7 in
-                      let γ0_8 := M.get_tuple_field γ 8 in
-                      let γ0_9 := M.get_tuple_field γ 9 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                      let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                      let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -2995,17 +2995,17 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
-                      let γ0_7 := M.get_tuple_field γ 7 in
-                      let γ0_8 := M.get_tuple_field γ 8 in
-                      let γ0_9 := M.get_tuple_field γ 9 in
-                      let γ0_10 := M.get_tuple_field γ 10 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                      let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                      let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                      let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -3133,18 +3133,18 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
-                      let γ0_3 := M.get_tuple_field γ 3 in
-                      let γ0_4 := M.get_tuple_field γ 4 in
-                      let γ0_5 := M.get_tuple_field γ 5 in
-                      let γ0_6 := M.get_tuple_field γ 6 in
-                      let γ0_7 := M.get_tuple_field γ 7 in
-                      let γ0_8 := M.get_tuple_field γ 8 in
-                      let γ0_9 := M.get_tuple_field γ 9 in
-                      let γ0_10 := M.get_tuple_field γ 10 in
-                      let γ0_11 := M.get_tuple_field γ 11 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                      let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                      let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                      let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
+                      let γ0_11 := M.SubPointer.get_tuple_field (| γ, 11 |) in
                       let value_T := M.alloc (| γ0_0 |) in
                       let value_B := M.alloc (| γ0_1 |) in
                       let value_C := M.alloc (| γ0_2 |) in
@@ -3412,8 +3412,8 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let address := M.copy (| γ0_0 |) in
                       let metadata := M.copy (| γ0_1 |) in
                       let _ :=
@@ -3494,8 +3494,8 @@ Module hash.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let address := M.copy (| γ0_0 |) in
                       let metadata := M.copy (| γ0_1 |) in
                       let _ :=

--- a/CoqOfRust/core/hash/sip.v
+++ b/CoqOfRust/core/hash/sip.v
@@ -39,10 +39,11 @@ Module hash.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::SipHasher13"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::SipHasher13",
                       "hasher"
+                    |)
                   |))
               ]
             |)))
@@ -81,10 +82,11 @@ Module hash.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::SipHasher13"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::SipHasher13",
                         "hasher"
+                      |)
                     ]
                   |))
               ]))
@@ -171,10 +173,11 @@ Module hash.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::SipHasher24"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::SipHasher24",
                       "hasher"
+                    |)
                   |))
               ]
             |)))
@@ -213,10 +216,11 @@ Module hash.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::SipHasher24"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::SipHasher24",
                         "hasher"
+                      |)
                     ]
                   |))
               ]))
@@ -296,7 +300,11 @@ Module hash.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::hash::sip::SipHasher" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::hash::sip::SipHasher",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -331,7 +339,13 @@ Module hash.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::hash::sip::SipHasher" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::hash::sip::SipHasher",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -430,47 +444,54 @@ Module hash.
                         [
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "k0");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "k0"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "k1");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "k1"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "length");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "length"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "state");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "state"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "tail");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "tail"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
-                              "ntail");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
+                              "ntail"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
                             (M.alloc (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::hash::sip::Hasher"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::hash::sip::Hasher",
                                 "_marker"
+                              |)
                             |))
                         ]
                     |))
@@ -538,20 +559,36 @@ Module hash.
                 M.read (| Value.String "v0" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::hash::sip::State" "v0");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::State",
+                    "v0"
+                  |));
                 M.read (| Value.String "v2" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::hash::sip::State" "v2");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::State",
+                    "v2"
+                  |));
                 M.read (| Value.String "v1" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::hash::sip::State" "v1");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::State",
+                    "v1"
+                  |));
                 M.read (| Value.String "v3" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::State" "v3"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |)
                   |))
               ]
             |)))
@@ -1289,72 +1326,104 @@ Module hash.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "length",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::Hasher",
+                    "length"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::Hasher"
-                      "state")
-                    "core::hash::sip::State"
-                    "v0",
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "state"
+                    |),
+                    "core::hash::sip::State",
+                    "v0"
+                  |),
                   BinOp.Pure.bit_xor
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k0"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "k0"
+                      |)
                     |))
                     (Value.Integer Integer.U64 8317987319222330741)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::Hasher"
-                      "state")
-                    "core::hash::sip::State"
-                    "v1",
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "state"
+                    |),
+                    "core::hash::sip::State",
+                    "v1"
+                  |),
                   BinOp.Pure.bit_xor
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k1"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "k1"
+                      |)
                     |))
                     (Value.Integer Integer.U64 7237128888997146477)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::Hasher"
-                      "state")
-                    "core::hash::sip::State"
-                    "v2",
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "state"
+                    |),
+                    "core::hash::sip::State",
+                    "v2"
+                  |),
                   BinOp.Pure.bit_xor
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k0"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "k0"
+                      |)
                     |))
                     (Value.Integer Integer.U64 7816392313619706465)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::Hasher"
-                      "state")
-                    "core::hash::sip::State"
-                    "v3",
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "state"
+                    |),
+                    "core::hash::sip::State",
+                    "v3"
+                  |),
                   BinOp.Pure.bit_xor
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k1"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "k1"
+                      |)
                     |))
                     (Value.Integer Integer.U64 8387220255154660723)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "ntail",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::Hasher",
+                    "ntail"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -1392,10 +1461,15 @@ Module hash.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.get_struct_tuple_field (M.read (| self |)) "core::hash::sip::SipHasher" 0)
-                  "core::hash::sip::SipHasher24"
-                  "hasher";
+                M.SubPointer.get_struct_record_field (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::hash::sip::SipHasher",
+                    0
+                  |),
+                  "core::hash::sip::SipHasher24",
+                  "hasher"
+                |);
                 M.read (| msg |)
               ]
             |)))
@@ -1427,13 +1501,15 @@ Module hash.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "core::hash::sip::SipHasher"
-                          0)
-                        "core::hash::sip::SipHasher24"
-                        "hasher";
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "core::hash::sip::SipHasher",
+                          0
+                        |),
+                        "core::hash::sip::SipHasher24",
+                        "hasher"
+                      |);
                       M.read (| s |)
                     ]
                   |)
@@ -1464,10 +1540,15 @@ Module hash.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.get_struct_tuple_field (M.read (| self |)) "core::hash::sip::SipHasher" 0)
-                  "core::hash::sip::SipHasher24"
+                M.SubPointer.get_struct_record_field (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::hash::sip::SipHasher",
+                    0
+                  |),
+                  "core::hash::sip::SipHasher24",
                   "hasher"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1511,10 +1592,11 @@ Module hash.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::hash::sip::SipHasher13"
-                  "hasher";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::hash::sip::SipHasher13",
+                  "hasher"
+                |);
                 M.read (| msg |)
               ]
             |)))
@@ -1546,10 +1628,11 @@ Module hash.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::SipHasher13"
-                        "hasher";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::SipHasher13",
+                        "hasher"
+                      |);
                       M.read (| s |)
                     ]
                   |)
@@ -1580,10 +1663,11 @@ Module hash.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::hash::sip::SipHasher13"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::hash::sip::SipHasher13",
                   "hasher"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1675,10 +1759,11 @@ Module hash.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::Hasher"
-                        "length" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "length"
+                      |) in
                     M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| length |) |) |) in
                   let needed := M.alloc (| Value.Integer Integer.Usize 0 |) in
                   let _ :=
@@ -1692,10 +1777,11 @@ Module hash.
                                 (M.alloc (|
                                   BinOp.Pure.ne
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::hash::sip::Hasher"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::hash::sip::Hasher",
                                         "ntail"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -1707,19 +1793,21 @@ Module hash.
                                 BinOp.Panic.sub (|
                                   Value.Integer Integer.Usize 8,
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::hash::sip::Hasher"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::hash::sip::Hasher",
                                       "ntail"
+                                    |)
                                   |)
                                 |)
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::hash::sip::Hasher"
-                                  "tail" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::hash::sip::Hasher",
+                                  "tail"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Pure.bit_or
@@ -1742,10 +1830,11 @@ Module hash.
                                     BinOp.Panic.mul (|
                                       Value.Integer Integer.Usize 8,
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::hash::sip::Hasher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::hash::sip::Hasher",
                                           "ntail"
+                                        |)
                                       |)
                                     |)
                                   |))
@@ -1770,10 +1859,11 @@ Module hash.
                                         M.read (|
                                           let _ :=
                                             let β :=
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::hash::sip::Hasher"
-                                                "ntail" in
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::hash::sip::Hasher",
+                                                "ntail"
+                                              |) in
                                             M.write (|
                                               β,
                                               BinOp.Panic.add (|
@@ -1789,22 +1879,25 @@ Module hash.
                                   ltac:(M.monadic
                                     (let _ :=
                                       let β :=
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::hash::sip::Hasher"
-                                            "state")
-                                          "core::hash::sip::State"
-                                          "v3" in
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::hash::sip::Hasher",
+                                            "state"
+                                          |),
+                                          "core::hash::sip::State",
+                                          "v3"
+                                        |) in
                                       M.write (|
                                         β,
                                         BinOp.Pure.bit_xor
                                           (M.read (| β |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::hash::sip::Hasher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::hash::sip::Hasher",
                                               "tail"
+                                            |)
                                           |))
                                       |) in
                                     let _ :=
@@ -1818,39 +1911,44 @@ Module hash.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::hash::sip::Hasher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::hash::sip::Hasher",
                                               "state"
+                                            |)
                                           ]
                                         |)
                                       |) in
                                     let _ :=
                                       let β :=
-                                        M.get_struct_record_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::hash::sip::Hasher"
-                                            "state")
-                                          "core::hash::sip::State"
-                                          "v0" in
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::hash::sip::Hasher",
+                                            "state"
+                                          |),
+                                          "core::hash::sip::State",
+                                          "v0"
+                                        |) in
                                       M.write (|
                                         β,
                                         BinOp.Pure.bit_xor
                                           (M.read (| β |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::hash::sip::Hasher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::hash::sip::Hasher",
                                               "tail"
+                                            |)
                                           |))
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::hash::sip::Hasher"
-                                          "ntail",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::hash::sip::Hasher",
+                                          "ntail"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     M.alloc (| Value.Tuple [] |)))
@@ -2012,13 +2110,15 @@ Module hash.
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::hash::sip::Hasher"
-                                        "state")
-                                      "core::hash::sip::State"
-                                      "v3" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::hash::sip::Hasher",
+                                        "state"
+                                      |),
+                                      "core::hash::sip::State",
+                                      "v3"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Pure.bit_xor (M.read (| β |)) (M.read (| mi |))
@@ -2034,22 +2134,25 @@ Module hash.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::hash::sip::Hasher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::hash::sip::Hasher",
                                           "state"
+                                        |)
                                       ]
                                     |)
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::hash::sip::Hasher"
-                                        "state")
-                                      "core::hash::sip::State"
-                                      "v0" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::hash::sip::Hasher",
+                                        "state"
+                                      |),
+                                      "core::hash::sip::State",
+                                      "v0"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Pure.bit_xor (M.read (| β |)) (M.read (| mi |))
@@ -2082,10 +2185,11 @@ Module hash.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::Hasher"
-                        "tail",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "tail"
+                      |),
                       M.call_closure (|
                         M.get_function (| "core::hash::sip::u8to64_le", [] |),
                         [ M.read (| msg |); M.read (| i |); M.read (| left |) ]
@@ -2093,10 +2197,11 @@ Module hash.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::hash::sip::Hasher"
-                        "ntail",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "ntail"
+                      |),
                       M.read (| left |)
                     |) in
                   M.alloc (| Value.Tuple [] |)
@@ -2183,7 +2288,11 @@ Module hash.
             M.read (|
               let state :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "state"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::hash::sip::Hasher",
+                    "state"
+                  |)
                 |) in
               let b :=
                 M.alloc (|
@@ -2192,20 +2301,30 @@ Module hash.
                       BinOp.Pure.bit_and
                         (M.rust_cast
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::hash::sip::Hasher"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::hash::sip::Hasher",
                               "length"
+                            |)
                           |)))
                         (Value.Integer Integer.U64 255),
                       Value.Integer Integer.I32 56
                     |))
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "tail"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::hash::sip::Hasher",
+                        "tail"
+                      |)
                     |))
                 |) in
               let _ :=
-                let β := M.get_struct_record_field state "core::hash::sip::State" "v3" in
+                let β :=
+                  M.SubPointer.get_struct_record_field (|
+                    state,
+                    "core::hash::sip::State",
+                    "v3"
+                  |) in
                 M.write (| β, BinOp.Pure.bit_xor (M.read (| β |)) (M.read (| b |)) |) in
               let _ :=
                 M.alloc (|
@@ -2215,10 +2334,20 @@ Module hash.
                   |)
                 |) in
               let _ :=
-                let β := M.get_struct_record_field state "core::hash::sip::State" "v0" in
+                let β :=
+                  M.SubPointer.get_struct_record_field (|
+                    state,
+                    "core::hash::sip::State",
+                    "v0"
+                  |) in
                 M.write (| β, BinOp.Pure.bit_xor (M.read (| β |)) (M.read (| b |)) |) in
               let _ :=
-                let β := M.get_struct_record_field state "core::hash::sip::State" "v2" in
+                let β :=
+                  M.SubPointer.get_struct_record_field (|
+                    state,
+                    "core::hash::sip::State",
+                    "v2"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Pure.bit_xor (M.read (| β |)) (Value.Integer Integer.U64 255)
@@ -2234,10 +2363,30 @@ Module hash.
                 BinOp.Pure.bit_xor
                   (BinOp.Pure.bit_xor
                     (BinOp.Pure.bit_xor
-                      (M.read (| M.get_struct_record_field state "core::hash::sip::State" "v0" |))
-                      (M.read (| M.get_struct_record_field state "core::hash::sip::State" "v1" |)))
-                    (M.read (| M.get_struct_record_field state "core::hash::sip::State" "v2" |)))
-                  (M.read (| M.get_struct_record_field state "core::hash::sip::State" "v3" |))
+                      (M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          state,
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
+                      |))
+                      (M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          state,
+                          "core::hash::sip::State",
+                          "v1"
+                        |)
+                      |)))
+                    (M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        state,
+                        "core::hash::sip::State",
+                        "v2"
+                      |)
+                    |)))
+                  (M.read (|
+                    M.SubPointer.get_struct_record_field (| state, "core::hash::sip::State", "v3" |)
+                  |))
               |)
             |)))
         | _, _ => M.impossible
@@ -2284,34 +2433,59 @@ Module hash.
               [
                 ("k0",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k0"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "k0"
+                    |)
                   |));
                 ("k1",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "k1"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "k1"
+                    |)
                   |));
                 ("length",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "length"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "length"
+                    |)
                   |));
                 ("state",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "state"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "state"
+                    |)
                   |));
                 ("tail",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "tail"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "tail"
+                    |)
                   |));
                 ("ntail",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::hash::sip::Hasher" "ntail"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
+                      "ntail"
+                    |)
                   |));
                 ("_marker",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::hash::sip::Hasher"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::hash::sip::Hasher",
                       "_marker"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -2450,36 +2624,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -2487,26 +2672,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -2514,36 +2712,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -2551,47 +2760,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -2599,47 +2827,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -2647,26 +2894,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -2694,36 +2954,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -2731,26 +3002,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -2758,36 +3042,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -2795,47 +3090,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -2843,47 +3157,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -2891,26 +3224,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -2920,36 +3266,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -2957,26 +3314,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -2984,36 +3354,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -3021,47 +3402,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -3069,47 +3469,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -3117,26 +3536,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3146,36 +3578,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -3183,26 +3626,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3210,36 +3666,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -3247,47 +3714,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -3295,47 +3781,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -3343,26 +3848,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3473,36 +3991,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -3510,26 +4039,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3537,36 +4079,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -3574,47 +4127,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -3622,47 +4194,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -3670,26 +4261,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3699,36 +4303,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -3736,26 +4351,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3763,36 +4391,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -3800,47 +4439,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -3848,47 +4506,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -3896,26 +4573,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -3944,36 +4634,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -3981,26 +4682,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4008,36 +4722,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -4045,47 +4770,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -4093,47 +4837,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -4141,26 +4904,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4170,36 +4946,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -4207,26 +4994,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4234,36 +5034,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -4271,47 +5082,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -4319,47 +5149,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -4367,26 +5216,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4396,36 +5258,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -4433,26 +5306,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4460,36 +5346,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -4497,47 +5394,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -4545,47 +5461,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -4593,26 +5528,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4622,36 +5570,47 @@ Module hash.
               let _ :=
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 13
                       ]
@@ -4659,26 +5618,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]
@@ -4686,36 +5658,47 @@ Module hash.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 16
                       ]
@@ -4723,47 +5706,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v0"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v0"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v3"
+                          |)
                         |);
                         Value.Integer Integer.U32 21
                       ]
@@ -4771,47 +5773,66 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v3" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v3"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v0"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v0"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |)
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v1"
+                          |)
                         |);
                         Value.Integer Integer.U32 17
                       ]
@@ -4819,26 +5840,39 @@ Module hash.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v1" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v1"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Pure.bit_xor
                       (M.read (| β |))
                       (M.read (|
-                        M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| state |),
+                          "core::hash::sip::State",
+                          "v2"
+                        |)
                       |))
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field (M.read (| state |)) "core::hash::sip::State" "v2",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| state |),
+                      "core::hash::sip::State",
+                      "v2"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| state |))
-                            "core::hash::sip::State"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| state |),
+                            "core::hash::sip::State",
                             "v2"
+                          |)
                         |);
                         Value.Integer Integer.U32 32
                       ]

--- a/CoqOfRust/core/io/borrowed_buf.v
+++ b/CoqOfRust/core/io/borrowed_buf.v
@@ -81,19 +81,21 @@ Module io.
                             M.read (| Value.String "init" |);
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::io::borrowed_buf::BorrowedBuf"
-                                "init")
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::io::borrowed_buf::BorrowedBuf",
+                                "init"
+                              |))
                           ]
                         |);
                         M.read (| Value.String "filled" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::io::borrowed_buf::BorrowedBuf"
-                            "filled")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::io::borrowed_buf::BorrowedBuf",
+                            "filled"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "capacity" |);
@@ -275,10 +277,11 @@ Module io.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::io::borrowed_buf::BorrowedBuf"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::io::borrowed_buf::BorrowedBuf",
                     "buf"
+                  |)
                 |)
               ]
             |)))
@@ -298,10 +301,11 @@ Module io.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::io::borrowed_buf::BorrowedBuf"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::io::borrowed_buf::BorrowedBuf",
                 "filled"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -319,10 +323,11 @@ Module io.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::io::borrowed_buf::BorrowedBuf"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::io::borrowed_buf::BorrowedBuf",
                 "init"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -360,10 +365,11 @@ Module io.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedBuf"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedBuf",
                         "buf"
+                      |)
                     |);
                     Value.StructRecord
                       "core::ops::range::Range"
@@ -371,10 +377,11 @@ Module io.
                         ("start", Value.Integer Integer.Usize 0);
                         ("end_",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "filled"
+                            |)
                           |))
                       ]
                   ]
@@ -417,10 +424,11 @@ Module io.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedBuf"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedBuf",
                         "buf"
+                      |)
                     |);
                     Value.StructRecord
                       "core::ops::range::Range"
@@ -428,10 +436,11 @@ Module io.
                         ("start", Value.Integer Integer.Usize 0);
                         ("end_",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "filled"
+                            |)
                           |))
                       ]
                   ]
@@ -465,10 +474,11 @@ Module io.
               [
                 ("start",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedBuf"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedBuf",
                       "filled"
+                    |)
                   |));
                 ("buf",
                   M.call_closure (|
@@ -501,10 +511,11 @@ Module io.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "filled",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "filled"
+                  |),
                   Value.Integer Integer.Usize 0
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -529,18 +540,20 @@ Module io.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "init",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "init"
+                  |),
                   M.call_closure (|
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "init"
+                        |)
                       |);
                       M.read (| n |)
                     ]
@@ -587,18 +600,20 @@ Module io.
                 M.read (| Value.String "buf" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::io::borrowed_buf::BorrowedCursor"
-                    "buf");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::io::borrowed_buf::BorrowedCursor",
+                    "buf"
+                  |));
                 M.read (| Value.String "start" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedCursor"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedCursor",
                       "start"
+                    |)
                   |))
               ]
             |)))
@@ -649,19 +664,21 @@ Module io.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::io::borrowed_buf::BorrowedCursor",
                           "buf"
+                        |)
                       |)
                     ]
                   |));
                 ("start",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedCursor"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedCursor",
                       "start"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -688,23 +705,26 @@ Module io.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedCursor"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedCursor",
                       "buf"
+                    |)
                   |)
                 ]
               |),
               M.read (|
-                M.get_struct_record_field
-                  (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedCursor"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedCursor",
                       "buf"
-                  |))
-                  "core::io::borrowed_buf::BorrowedBuf"
+                    |)
+                  |),
+                  "core::io::borrowed_buf::BorrowedBuf",
                   "filled"
+                |)
               |)
             |)))
         | _, _ => M.impossible
@@ -724,21 +744,24 @@ Module io.
             (let self := M.alloc (| self |) in
             BinOp.Panic.sub (|
               M.read (|
-                M.get_struct_record_field
-                  (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::io::borrowed_buf::BorrowedCursor"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::io::borrowed_buf::BorrowedCursor",
                       "buf"
-                  |))
-                  "core::io::borrowed_buf::BorrowedBuf"
+                    |)
+                  |),
+                  "core::io::borrowed_buf::BorrowedBuf",
                   "filled"
+                |)
               |),
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::io::borrowed_buf::BorrowedCursor"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::io::borrowed_buf::BorrowedCursor",
                   "start"
+                |)
               |)
             |)))
         | _, _ => M.impossible
@@ -777,42 +800,48 @@ Module io.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::io::borrowed_buf::BorrowedCursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::io::borrowed_buf::BorrowedCursor",
                             "buf"
-                        |))
-                        "core::io::borrowed_buf::BorrowedBuf"
+                          |)
+                        |),
+                        "core::io::borrowed_buf::BorrowedBuf",
                         "buf"
+                      |)
                     |);
                     Value.StructRecord
                       "core::ops::range::Range"
                       [
                         ("start",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::io::borrowed_buf::BorrowedCursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::io::borrowed_buf::BorrowedCursor",
                                   "buf"
-                              |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                                |)
+                              |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "filled"
+                            |)
                           |));
                         ("end_",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::io::borrowed_buf::BorrowedCursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::io::borrowed_buf::BorrowedCursor",
                                   "buf"
-                              |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                                |)
+                              |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "init"
+                            |)
                           |))
                       ]
                   ]
@@ -857,42 +886,48 @@ Module io.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::io::borrowed_buf::BorrowedCursor"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::io::borrowed_buf::BorrowedCursor",
                             "buf"
-                        |))
-                        "core::io::borrowed_buf::BorrowedBuf"
+                          |)
+                        |),
+                        "core::io::borrowed_buf::BorrowedBuf",
                         "buf"
+                      |)
                     |);
                     Value.StructRecord
                       "core::ops::range::Range"
                       [
                         ("start",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::io::borrowed_buf::BorrowedCursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::io::borrowed_buf::BorrowedCursor",
                                   "buf"
-                              |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                                |)
+                              |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "filled"
+                            |)
                           |));
                         ("end_",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::io::borrowed_buf::BorrowedCursor"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::io::borrowed_buf::BorrowedCursor",
                                   "buf"
-                              |))
-                              "core::io::borrowed_buf::BorrowedBuf"
+                                |)
+                              |),
+                              "core::io::borrowed_buf::BorrowedBuf",
                               "init"
+                            |)
                           |))
                       ]
                   ]
@@ -926,30 +961,34 @@ Module io.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
                     "buf"
+                  |)
                 |);
                 Value.StructRecord
                   "core::ops::range::RangeFrom"
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedCursor",
                               "buf"
-                          |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                            |)
+                          |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "init"
+                        |)
                       |))
                   ]
               ]
@@ -981,30 +1020,34 @@ Module io.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
                     "buf"
+                  |)
                 |);
                 Value.StructRecord
                   "core::ops::range::RangeFrom"
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedCursor",
                               "buf"
-                          |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                            |)
+                          |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "filled"
+                        |)
                       |))
                   ]
               ]
@@ -1030,51 +1073,59 @@ Module io.
             M.read (|
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "filled" in
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "filled"
+                  |) in
                 M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| n |) |) |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "init",
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "init"
+                  |),
                   M.call_closure (|
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedCursor",
                               "buf"
-                          |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                            |)
+                          |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "init"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedCursor",
                               "buf"
-                          |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                            |)
+                          |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "filled"
+                        |)
                       |)
                     ]
                   |)
@@ -1161,15 +1212,17 @@ Module io.
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "init",
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "init"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.path "core::io::borrowed_buf::BorrowedBuf",
@@ -1178,10 +1231,11 @@ Module io.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::io::borrowed_buf::BorrowedCursor",
                           "buf"
+                        |)
                       |)
                     ]
                   |)
@@ -1208,40 +1262,46 @@ Module io.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "init",
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "init"
+                  |),
                   M.call_closure (|
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::io::borrowed_buf::BorrowedCursor"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::io::borrowed_buf::BorrowedCursor",
                               "buf"
-                          |))
-                          "core::io::borrowed_buf::BorrowedBuf"
+                            |)
+                          |),
+                          "core::io::borrowed_buf::BorrowedBuf",
                           "init"
+                        |)
                       |);
                       BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::io::borrowed_buf::BorrowedCursor"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::io::borrowed_buf::BorrowedCursor",
                                 "buf"
-                            |))
-                            "core::io::borrowed_buf::BorrowedBuf"
+                              |)
+                            |),
+                            "core::io::borrowed_buf::BorrowedBuf",
                             "filled"
+                          |)
                         |),
                         M.read (| n |)
                       |)
@@ -1401,15 +1461,17 @@ Module io.
                 M.alloc (| Value.Tuple [] |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::io::borrowed_buf::BorrowedCursor"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::io::borrowed_buf::BorrowedCursor",
                         "buf"
-                    |))
-                    "core::io::borrowed_buf::BorrowedBuf"
-                    "filled" in
+                      |)
+                    |),
+                    "core::io::borrowed_buf::BorrowedBuf",
+                    "filled"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (|

--- a/CoqOfRust/core/iter/adapters/array_chunks.v
+++ b/CoqOfRust/core/iter/adapters/array_chunks.v
@@ -42,18 +42,20 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::array_chunks::ArrayChunks"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::array_chunks::ArrayChunks",
+                      "iter"
+                    |));
                   M.read (| Value.String "remainder" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::array_chunks::ArrayChunks"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::array_chunks::ArrayChunks",
                         "remainder"
+                      |)
                     |))
                 ]
               |)))
@@ -87,10 +89,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::array_chunks::ArrayChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::array_chunks::ArrayChunks",
                           "iter"
+                        |)
                       ]
                     |));
                   ("remainder",
@@ -105,10 +108,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::array_chunks::ArrayChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::array_chunks::ArrayChunks",
                           "remainder"
+                        |)
                       ]
                     |))
                 ]))
@@ -218,10 +222,11 @@ Module iter.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  self
-                  "core::iter::adapters::array_chunks::ArrayChunks"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "core::iter::adapters::array_chunks::ArrayChunks",
                   "remainder"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -282,10 +287,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::array_chunks::ArrayChunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::array_chunks::ArrayChunks",
                                           "remainder"
+                                        |)
                                       ]
                                     |)
                                   |)) in
@@ -312,10 +318,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::array_chunks::ArrayChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::array_chunks::ArrayChunks",
                                 "iter"
+                              |)
                             ]
                           |),
                           M.read (| M.get_constant (| "core::iter::adapters::array_chunks::N" |) |)
@@ -380,10 +387,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::array_chunks::ArrayChunks"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::array_chunks::ArrayChunks",
                                                 "iter"
+                                              |)
                                             ]
                                           |)
                                         ]
@@ -419,10 +427,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::array_chunks::ArrayChunks"
-                          "remainder",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::array_chunks::ArrayChunks",
+                          "remainder"
+                        |),
                         Value.StructTuple "core::option::Option::Some" [ M.read (| remainder |) ]
                       |) in
                     M.alloc (| Value.Tuple [] |)
@@ -515,18 +524,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::array_chunks::ArrayChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::array_chunks::ArrayChunks",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let lower := M.copy (| γ0_0 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -604,10 +614,11 @@ Module iter.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "core::iter::adapters::array_chunks::ArrayChunks"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::array_chunks::ArrayChunks",
                         "iter"
+                      |)
                     |)
                   ]
                 |),
@@ -663,10 +674,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::array_chunks::ArrayChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::array_chunks::ArrayChunks",
                                   "iter"
+                                |)
                               ]
                             |)
                           |),
@@ -674,7 +686,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -720,7 +732,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -747,7 +759,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -761,7 +773,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -785,10 +797,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::array_chunks::ArrayChunks"
-                                                "remainder";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::array_chunks::ArrayChunks",
+                                                "remainder"
+                                              |);
                                               M.read (| remainder |)
                                             ]
                                           |)
@@ -996,10 +1009,11 @@ Module iter.
                             Value.StructTuple
                               "core::iter::adapters::by_ref_sized::ByRefSized"
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::array_chunks::ArrayChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::array_chunks::ArrayChunks",
                                   "iter"
+                                |)
                               ]
                           ]
                         |)
@@ -1033,7 +1047,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::result::Result::Ok",
                                       0
@@ -1091,7 +1105,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -1118,7 +1132,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -1181,8 +1195,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::double_ended::DoubleEndedIterator",
@@ -1208,9 +1222,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -1281,10 +1296,11 @@ Module iter.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::array_chunks::ArrayChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::array_chunks::ArrayChunks",
                       "iter"
+                    |)
                   ]
                 |),
                 M.read (| M.get_constant (| "core::iter::adapters::array_chunks::N" |) |)
@@ -1313,10 +1329,11 @@ Module iter.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::array_chunks::ArrayChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::array_chunks::ArrayChunks",
                       "iter"
+                    |)
                   ]
                 |))
                 (M.read (| M.get_constant (| "core::iter::adapters::array_chunks::N" |) |))))
@@ -1359,8 +1376,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let f := M.alloc (| f |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -1386,9 +1403,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -1456,10 +1474,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::array_chunks::ArrayChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::array_chunks::ArrayChunks",
                           "iter"
+                        |)
                       ]
                     |)
                   |) in
@@ -1526,10 +1545,11 @@ Module iter.
                                                               []
                                                             |),
                                                             [
-                                                              M.get_struct_record_field
-                                                                self
-                                                                "core::iter::adapters::array_chunks::ArrayChunks"
-                                                                "iter";
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                self,
+                                                                "core::iter::adapters::array_chunks::ArrayChunks",
+                                                                "iter"
+                                                              |);
                                                               M.read (| idx |)
                                                             ]
                                                           |)
@@ -1621,10 +1641,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::array_chunks::ArrayChunks"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::array_chunks::ArrayChunks",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/by_ref_sized.v
+++ b/CoqOfRust/core/iter/adapters/by_ref_sized.v
@@ -35,10 +35,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::iter::adapters::by_ref_sized::ByRefSized"
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::by_ref_sized::ByRefSized",
                         0
+                      |)
                     |))
                 ]
               |)))
@@ -82,10 +83,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |)
                 ]
               |)))
@@ -113,10 +115,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |)
                 ]
               |)))
@@ -145,10 +148,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| n |)
                 ]
@@ -172,10 +176,11 @@ Module iter.
                 M.get_trait_method (| "core::iter::traits::iterator::Iterator", I, [], "nth", [] |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| n |)
                 ]
@@ -201,8 +206,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let f := M.alloc (| f |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -217,10 +222,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_tuple_field
-                            self
-                            "core::iter::adapters::by_ref_sized::ByRefSized"
+                          M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::iter::adapters::by_ref_sized::ByRefSized",
                             0
+                          |)
                         |);
                         M.read (| init |);
                         M.call_closure (|
@@ -233,9 +239,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -267,10 +274,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| f |)
@@ -322,10 +330,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |)
                 ]
               |)))
@@ -354,10 +363,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| n |)
                 ]
@@ -387,10 +397,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| n |)
                 ]
@@ -416,8 +427,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let f := M.alloc (| f |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::double_ended::DoubleEndedIterator",
@@ -432,10 +443,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_tuple_field
-                            self
-                            "core::iter::adapters::by_ref_sized::ByRefSized"
+                          M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::iter::adapters::by_ref_sized::ByRefSized",
                             0
+                          |)
                         |);
                         M.read (| init |);
                         M.call_closure (|
@@ -448,9 +460,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -482,10 +495,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::iter::adapters::by_ref_sized::ByRefSized"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::by_ref_sized::ByRefSized",
                       0
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| f |)

--- a/CoqOfRust/core/iter/adapters/chain.v
+++ b/CoqOfRust/core/iter/adapters/chain.v
@@ -39,10 +39,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::chain::Chain"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::chain::Chain",
                           "a"
+                        |)
                       ]
                     |));
                   ("b",
@@ -55,10 +56,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::chain::Chain"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::chain::Chain",
                           "b"
+                        |)
                       ]
                     |))
                 ]))
@@ -98,18 +100,20 @@ Module iter.
                   M.read (| Value.String "a" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::chain::Chain"
-                      "a");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::chain::Chain",
+                      "a"
+                    |));
                   M.read (| Value.String "b" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::chain::Chain"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::chain::Chain",
                         "b"
+                      |)
                     |))
                 ]
               |)))
@@ -196,10 +200,11 @@ Module iter.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::chain::Chain"
-                        "a";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::chain::Chain",
+                        "a"
+                      |);
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
                         A,
@@ -249,10 +254,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::chain::Chain"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::chain::Chain",
                                                       "b"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -262,7 +268,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -298,7 +304,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -342,12 +348,16 @@ Module iter.
                 let a_count :=
                   M.copy (|
                     M.match_operator (|
-                      M.get_struct_record_field self "core::iter::adapters::chain::Chain" "a",
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::chain::Chain",
+                        "a"
+                      |),
                       [
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -372,12 +382,16 @@ Module iter.
                 let b_count :=
                   M.copy (|
                     M.match_operator (|
-                      M.get_struct_record_field self "core::iter::adapters::chain::Chain" "b",
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::chain::Chain",
+                        "b"
+                      |),
                       [
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -440,12 +454,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "a" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "a"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -483,7 +498,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -510,7 +525,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -523,10 +538,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "a",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "a"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -540,12 +556,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "b" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "b"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -583,7 +600,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -610,7 +627,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -672,12 +689,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::chain::Chain"
-                              "a" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::chain::Chain",
+                              "a"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -708,12 +726,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::chain::Chain"
-                              "b" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::chain::Chain",
+                              "b"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -777,12 +796,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "a" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "a"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -809,7 +829,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Ok",
                                                 0
@@ -828,7 +848,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Err",
                                                 0
@@ -850,10 +870,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "a",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "a"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -867,12 +888,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "b" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "b"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -970,12 +992,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "a" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "a"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1002,7 +1025,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Ok",
                                                 0
@@ -1037,7 +1060,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Err",
                                                 0
@@ -1059,10 +1082,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "a",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "a"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -1100,10 +1124,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::chain::Chain"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::chain::Chain",
                                           "b"
+                                        |)
                                       ]
                                     |)
                                   ]
@@ -1113,7 +1138,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1146,7 +1171,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1204,10 +1229,11 @@ Module iter.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::chain::Chain"
-                        "a";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::chain::Chain",
+                        "a"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -1275,10 +1301,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::chain::Chain"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::chain::Chain",
                                                       "b"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -1288,7 +1315,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -1324,7 +1351,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -1376,7 +1403,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field self "core::iter::adapters::chain::Chain" "a"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::chain::Chain",
+                            "a"
+                          |)
                         |);
                         M.get_trait_method (|
                           "core::iter::traits::iterator::Iterator",
@@ -1403,7 +1434,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field self "core::iter::adapters::chain::Chain" "b"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::chain::Chain",
+                            "b"
+                          |)
                         |);
                         M.get_trait_method (|
                           "core::iter::traits::iterator::Iterator",
@@ -1465,26 +1500,26 @@ Module iter.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "b"
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "core::option::Option::Some",
                             0
                           |) in
                         let a := M.alloc (| γ2_0 |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_1,
                             "core::option::Option::Some",
                             0
@@ -1506,8 +1541,8 @@ Module iter.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let a_lower := M.copy (| γ0_0 |) in
                                 let a_upper := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -1526,8 +1561,8 @@ Module iter.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let b_lower := M.copy (| γ0_0 |) in
                                         let b_upper := M.copy (| γ0_1 |) in
                                         let lower :=
@@ -1551,17 +1586,19 @@ Module iter.
                                               [
                                                 fun γ =>
                                                   ltac:(M.monadic
-                                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                                    (let γ0_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ0_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let γ1_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ0_0,
                                                         "core::option::Option::Some",
                                                         0
                                                       |) in
                                                     let x := M.copy (| γ1_0 |) in
                                                     let γ1_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ0_1,
                                                         "core::option::Option::Some",
                                                         0
@@ -1598,19 +1635,19 @@ Module iter.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "b"
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_0,
                             "core::option::Option::Some",
                             0
@@ -1632,19 +1669,19 @@ Module iter.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "b"
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_1,
                             "core::option::Option::Some",
                             0
@@ -1666,13 +1703,13 @@ Module iter.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "a"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::chain::Chain",
                             "b"
@@ -1751,10 +1788,11 @@ Module iter.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::chain::Chain"
-                        "b";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::chain::Chain",
+                        "b"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -1822,10 +1860,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::chain::Chain"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::chain::Chain",
                                                       "a"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -1835,7 +1874,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -1871,7 +1910,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -1927,12 +1966,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "b" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "b"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1959,7 +1999,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Ok",
                                                 0
@@ -1978,7 +2018,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Err",
                                                 0
@@ -2000,10 +2040,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "b",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "b"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -2017,12 +2058,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "a" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "a"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2120,12 +2162,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "b" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "b"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2152,7 +2195,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Ok",
                                                 0
@@ -2187,7 +2230,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::result::Result::Err",
                                                 0
@@ -2209,10 +2252,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "b",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "b"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -2250,10 +2294,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::chain::Chain"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::chain::Chain",
                                           "a"
+                                        |)
                                       ]
                                     |)
                                   ]
@@ -2263,7 +2308,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -2296,7 +2341,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -2354,10 +2399,11 @@ Module iter.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::chain::Chain"
-                        "b";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::chain::Chain",
+                        "b"
+                      |);
                       M.closure
                         (fun γ =>
                           ltac:(M.monadic
@@ -2425,10 +2471,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::chain::Chain"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::chain::Chain",
                                                       "a"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -2438,7 +2485,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -2474,7 +2521,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -2532,12 +2579,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "b" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "b"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2575,7 +2623,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2602,7 +2650,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2615,10 +2663,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::chain::Chain"
-                                    "b",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::chain::Chain",
+                                    "b"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -2632,12 +2681,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::chain::Chain"
-                                  "a" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::chain::Chain",
+                                  "a"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2675,7 +2725,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2702,7 +2752,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2764,12 +2814,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::chain::Chain"
-                              "b" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::chain::Chain",
+                              "b"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2800,12 +2851,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::chain::Chain"
-                              "a" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::chain::Chain",
+                              "a"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2981,7 +3033,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -3012,7 +3064,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0

--- a/CoqOfRust/core/iter/adapters/cloned.v
+++ b/CoqOfRust/core/iter/adapters/cloned.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cloned::Cloned"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cloned::Cloned",
                           "it"
+                        |)
                       ]
                     |))
                 ]))
@@ -73,10 +74,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::cloned::Cloned"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::cloned::Cloned",
                         "it"
+                      |)
                     |))
                 ]
               |)))
@@ -218,10 +220,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::cloned::Cloned"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::cloned::Cloned",
                         "it"
+                      |)
                     ]
                   |)
                 ]
@@ -249,10 +252,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::cloned::Cloned"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::cloned::Cloned",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -285,10 +289,11 @@ Module iter.
                   [ B; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::cloned::Cloned"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::cloned::Cloned",
+                    "it"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -339,7 +344,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::cloned::Cloned" "it"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::cloned::Cloned",
+                          "it"
+                        |)
                       |);
                       M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |)
                     ]
@@ -374,10 +383,11 @@ Module iter.
                   M.call_closure (|
                     M.get_function (| "core::iter::adapters::zip::try_get_unchecked", [ I ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::cloned::Cloned"
-                        "it";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::cloned::Cloned",
+                        "it"
+                      |);
                       M.read (| idx |)
                     ]
                   |)
@@ -434,10 +444,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::cloned::Cloned"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::cloned::Cloned",
                         "it"
+                      |)
                     ]
                   |)
                 ]
@@ -472,10 +483,11 @@ Module iter.
                   [ B; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::cloned::Cloned"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::cloned::Cloned",
+                    "it"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -526,7 +538,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::cloned::Cloned" "it"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::cloned::Cloned",
+                          "it"
+                        |)
                       |);
                       M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |)
                     ]
@@ -576,10 +592,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::cloned::Cloned"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::cloned::Cloned",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -605,10 +622,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::cloned::Cloned"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::cloned::Cloned",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -717,10 +735,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cloned::Cloned"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cloned::Cloned",
                           "it"
+                        |)
                       ]
                     |)
                   |) in

--- a/CoqOfRust/core/iter/adapters/copied.v
+++ b/CoqOfRust/core/iter/adapters/copied.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::copied::Copied"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::copied::Copied",
                           "it"
+                        |)
                       ]
                     |))
                 ]))
@@ -73,10 +74,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::copied::Copied"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::copied::Copied",
                         "it"
+                      |)
                     |))
                 ]
               |)))
@@ -254,10 +256,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::copied::Copied"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::copied::Copied",
                         "it"
+                      |)
                     ]
                   |)
                 ]
@@ -290,10 +293,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -319,10 +323,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -355,10 +360,11 @@ Module iter.
                   [ B; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
+                    "it"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -398,7 +404,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::copied::Copied" "it"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::copied::Copied",
+                      "it"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -438,10 +448,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::copied::Copied"
-                        "it";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::copied::Copied",
+                        "it"
+                      |);
                       M.read (| n |)
                     ]
                   |)
@@ -478,7 +489,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::copied::Copied" "it"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::copied::Copied",
+                          "it"
+                        |)
                       |)
                     ]
                   |)
@@ -508,7 +523,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::copied::Copied" "it"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::copied::Copied",
+                      "it"
+                    |)
                   |)
                 ]
               |)))
@@ -536,10 +555,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
+                    "it"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -567,10 +587,11 @@ Module iter.
                 M.call_closure (|
                   M.get_function (| "core::iter::adapters::zip::try_get_unchecked", [ I ] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::copied::Copied"
-                      "it";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::copied::Copied",
+                      "it"
+                    |);
                     M.read (| idx |)
                   ]
                 |)
@@ -631,10 +652,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::copied::Copied"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::copied::Copied",
                         "it"
+                      |)
                     ]
                   |)
                 ]
@@ -669,10 +691,11 @@ Module iter.
                   [ B; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
+                    "it"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -712,7 +735,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::copied::Copied" "it"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::copied::Copied",
+                      "it"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -745,10 +772,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
-                    "it";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
+                    "it"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -794,10 +822,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -823,10 +852,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::copied::Copied"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::copied::Copied",
                     "it"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/cycle.v
+++ b/CoqOfRust/core/iter/adapters/cycle.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cycle::Cycle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cycle::Cycle",
                           "orig"
+                        |)
                       ]
                     |));
                   ("iter",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cycle::Cycle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cycle::Cycle",
                           "iter"
+                        |)
                       ]
                     |))
                 ]))
@@ -82,18 +84,20 @@ Module iter.
                   M.read (| Value.String "orig" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::cycle::Cycle"
-                      "orig");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::cycle::Cycle",
+                      "orig"
+                    |));
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::cycle::Cycle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::cycle::Cycle",
                         "iter"
+                      |)
                     |))
                 ]
               |)))
@@ -178,10 +182,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cycle::Cycle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cycle::Cycle",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
@@ -190,17 +195,19 @@ Module iter.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::cycle::Cycle"
-                              "iter",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::cycle::Cycle",
+                              "iter"
+                            |),
                             M.call_closure (|
                               M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::cycle::Cycle"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::cycle::Cycle",
                                   "orig"
+                                |)
                               ]
                             |)
                           |) in
@@ -214,10 +221,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::cycle::Cycle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::cycle::Cycle",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)));
@@ -259,10 +267,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cycle::Cycle"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cycle::Cycle",
                           "orig"
+                        |)
                       ]
                     |)
                   |),
@@ -270,15 +279,15 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let sz := M.copy (| γ |) in
-                        let γ1_0 := M.get_tuple_field γ 0 in
-                        let γ1_1 := M.get_tuple_field γ 1 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let _ :=
                           M.is_constant_or_break_match (|
                             M.read (| γ1_0 |),
                             Value.Integer Integer.Usize 0
                           |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ1_1,
                             "core::option::Option::Some",
                             0
@@ -291,8 +300,8 @@ Module iter.
                         sz));
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let _ :=
                           M.is_constant_or_break_match (|
                             M.read (| γ0_0 |),
@@ -385,10 +394,11 @@ Module iter.
                                       [ Acc; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::cycle::Cycle"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::cycle::Cycle",
+                                        "iter"
+                                      |);
                                       M.read (| acc |);
                                       f
                                     ]
@@ -400,7 +410,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -427,7 +437,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -440,17 +450,19 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::cycle::Cycle"
-                          "iter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::cycle::Cycle",
+                          "iter"
+                        |),
                         M.call_closure (|
                           M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::cycle::Cycle"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::cycle::Cycle",
                               "orig"
+                            |)
                           ]
                         |)
                       |) in
@@ -479,10 +491,11 @@ Module iter.
                                       [ Acc; Ty.function [ Ty.tuple [ Acc; Ty.associated ] ] R; R ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::cycle::Cycle"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::cycle::Cycle",
+                                        "iter"
+                                      |);
                                       M.read (| acc |);
                                       M.closure
                                         (fun γ =>
@@ -545,7 +558,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -572,7 +585,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -623,10 +636,11 @@ Module iter.
                             ltac:(M.monadic
                               (let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::cycle::Cycle"
-                                    "iter",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::cycle::Cycle",
+                                    "iter"
+                                  |),
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::clone::Clone",
@@ -636,10 +650,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::cycle::Cycle"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::cycle::Cycle",
                                         "orig"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -667,10 +682,11 @@ Module iter.
                                                 [ Acc; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::cycle::Cycle"
-                                                  "iter";
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::cycle::Cycle",
+                                                  "iter"
+                                                |);
                                                 M.read (| acc |);
                                                 f
                                               ]
@@ -682,7 +698,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -709,7 +725,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -772,10 +788,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::cycle::Cycle"
-                                  "iter";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::cycle::Cycle",
+                                  "iter"
+                                |);
                                 M.read (| n |)
                               ]
                             |)
@@ -784,7 +801,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Ok",
                                     0
@@ -803,7 +820,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -844,10 +861,11 @@ Module iter.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::cycle::Cycle"
-                                        "iter",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::cycle::Cycle",
+                                        "iter"
+                                      |),
                                       M.call_closure (|
                                         M.get_trait_method (|
                                           "core::clone::Clone",
@@ -857,10 +875,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::cycle::Cycle"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::cycle::Cycle",
                                             "orig"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -879,10 +898,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::cycle::Cycle"
-                                                  "iter";
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::cycle::Cycle",
+                                                  "iter"
+                                                |);
                                                 M.read (| n |)
                                               ]
                                             |)
@@ -891,7 +911,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::result::Result::Ok",
                                                     0
@@ -911,7 +931,7 @@ Module iter.
                                               ltac:(M.monadic
                                                 (let e := M.copy (| γ |) in
                                                 let γ1_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::result::Result::Err",
                                                     0
@@ -944,7 +964,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::result::Result::Err",
                                                     0

--- a/CoqOfRust/core/iter/adapters/enumerate.v
+++ b/CoqOfRust/core/iter/adapters/enumerate.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
                           "iter"
+                        |)
                       ]
                     |));
                   ("count",
@@ -45,10 +46,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
                           "count"
+                        |)
                       ]
                     |))
                 ]))
@@ -88,18 +90,20 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::enumerate::Enumerate"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::enumerate::Enumerate",
+                      "iter"
+                    |));
                   M.read (| Value.String "count" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::enumerate::Enumerate"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::enumerate::Enumerate",
                         "count"
+                      |)
                     |))
                 ]
               |)))
@@ -187,10 +191,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::enumerate::Enumerate"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::enumerate::Enumerate",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -200,7 +205,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -233,7 +238,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -245,17 +250,19 @@ Module iter.
                       |) in
                     let i :=
                       M.copy (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
                           "count"
+                        |)
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
-                          "count" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
+                          "count"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -290,10 +297,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -339,10 +347,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::enumerate::Enumerate"
-                                      "iter";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::enumerate::Enumerate",
+                                      "iter"
+                                    |);
                                     M.read (| n |)
                                   ]
                                 |)
@@ -353,7 +362,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -386,7 +395,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -400,20 +409,22 @@ Module iter.
                       M.alloc (|
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::enumerate::Enumerate"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::enumerate::Enumerate",
                               "count"
+                            |)
                           |),
                           M.read (| n |)
                         |)
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
-                          "count",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
+                          "count"
+                        |),
                         BinOp.Panic.add (| M.read (| i |), Value.Integer Integer.Usize 1 |)
                       |) in
                     M.alloc (|
@@ -447,10 +458,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::enumerate::Enumerate"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::enumerate::Enumerate",
                       "iter"
+                    |)
                   |)
                 ]
               |)))
@@ -497,18 +509,20 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_associated_function (| Self, "enumerate.try_fold", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::enumerate::Enumerate"
-                        "count";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::enumerate::Enumerate",
+                        "count"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -556,20 +570,22 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::enumerate::Enumerate"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::enumerate::Enumerate",
                       "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_associated_function (| Self, "enumerate.fold", [] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::enumerate::Enumerate",
                           "count"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -609,10 +625,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
-                          "iter";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
+                          "iter"
+                        |);
                         M.read (| n |)
                       ]
                     |)
@@ -625,7 +642,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -634,7 +651,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -658,10 +675,11 @@ Module iter.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::enumerate::Enumerate"
-                      "count" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::enumerate::Enumerate",
+                      "count"
+                    |) in
                   M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| advanced |) |) |) in
                 remaining
               |)))
@@ -692,10 +710,11 @@ Module iter.
                     M.call_closure (|
                       M.get_function (| "core::iter::adapters::zip::try_get_unchecked", [ I ] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
-                          "iter";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
+                          "iter"
+                        |);
                         M.read (| idx |)
                       ]
                     |)
@@ -705,10 +724,11 @@ Module iter.
                     [
                       BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::enumerate::Enumerate"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::enumerate::Enumerate",
                             "count"
+                          |)
                         |),
                         M.read (| idx |)
                       |);
@@ -783,10 +803,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::enumerate::Enumerate"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::enumerate::Enumerate",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -796,7 +817,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -829,7 +850,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -850,10 +871,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::enumerate::Enumerate"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::enumerate::Enumerate",
                               "iter"
+                            |)
                           ]
                         |)
                       |) in
@@ -865,10 +887,11 @@ Module iter.
                             [
                               BinOp.Panic.add (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::enumerate::Enumerate"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::enumerate::Enumerate",
                                     "count"
+                                  |)
                                 |),
                                 M.read (| len |)
                               |);
@@ -922,10 +945,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::enumerate::Enumerate"
-                                      "iter";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::enumerate::Enumerate",
+                                      "iter"
+                                    |);
                                     M.read (| n |)
                                   ]
                                 |)
@@ -936,7 +960,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -969,7 +993,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -990,10 +1014,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::enumerate::Enumerate"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::enumerate::Enumerate",
                               "iter"
+                            |)
                           ]
                         |)
                       |) in
@@ -1005,10 +1030,11 @@ Module iter.
                             [
                               BinOp.Panic.add (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::enumerate::Enumerate"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::enumerate::Enumerate",
                                     "count"
+                                  |)
                                 |),
                                 M.read (| len |)
                               |);
@@ -1057,10 +1083,11 @@ Module iter.
                   M.alloc (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::enumerate::Enumerate",
                           "count"
+                        |)
                       |),
                       M.call_closure (|
                         M.get_trait_method (|
@@ -1071,10 +1098,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::enumerate::Enumerate"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::enumerate::Enumerate",
                             "iter"
+                          |)
                         ]
                       |)
                     |)
@@ -1089,10 +1117,11 @@ Module iter.
                       [ Acc; Ty.associated; R ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::enumerate::Enumerate"
-                        "iter";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::enumerate::Enumerate",
+                        "iter"
+                      |);
                       M.read (| init |);
                       M.call_closure (|
                         M.get_associated_function (| Self, "enumerate.try_rfold", [] |),
@@ -1139,10 +1168,11 @@ Module iter.
                   M.alloc (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::enumerate::Enumerate",
                           "count"
+                        |)
                       |),
                       M.call_closure (|
                         M.get_trait_method (|
@@ -1153,10 +1183,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            self
-                            "core::iter::adapters::enumerate::Enumerate"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::enumerate::Enumerate",
                             "iter"
+                          |)
                         ]
                       |)
                     |)
@@ -1172,10 +1203,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::enumerate::Enumerate"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::enumerate::Enumerate",
                           "iter"
+                        |)
                       |);
                       M.read (| init |);
                       M.call_closure (|
@@ -1212,10 +1244,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
+                    "iter"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -1262,10 +1295,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1291,10 +1325,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1410,10 +1445,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::enumerate::Enumerate"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::enumerate::Enumerate",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/filter.v
+++ b/CoqOfRust/core/iter/adapters/filter.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter::Filter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter::Filter",
                           "iter"
+                        |)
                       ]
                     |));
                   ("predicate",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter::Filter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter::Filter",
                           "predicate"
+                        |)
                       ]
                     |))
                 ]))
@@ -128,10 +130,11 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter::Filter"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter::Filter",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -371,14 +374,16 @@ Module iter.
                   [ Ty.apply (Ty.path "&mut") [ P ] ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
-                    "iter";
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
+                    "iter"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
                     "predicate"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -483,10 +488,11 @@ Module iter.
                         ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter::Filter"
-                          "iter";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter::Filter",
+                          "iter"
+                        |);
                         M.closure
                           (fun γ =>
                             ltac:(M.monadic
@@ -501,17 +507,19 @@ Module iter.
                                         M.read (|
                                           let idx :=
                                             M.copy (|
-                                              M.get_struct_record_field
-                                                guard
-                                                "core::iter::adapters::filter::next_chunk::Guard"
+                                              M.SubPointer.get_struct_record_field (|
+                                                guard,
+                                                "core::iter::adapters::filter::next_chunk::Guard",
                                                 "initialized"
+                                              |)
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                guard
-                                                "core::iter::adapters::filter::next_chunk::Guard"
-                                                "initialized",
+                                              M.SubPointer.get_struct_record_field (|
+                                                guard,
+                                                "core::iter::adapters::filter::next_chunk::Guard",
+                                                "initialized"
+                                              |),
                                               BinOp.Panic.add (|
                                                 M.read (| idx |),
                                                 M.rust_cast
@@ -528,10 +536,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::iter::adapters::filter::Filter"
-                                                        "predicate";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::iter::adapters::filter::Filter",
+                                                        "predicate"
+                                                      |);
                                                       Value.Tuple [ element ]
                                                     ]
                                                   |))
@@ -563,10 +572,11 @@ Module iter.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          guard
-                                                          "core::iter::adapters::filter::next_chunk::Guard"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          guard,
+                                                          "core::iter::adapters::filter::next_chunk::Guard",
                                                           "array"
+                                                        |)
                                                       |);
                                                       M.read (| idx |)
                                                     ]
@@ -585,10 +595,11 @@ Module iter.
                                                       (M.alloc (|
                                                         BinOp.Pure.lt
                                                           (M.read (|
-                                                            M.get_struct_record_field
-                                                              guard
-                                                              "core::iter::adapters::filter::next_chunk::Guard"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              guard,
+                                                              "core::iter::adapters::filter::next_chunk::Guard",
                                                               "initialized"
+                                                            |)
                                                           |))
                                                           (M.read (|
                                                             M.get_constant (|
@@ -646,7 +657,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -670,15 +681,15 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
                           |) in
                         let initialized :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_trait_method (|
                                   "core::ops::deref::Deref",
                                   Ty.apply
@@ -693,9 +704,10 @@ Module iter.
                                   []
                                 |),
                                 [ guard ]
-                              |))
-                              "core::iter::adapters::filter::next_chunk::Guard"
+                              |),
+                              "core::iter::adapters::filter::next_chunk::Guard",
                               "initialized"
+                            |)
                           |) in
                         M.alloc (|
                           Value.StructTuple
@@ -751,18 +763,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter::Filter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter::Filter",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
                           Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -808,16 +821,21 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::filter::Filter" "iter"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::filter::Filter",
+                          "iter"
+                        |)
                       |);
                       M.call_closure (|
                         M.get_associated_function (| Self, "to_usize.count", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::filter::Filter"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::filter::Filter",
                               "predicate"
+                            |)
                           |)
                         ]
                       |)
@@ -855,10 +873,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -866,10 +885,11 @@ Module iter.
                       [ Ty.associated; Acc; R; P; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::filter::Filter"
-                        "predicate";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::filter::Filter",
+                        "predicate"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -904,7 +924,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::filter::Filter" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::filter::Filter",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -914,10 +938,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::filter::Filter"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::filter::Filter",
                           "predicate"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -969,14 +994,16 @@ Module iter.
                   [ Ty.apply (Ty.path "&mut") [ P ] ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
-                    "iter";
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
+                    "iter"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
                     "predicate"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1009,10 +1036,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -1020,10 +1048,11 @@ Module iter.
                       [ Ty.associated; Acc; R; P; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::filter::Filter"
-                        "predicate";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::filter::Filter",
+                        "predicate"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -1058,7 +1087,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::filter::Filter" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::filter::Filter",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -1068,10 +1101,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::filter::Filter"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::filter::Filter",
                           "predicate"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -1143,10 +1177,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter::Filter"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter::Filter",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/filter_map.v
+++ b/CoqOfRust/core/iter/adapters/filter_map.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter_map::FilterMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter_map::FilterMap",
                           "iter"
+                        |)
                       ]
                     |));
                   ("f",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter_map::FilterMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter_map::FilterMap",
                           "f"
+                        |)
                       ]
                     |))
                 ]))
@@ -128,10 +130,11 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter_map::FilterMap"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter_map::FilterMap",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -200,7 +203,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -291,7 +294,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -369,14 +372,16 @@ Module iter.
                   [ B; Ty.apply (Ty.path "&mut") [ F ] ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter_map::FilterMap"
-                    "iter";
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter_map::FilterMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter_map::FilterMap",
+                    "iter"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter_map::FilterMap",
                     "f"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -490,10 +495,11 @@ Module iter.
                         ]
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter_map::FilterMap"
-                          "iter";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter_map::FilterMap",
+                          "iter"
+                        |);
                         M.closure
                           (fun γ =>
                             ltac:(M.monadic
@@ -508,10 +514,11 @@ Module iter.
                                         M.read (|
                                           let idx :=
                                             M.copy (|
-                                              M.get_struct_record_field
-                                                guard
-                                                "core::iter::adapters::filter_map::next_chunk::Guard"
+                                              M.SubPointer.get_struct_record_field (|
+                                                guard,
+                                                "core::iter::adapters::filter_map::next_chunk::Guard",
                                                 "initialized"
+                                              |)
                                             |) in
                                           let val :=
                                             M.alloc (|
@@ -524,20 +531,22 @@ Module iter.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::filter_map::FilterMap"
-                                                    "f";
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::filter_map::FilterMap",
+                                                    "f"
+                                                  |);
                                                   Value.Tuple [ M.read (| element |) ]
                                                 ]
                                               |)
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                guard
-                                                "core::iter::adapters::filter_map::next_chunk::Guard"
-                                                "initialized",
+                                              M.SubPointer.get_struct_record_field (|
+                                                guard,
+                                                "core::iter::adapters::filter_map::next_chunk::Guard",
+                                                "initialized"
+                                              |),
                                               BinOp.Panic.add (|
                                                 M.read (| idx |),
                                                 M.rust_cast
@@ -636,10 +645,11 @@ Module iter.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            guard
-                                                            "core::iter::adapters::filter_map::next_chunk::Guard"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            guard,
+                                                            "core::iter::adapters::filter_map::next_chunk::Guard",
                                                             "array"
+                                                          |)
                                                         |)
                                                       ]
                                                     |);
@@ -691,10 +701,11 @@ Module iter.
                                                       (M.alloc (|
                                                         BinOp.Pure.lt
                                                           (M.read (|
-                                                            M.get_struct_record_field
-                                                              guard
-                                                              "core::iter::adapters::filter_map::next_chunk::Guard"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              guard,
+                                                              "core::iter::adapters::filter_map::next_chunk::Guard",
                                                               "initialized"
+                                                            |)
                                                           |))
                                                           (M.read (|
                                                             M.get_constant (|
@@ -752,7 +763,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -774,15 +785,15 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
                           |) in
                         let initialized :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.call_closure (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.call_closure (|
                                 M.get_trait_method (|
                                   "core::ops::deref::Deref",
                                   Ty.apply
@@ -798,9 +809,10 @@ Module iter.
                                   []
                                 |),
                                 [ guard ]
-                              |))
-                              "core::iter::adapters::filter_map::next_chunk::Guard"
+                              |),
+                              "core::iter::adapters::filter_map::next_chunk::Guard",
                               "initialized"
+                            |)
                           |) in
                         M.alloc (|
                           Value.StructTuple
@@ -854,18 +866,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::filter_map::FilterMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::filter_map::FilterMap",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
                           Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -903,10 +916,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter_map::FilterMap"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter_map::FilterMap",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -914,10 +928,11 @@ Module iter.
                       [ Ty.associated; B; Acc; R; F; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::filter_map::FilterMap"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::filter_map::FilterMap",
+                        "f"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -952,10 +967,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::filter_map::FilterMap"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::filter_map::FilterMap",
                       "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -965,10 +981,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::filter_map::FilterMap"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::filter_map::FilterMap",
                           "f"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -1040,18 +1057,20 @@ Module iter.
                       ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::filter_map::FilterMap"
-                        "iter";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::filter_map::FilterMap",
+                        "iter"
+                      |);
                       Value.Tuple [];
                       M.call_closure (|
                         M.get_associated_function (| Self, "find.next_back", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::filter_map::FilterMap"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::filter_map::FilterMap",
                             "f"
+                          |)
                         ]
                       |)
                     ]
@@ -1088,10 +1107,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter_map::FilterMap"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter_map::FilterMap",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -1099,10 +1119,11 @@ Module iter.
                       [ Ty.associated; B; Acc; R; F; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::filter_map::FilterMap"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::filter_map::FilterMap",
+                        "f"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -1137,10 +1158,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::filter_map::FilterMap"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::filter_map::FilterMap",
                       "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -1150,10 +1172,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::filter_map::FilterMap"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::filter_map::FilterMap",
                           "f"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -1225,10 +1248,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::filter_map::FilterMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::filter_map::FilterMap",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/flatten.v
+++ b/CoqOfRust/core/iter/adapters/flatten.v
@@ -103,10 +103,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlatMap"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlatMap",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -165,10 +166,11 @@ Module iter.
                       M.read (| Value.String "inner" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlatMap"
-                          "inner")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlatMap",
+                          "inner"
+                        |))
                     ]
                   |)
                 ]
@@ -214,10 +216,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -245,10 +248,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -283,10 +287,11 @@ Module iter.
                   [ Acc; Fold; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
+                    "inner"
+                  |);
                   M.read (| init |);
                   M.read (| fold |)
                 ]
@@ -322,7 +327,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::FlatMap" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::FlatMap",
+                      "inner"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| fold |)
@@ -354,10 +363,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
+                    "inner"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -387,7 +397,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::FlatMap" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::FlatMap",
+                      "inner"
+                    |)
                   |)
                 ]
               |)))
@@ -417,7 +431,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::FlatMap" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::FlatMap",
+                      "inner"
+                    |)
                   |)
                 ]
               |)))
@@ -469,10 +487,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -507,10 +526,11 @@ Module iter.
                   [ Acc; Fold; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
+                    "inner"
+                  |);
                   M.read (| init |);
                   M.read (| fold |)
                 ]
@@ -546,7 +566,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::FlatMap" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::FlatMap",
+                      "inner"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| fold |)
@@ -578,10 +602,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::FlatMap"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::FlatMap",
+                    "inner"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -703,13 +728,15 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::flatten::FlatMap"
-                      "inner")
-                    "core::iter::adapters::flatten::FlattenCompat"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::flatten::FlatMap",
+                      "inner"
+                    |),
+                    "core::iter::adapters::flatten::FlattenCompat",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1079,10 +1106,11 @@ Module iter.
                       M.read (| Value.String "inner" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::Flatten"
-                          "inner")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::Flatten",
+                          "inner"
+                        |))
                     ]
                   |)
                 ]
@@ -1127,10 +1155,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::Flatten"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::Flatten",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -1173,10 +1202,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1202,10 +1232,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1238,10 +1269,11 @@ Module iter.
                   [ Acc; Fold; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
+                    "inner"
+                  |);
                   M.read (| init |);
                   M.read (| fold |)
                 ]
@@ -1275,7 +1307,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::Flatten" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::Flatten",
+                      "inner"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| fold |)
@@ -1305,10 +1341,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
+                    "inner"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -1336,7 +1373,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::Flatten" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::Flatten",
+                      "inner"
+                    |)
                   |)
                 ]
               |)))
@@ -1364,7 +1405,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::Flatten" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::Flatten",
+                      "inner"
+                    |)
                   |)
                 ]
               |)))
@@ -1414,10 +1459,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1450,10 +1496,11 @@ Module iter.
                   [ Acc; Fold; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
+                    "inner"
+                  |);
                   M.read (| init |);
                   M.read (| fold |)
                 ]
@@ -1487,7 +1534,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::flatten::Flatten" "inner"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::flatten::Flatten",
+                      "inner"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| fold |)
@@ -1517,10 +1568,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::flatten::Flatten"
-                    "inner";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::flatten::Flatten",
+                    "inner"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -1640,13 +1692,15 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::flatten::Flatten"
-                      "inner")
-                    "core::iter::adapters::flatten::FlattenCompat"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::flatten::Flatten",
+                      "inner"
+                    |),
+                    "core::iter::adapters::flatten::FlattenCompat",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -1740,10 +1794,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
                           "iter"
+                        |)
                       ]
                     |));
                   ("frontiter",
@@ -1756,10 +1811,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
                           "frontiter"
+                        |)
                       ]
                     |));
                   ("backiter",
@@ -1772,10 +1828,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
                           "backiter"
+                        |)
                       ]
                     |))
                 ]))
@@ -1815,25 +1872,28 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::flatten::FlattenCompat"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::flatten::FlattenCompat",
+                      "iter"
+                    |));
                   M.read (| Value.String "frontiter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::flatten::FlattenCompat"
-                      "frontiter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::flatten::FlattenCompat",
+                      "frontiter"
+                    |));
                   M.read (| Value.String "backiter" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::flatten::FlattenCompat"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::flatten::FlattenCompat",
                         "backiter"
+                      |)
                     |))
                 ]
               |)))
@@ -1928,12 +1988,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::flatten::FlattenCompat"
-                              "frontiter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::flatten::FlattenCompat",
+                              "frontiter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -1970,10 +2031,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "core::iter::adapters::flatten::FlattenCompat"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::flatten::FlattenCompat",
                             "iter"
+                          |)
                         |);
                         M.read (| acc |);
                         M.call_closure (|
@@ -1990,12 +2052,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::flatten::FlattenCompat"
-                              "backiter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::flatten::FlattenCompat",
+                              "backiter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2077,14 +2140,15 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "frontiter"
+                                  |)
                                 |) in
                               let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2126,7 +2190,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2153,7 +2217,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2170,10 +2234,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "frontiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "frontiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     let _ :=
@@ -2200,10 +2265,11 @@ Module iter.
                                       [ Acc; Ty.associated; R ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::flatten::FlattenCompat"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::flatten::FlattenCompat",
+                                        "iter"
+                                      |);
                                       M.read (| acc |);
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -2212,10 +2278,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::flatten::FlattenCompat"
-                                            "frontiter";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::flatten::FlattenCompat",
+                                            "frontiter"
+                                          |);
                                           fold
                                         ]
                                       |)
@@ -2228,7 +2295,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -2255,7 +2322,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2268,10 +2335,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "frontiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "frontiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     let _ :=
@@ -2282,14 +2350,15 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "backiter"
+                                  |)
                                 |) in
                               let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2331,7 +2400,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2358,7 +2427,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2375,10 +2444,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "backiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "backiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     M.alloc (|
@@ -2442,12 +2512,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::flatten::FlattenCompat"
-                              "backiter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::flatten::FlattenCompat",
+                              "backiter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2484,10 +2555,11 @@ Module iter.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            self
-                            "core::iter::adapters::flatten::FlattenCompat"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::flatten::FlattenCompat",
                             "iter"
+                          |)
                         |);
                         M.read (| acc |);
                         M.call_closure (|
@@ -2504,12 +2576,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::flatten::FlattenCompat"
-                              "frontiter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::flatten::FlattenCompat",
+                              "frontiter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2591,14 +2664,15 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "backiter"
+                                  |)
                                 |) in
                               let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2640,7 +2714,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2667,7 +2741,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2684,10 +2758,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "backiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "backiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     let _ :=
@@ -2714,10 +2789,11 @@ Module iter.
                                       [ Acc; Ty.associated; R ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::flatten::FlattenCompat"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::flatten::FlattenCompat",
+                                        "iter"
+                                      |);
                                       M.read (| acc |);
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -2726,10 +2802,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::flatten::FlattenCompat"
-                                            "backiter";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::flatten::FlattenCompat",
+                                            "backiter"
+                                          |);
                                           fold
                                         ]
                                       |)
@@ -2742,7 +2819,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -2769,7 +2846,7 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2782,10 +2859,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "backiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "backiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     let _ :=
@@ -2796,14 +2874,15 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "frontiter"
+                                  |)
                                 |) in
                               let γ := M.read (| γ |) in
                               let γ1_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2845,7 +2924,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2872,7 +2951,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2889,10 +2968,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::flatten::FlattenCompat"
-                          "frontiter",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::flatten::FlattenCompat",
+                          "frontiter"
+                        |),
                         Value.StructTuple "core::option::Option::None" []
                       |) in
                     M.alloc (|
@@ -2973,10 +3053,11 @@ Module iter.
                                             ]
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::flatten::FlattenCompat"
-                                              "frontiter";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::flatten::FlattenCompat",
+                                              "frontiter"
+                                            |);
                                             M.get_trait_method (|
                                               "core::iter::traits::iterator::Iterator",
                                               U,
@@ -2989,7 +3070,7 @@ Module iter.
                                       |) in
                                     let elt := M.copy (| γ |) in
                                     let γ1_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -3013,10 +3094,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "iter"
+                                  |)
                                 ]
                               |)
                             |),
@@ -3041,10 +3123,11 @@ Module iter.
                                               ]
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::flatten::FlattenCompat"
-                                                "backiter";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::flatten::FlattenCompat",
+                                                "backiter"
+                                              |);
                                               M.get_trait_method (|
                                                 "core::iter::traits::iterator::Iterator",
                                                 U,
@@ -3061,17 +3144,18 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
                                   let inner := M.copy (| γ0_0 |) in
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::flatten::FlattenCompat"
-                                      "frontiter",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::flatten::FlattenCompat",
+                                      "frontiter"
+                                    |),
                                     Value.StructTuple
                                       "core::option::Option::Some"
                                       [
@@ -3158,10 +3242,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::flatten::FlattenCompat"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::flatten::FlattenCompat",
                                   "frontiter"
+                                |)
                               ]
                             |);
                             Value.Tuple
@@ -3184,8 +3269,8 @@ Module iter.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let flo := M.copy (| γ0_0 |) in
                             let fhi := M.copy (| γ0_1 |) in
                             M.match_operator (|
@@ -3223,10 +3308,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::flatten::FlattenCompat"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::flatten::FlattenCompat",
                                           "backiter"
+                                        |)
                                       ]
                                     |);
                                     Value.Tuple
@@ -3249,8 +3335,8 @@ Module iter.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let blo := M.copy (| γ0_0 |) in
                                     let bhi := M.copy (| γ0_1 |) in
                                     let lo :=
@@ -3284,7 +3370,7 @@ Module iter.
                                                   |)
                                                 |) in
                                               let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -3307,18 +3393,27 @@ Module iter.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::iter::adapters::flatten::FlattenCompat"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::iter::adapters::flatten::FlattenCompat",
                                                               "iter"
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
                                                       [
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             let lower := M.copy (| γ0_0 |) in
                                                             let upper := M.copy (| γ0_1 |) in
                                                             let lower :=
@@ -3437,7 +3532,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                                                               0
@@ -3459,7 +3554,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                                                               0
@@ -3503,7 +3598,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                                                               0
@@ -3525,7 +3620,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                                                               0
@@ -3549,7 +3644,7 @@ Module iter.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                                                 0
@@ -3570,7 +3665,7 @@ Module iter.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                                                 0
@@ -3643,7 +3738,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                                                               0
@@ -3665,7 +3760,7 @@ Module iter.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                                                               0
@@ -3689,7 +3784,7 @@ Module iter.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::ops::control_flow::ControlFlow::Break",
                                                                                                 0
@@ -3710,7 +3805,7 @@ Module iter.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                                                                 0
@@ -3733,7 +3828,7 @@ Module iter.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -3750,7 +3845,7 @@ Module iter.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -3794,10 +3889,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::flatten::FlattenCompat"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::flatten::FlattenCompat",
                                                   "iter"
+                                                |)
                                               ]
                                             |);
                                             M.read (| fhi |);
@@ -3807,18 +3903,20 @@ Module iter.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
-                                            let γ0_2 := M.get_tuple_field γ 2 in
-                                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                                            let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                                            let γ1_0 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                            let γ1_1 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                             let _ :=
                                               M.is_constant_or_break_match (|
                                                 M.read (| γ1_0 |),
                                                 Value.Integer Integer.Usize 0
                                               |) in
                                             let γ2_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ1_1,
                                                 "core::option::Option::Some",
                                                 0
@@ -3829,14 +3927,14 @@ Module iter.
                                                 Value.Integer Integer.Usize 0
                                               |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_1,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
                                             let a := M.copy (| γ1_0 |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_2,
                                                 "core::option::Option::Some",
                                                 0
@@ -4014,7 +4112,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -4201,10 +4299,11 @@ Module iter.
                                             ]
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::flatten::FlattenCompat"
-                                              "backiter";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::flatten::FlattenCompat",
+                                              "backiter"
+                                            |);
                                             M.closure
                                               (fun γ =>
                                                 ltac:(M.monadic
@@ -4235,7 +4334,7 @@ Module iter.
                                       |) in
                                     let elt := M.copy (| γ |) in
                                     let γ1_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -4259,10 +4358,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::flatten::FlattenCompat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::flatten::FlattenCompat",
                                     "iter"
+                                  |)
                                 ]
                               |)
                             |),
@@ -4287,10 +4387,11 @@ Module iter.
                                               ]
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::flatten::FlattenCompat"
-                                                "frontiter";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::flatten::FlattenCompat",
+                                                "frontiter"
+                                              |);
                                               M.closure
                                                 (fun γ =>
                                                   ltac:(M.monadic
@@ -4325,17 +4426,18 @@ Module iter.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
                                   let inner := M.copy (| γ0_0 |) in
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::flatten::FlattenCompat"
-                                      "backiter",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::flatten::FlattenCompat",
+                                      "backiter"
+                                    |),
                                     Value.StructTuple
                                       "core::option::Option::Some"
                                       [
@@ -4498,7 +4600,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -4765,7 +4867,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -4796,7 +4898,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0

--- a/CoqOfRust/core/iter/adapters/fuse.v
+++ b/CoqOfRust/core/iter/adapters/fuse.v
@@ -35,10 +35,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::fuse::Fuse"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::fuse::Fuse",
                           "iter"
+                        |)
                       ]
                     |))
                 ]))
@@ -79,10 +80,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::fuse::Fuse"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::fuse::Fuse",
                         "iter"
+                      |)
                     |))
                 ]
               |)))
@@ -222,12 +224,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field self "core::iter::adapters::fuse::Fuse" "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -270,12 +276,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field self "core::iter::adapters::fuse::Fuse" "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -316,15 +326,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -417,12 +428,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::fuse::Fuse"
-                              "iter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::fuse::Fuse",
+                              "iter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -502,15 +514,16 @@ Module iter.
               let idx := M.alloc (| idx |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -673,12 +686,13 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ :=
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::fuse::Fuse"
-                              "iter" in
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::fuse::Fuse",
+                              "iter"
+                            |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -771,15 +785,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -820,15 +835,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -989,10 +1005,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.get_trait_method (|
                     "core::iter::traits::iterator::Iterator",
                     I,
@@ -1029,10 +1046,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.closure
                     (fun γ =>
                       ltac:(M.monadic
@@ -1095,12 +1113,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::fuse::Fuse"
-                                  "iter" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::fuse::Fuse",
+                                  "iter"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1142,7 +1161,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -1169,7 +1188,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -1182,10 +1201,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::fuse::Fuse"
-                                    "iter",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::fuse::Fuse",
+                                    "iter"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -1236,10 +1256,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.closure
                     (fun γ =>
                       ltac:(M.monadic
@@ -1296,10 +1317,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.closure
                     (fun γ =>
                       ltac:(M.monadic
@@ -1357,10 +1379,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.closure
                     (fun γ =>
                       ltac:(M.monadic
@@ -1424,12 +1447,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::fuse::Fuse"
-                                  "iter" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::fuse::Fuse",
+                                  "iter"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1471,7 +1495,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -1498,7 +1522,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -1511,10 +1535,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::fuse::Fuse"
-                                    "iter",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::fuse::Fuse",
+                                    "iter"
+                                  |),
                                   Value.StructTuple "core::option::Option::None" []
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
@@ -1566,10 +1591,11 @@ Module iter.
                   ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::fuse::Fuse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::fuse::Fuse",
+                    "iter"
+                  |);
                   M.closure
                     (fun γ =>
                       ltac:(M.monadic
@@ -1667,10 +1693,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1680,7 +1707,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1713,7 +1740,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1773,10 +1800,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1786,7 +1814,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1819,7 +1847,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1867,12 +1895,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::fuse::Fuse"
-                                  "iter" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::fuse::Fuse",
+                                  "iter"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1914,7 +1943,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -1941,7 +1970,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2020,10 +2049,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2033,7 +2063,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2066,7 +2096,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2129,10 +2159,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2142,7 +2173,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2175,7 +2206,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2238,10 +2269,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2251,7 +2283,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2284,7 +2316,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2333,12 +2365,13 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::fuse::Fuse"
-                                  "iter" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::fuse::Fuse",
+                                  "iter"
+                                |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2380,7 +2413,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -2407,7 +2440,7 @@ Module iter.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -2487,10 +2520,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::fuse::Fuse"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::fuse::Fuse",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2500,7 +2534,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2533,7 +2567,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2607,10 +2641,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::fuse::Fuse"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::fuse::Fuse",
                             "iter"
+                          |)
                         ]
                       |)
                     ]
@@ -2694,7 +2729,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -2725,7 +2760,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0

--- a/CoqOfRust/core/iter/adapters/inspect.v
+++ b/CoqOfRust/core/iter/adapters/inspect.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::inspect::Inspect"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::inspect::Inspect",
                           "iter"
+                        |)
                       ]
                     |));
                   ("f",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::inspect::Inspect"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::inspect::Inspect",
                           "f"
+                        |)
                       ]
                     |))
                 ]))
@@ -108,7 +110,7 @@ Module iter.
                         ltac:(M.monadic
                           (let γ := elt in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -125,10 +127,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::inspect::Inspect"
-                                    "f";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::inspect::Inspect",
+                                    "f"
+                                  |);
                                   Value.Tuple [ M.read (| a |) ]
                                 ]
                               |)
@@ -190,10 +193,11 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::inspect::Inspect"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::inspect::Inspect",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -396,10 +400,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::inspect::Inspect"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::inspect::Inspect",
                           "iter"
+                        |)
                       ]
                     |)
                   |) in
@@ -437,10 +442,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -473,10 +479,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -484,10 +491,11 @@ Module iter.
                       [ Ty.associated; Acc; R; F; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::inspect::Inspect"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::inspect::Inspect",
+                        "f"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -522,7 +530,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::inspect::Inspect" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::inspect::Inspect",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -532,7 +544,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::inspect::Inspect" "f"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::inspect::Inspect",
+                          "f"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -586,10 +602,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::inspect::Inspect"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::inspect::Inspect",
                           "iter"
+                        |)
                       ]
                     |)
                   |) in
@@ -634,10 +651,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -645,10 +663,11 @@ Module iter.
                       [ Ty.associated; Acc; R; F; Fold ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::inspect::Inspect"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::inspect::Inspect",
+                        "f"
+                      |);
                       M.read (| fold |)
                     ]
                   |)
@@ -683,7 +702,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::inspect::Inspect" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::inspect::Inspect",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -693,7 +716,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::inspect::Inspect" "f"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::inspect::Inspect",
+                          "f"
+                        |)
                       |);
                       M.read (| fold |)
                     ]
@@ -741,10 +768,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -770,10 +798,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -840,10 +869,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::inspect::Inspect"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::inspect::Inspect",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/intersperse.v
+++ b/CoqOfRust/core/iter/adapters/intersperse.v
@@ -40,25 +40,28 @@ Module iter.
                   M.read (| Value.String "separator" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::intersperse::Intersperse"
-                      "separator");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::intersperse::Intersperse",
+                      "separator"
+                    |));
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::intersperse::Intersperse"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::intersperse::Intersperse",
+                      "iter"
+                    |));
                   M.read (| Value.String "needs_sep" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::intersperse::Intersperse"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::intersperse::Intersperse",
                         "needs_sep"
+                      |)
                     |))
                 ]
               |)))
@@ -92,10 +95,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", Ty.associated, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::Intersperse"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::Intersperse",
                           "separator"
+                        |)
                       ]
                     |));
                   ("iter",
@@ -108,10 +112,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::Intersperse"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::Intersperse",
                           "iter"
+                        |)
                       ]
                     |));
                   ("needs_sep",
@@ -124,10 +129,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::Intersperse"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::Intersperse",
                           "needs_sep"
+                        |)
                       ]
                     |))
                 ]))
@@ -219,10 +225,11 @@ Module iter.
                             (M.alloc (|
                               LogicalOp.and (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::intersperse::Intersperse"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::intersperse::Intersperse",
                                     "needs_sep"
+                                  |)
                                 |),
                                 ltac:(M.monadic
                                   (M.call_closure (|
@@ -244,10 +251,11 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::intersperse::Intersperse"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::intersperse::Intersperse",
                                               "iter"
+                                            |)
                                           ]
                                         |)
                                       |)
@@ -259,10 +267,11 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::intersperse::Intersperse"
-                              "needs_sep",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::intersperse::Intersperse",
+                              "needs_sep"
+                            |),
                             Value.Bool false
                           |) in
                         M.alloc (|
@@ -278,10 +287,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::intersperse::Intersperse"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::intersperse::Intersperse",
                                     "separator"
+                                  |)
                                 ]
                               |)
                             ]
@@ -290,10 +300,11 @@ Module iter.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::intersperse::Intersperse"
-                              "needs_sep",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::intersperse::Intersperse",
+                              "needs_sep"
+                            |),
                             Value.Bool true
                           |) in
                         M.alloc (|
@@ -306,10 +317,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::intersperse::Intersperse"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::intersperse::Intersperse",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)))
@@ -340,10 +352,11 @@ Module iter.
               M.read (|
                 let separator :=
                   M.copy (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::intersperse::Intersperse"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::intersperse::Intersperse",
                       "separator"
+                    |)
                   |) in
                 M.alloc (|
                   M.call_closure (|
@@ -358,10 +371,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::intersperse::Intersperse"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::intersperse::Intersperse",
                           "iter"
+                        |)
                       |);
                       M.read (| init |);
                       M.read (| f |);
@@ -390,10 +404,11 @@ Module iter.
                             | _ => M.impossible (||)
                             end));
                       M.read (|
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::intersperse::Intersperse"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::intersperse::Intersperse",
                           "needs_sep"
+                        |)
                       |)
                     ]
                   |)
@@ -419,15 +434,17 @@ Module iter.
                   [ Ty.apply (Ty.path "core::iter::adapters::peekable::Peekable") [ I ] ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::intersperse::Intersperse"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::intersperse::Intersperse",
+                    "iter"
+                  |);
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::intersperse::Intersperse"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::intersperse::Intersperse",
                       "needs_sep"
+                    |)
                   |)
                 ]
               |)))
@@ -522,28 +539,31 @@ Module iter.
                               M.read (| Value.String "separator" |);
                               (* Unsize *)
                               M.pointer_coercion
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::intersperse::IntersperseWith"
-                                  "separator")
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::intersperse::IntersperseWith",
+                                  "separator"
+                                |))
                             ]
                           |);
                           M.read (| Value.String "iter" |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::intersperse::IntersperseWith"
-                              "iter")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::intersperse::IntersperseWith",
+                              "iter"
+                            |))
                         ]
                       |);
                       M.read (| Value.String "needs_sep" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::IntersperseWith"
-                          "needs_sep")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::IntersperseWith",
+                          "needs_sep"
+                        |))
                     ]
                   |)
                 ]
@@ -586,10 +606,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", G, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::IntersperseWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::IntersperseWith",
                           "separator"
+                        |)
                       ]
                     |));
                   ("iter",
@@ -602,10 +623,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::IntersperseWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::IntersperseWith",
                           "iter"
+                        |)
                       ]
                     |));
                   ("needs_sep",
@@ -618,10 +640,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::intersperse::IntersperseWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::intersperse::IntersperseWith",
                           "needs_sep"
+                        |)
                       ]
                     |))
                 ]))
@@ -713,10 +736,11 @@ Module iter.
                             (M.alloc (|
                               LogicalOp.and (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::intersperse::IntersperseWith"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::intersperse::IntersperseWith",
                                     "needs_sep"
+                                  |)
                                 |),
                                 ltac:(M.monadic
                                   (M.call_closure (|
@@ -738,10 +762,11 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::intersperse::IntersperseWith"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::intersperse::IntersperseWith",
                                               "iter"
+                                            |)
                                           ]
                                         |)
                                       |)
@@ -753,10 +778,11 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::intersperse::IntersperseWith"
-                              "needs_sep",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::intersperse::IntersperseWith",
+                              "needs_sep"
+                            |),
                             Value.Bool false
                           |) in
                         M.alloc (|
@@ -772,10 +798,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::intersperse::IntersperseWith"
-                                    "separator";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::intersperse::IntersperseWith",
+                                    "separator"
+                                  |);
                                   Value.Tuple []
                                 ]
                               |)
@@ -785,10 +812,11 @@ Module iter.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::intersperse::IntersperseWith"
-                              "needs_sep",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::intersperse::IntersperseWith",
+                              "needs_sep"
+                            |),
                             Value.Bool true
                           |) in
                         M.alloc (|
@@ -801,10 +829,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::intersperse::IntersperseWith"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::intersperse::IntersperseWith",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)))
@@ -838,24 +867,27 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::intersperse::IntersperseWith"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::intersperse::IntersperseWith",
                       "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| f |);
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::intersperse::IntersperseWith"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::intersperse::IntersperseWith",
                       "separator"
+                    |)
                   |);
                   M.read (|
-                    M.get_struct_record_field
-                      self
-                      "core::iter::adapters::intersperse::IntersperseWith"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::intersperse::IntersperseWith",
                       "needs_sep"
+                    |)
                   |)
                 ]
               |)))
@@ -879,15 +911,17 @@ Module iter.
                   [ Ty.apply (Ty.path "core::iter::adapters::peekable::Peekable") [ I ] ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::intersperse::IntersperseWith"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::intersperse::IntersperseWith",
+                    "iter"
+                  |);
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::intersperse::IntersperseWith"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::intersperse::IntersperseWith",
                       "needs_sep"
+                    |)
                   |)
                 ]
               |)))
@@ -945,8 +979,8 @@ Module iter.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let lo := M.copy (| γ0_0 |) in
                       let hi := M.copy (| γ0_1 |) in
                       let next_is_elem := M.alloc (| UnOp.Pure.not (M.read (| needs_sep |)) |) in
@@ -1098,7 +1132,7 @@ Module iter.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0

--- a/CoqOfRust/core/iter/adapters/map.v
+++ b/CoqOfRust/core/iter/adapters/map.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map::Map"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map::Map",
                           "iter"
+                        |)
                       ]
                     |));
                   ("f",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map::Map"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map::Map",
                           "f"
+                        |)
                       ]
                     |))
                 ]))
@@ -128,10 +130,11 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map::Map"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map::Map",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -322,13 +325,18 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::map::Map"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::map::Map",
                         "iter"
+                      |)
                     ]
                   |);
-                  M.get_struct_record_field (M.read (| self |)) "core::iter::adapters::map::Map" "f"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
+                    "f"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -354,10 +362,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -390,10 +399,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -401,10 +411,11 @@ Module iter.
                       [ Ty.associated; B; Acc; R; F; G ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::map::Map"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::map::Map",
+                        "f"
+                      |);
                       M.read (| g |)
                     ]
                   |)
@@ -439,7 +450,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::map::Map" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::map::Map",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -449,7 +464,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::map::Map" "f"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::map::Map",
+                          "f"
+                        |)
                       |);
                       M.read (| g |)
                     ]
@@ -485,19 +504,21 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
-                    "f";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
+                    "f"
+                  |);
                   Value.Tuple
                     [
                       M.call_closure (|
                         M.get_function (| "core::iter::adapters::zip::try_get_unchecked", [ I ] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::map::Map"
-                            "iter";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::map::Map",
+                            "iter"
+                          |);
                           M.read (| idx |)
                         ]
                       |)
@@ -555,13 +576,18 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::map::Map"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::map::Map",
                         "iter"
+                      |)
                     ]
                   |);
-                  M.get_struct_record_field (M.read (| self |)) "core::iter::adapters::map::Map" "f"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
+                    "f"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -594,10 +620,11 @@ Module iter.
                   [ Acc; Ty.associated; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.call_closure (|
                     M.get_function (|
@@ -605,10 +632,11 @@ Module iter.
                       [ Ty.associated; B; Acc; R; F; G ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::map::Map"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::map::Map",
+                        "f"
+                      |);
                       M.read (| g |)
                     ]
                   |)
@@ -643,7 +671,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::map::Map" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::map::Map",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.call_closure (|
@@ -653,7 +685,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::iter::adapters::map::Map" "f"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::map::Map",
+                          "f"
+                        |)
                       |);
                       M.read (| g |)
                     ]
@@ -701,10 +737,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -730,10 +767,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -821,10 +859,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map::Map"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map::Map",
                           "iter"
+                        |)
                       ]
                     |)
                   |) in
@@ -838,10 +877,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::map::Map"
-                        "f";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::map::Map",
+                        "f"
+                      |);
                       Value.Tuple [ M.read (| item |) ]
                     ]
                   |)
@@ -917,10 +957,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map::Map"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map::Map",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/map_while.v
+++ b/CoqOfRust/core/iter/adapters/map_while.v
@@ -29,20 +29,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_while::MapWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_while::MapWhile",
                           "iter"
+                        |)
                       ]
                     |));
                   ("predicate",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_while::MapWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_while::MapWhile",
                           "predicate"
+                        |)
                       ]
                     |))
                 ]))
@@ -128,10 +130,11 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_while::MapWhile"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_while::MapWhile",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -192,10 +195,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::map_while::MapWhile"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::map_while::MapWhile",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -205,7 +209,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -236,7 +240,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -256,10 +260,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::map_while::MapWhile"
-                            "predicate";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::map_while::MapWhile",
+                            "predicate"
+                          |);
                           Value.Tuple [ M.read (| x |) ]
                         ]
                       |)
@@ -293,18 +298,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_while::MapWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_while::MapWhile",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
                           Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -346,13 +352,13 @@ Module iter.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::map_while::MapWhile",
                             "iter"
                           |) in
                         let γ1_1 :=
-                          M.get_struct_record_field_or_break_match (|
+                          M.SubPointer.get_struct_record_field (|
                             γ,
                             "core::iter::adapters::map_while::MapWhile",
                             "predicate"
@@ -428,7 +434,7 @@ Module iter.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -523,8 +529,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -550,9 +556,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -595,10 +602,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map_while::MapWhile"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map_while::MapWhile",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/map_windows.v
+++ b/CoqOfRust/core/iter/adapters/map_windows.v
@@ -332,10 +332,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::map_windows::MapWindowsInner"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::map_windows::MapWindowsInner",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -345,7 +346,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -382,7 +383,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -394,18 +395,20 @@ Module iter.
                       |) in
                     let _ :=
                       M.match_operator (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::MapWindowsInner"
-                          "buffer",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::MapWindowsInner",
+                          "buffer"
+                        |),
                         [
                           fun γ =>
                             ltac:(M.monadic
                               (M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::map_windows::MapWindowsInner"
-                                  "buffer",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::map_windows::MapWindowsInner",
+                                  "buffer"
+                                |),
                                 M.call_closure (|
                                   M.get_associated_function (|
                                     Ty.apply
@@ -420,7 +423,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -451,10 +454,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::map_windows::MapWindowsInner"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::map_windows::MapWindowsInner",
                                                 "iter"
+                                              |)
                                             ]
                                           |)
                                         |) in
@@ -474,10 +478,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::map_windows::MapWindowsInner"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::map_windows::MapWindowsInner",
                                                 "buffer"
+                                              |)
                                             ]
                                           |)
                                         |) in
@@ -485,7 +490,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -553,10 +558,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::map_windows::MapWindowsInner"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::map_windows::MapWindowsInner",
                                 "buffer"
+                              |)
                             ]
                           |);
                           M.get_associated_function (|
@@ -602,15 +608,16 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map_windows::MapWindowsInner"
-                    "iter",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map_windows::MapWindowsInner",
+                    "iter"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -632,8 +639,8 @@ Module iter.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let lo := M.copy (| γ0_0 |) in
                                 let hi := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -658,10 +665,11 @@ Module iter.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::map_windows::MapWindowsInner"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::map_windows::MapWindowsInner",
                                                     "buffer"
+                                                  |)
                                                 ]
                                               |)
                                             |)) in
@@ -828,7 +836,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -866,7 +874,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -971,10 +979,11 @@ Module iter.
                     [
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::Buffer"
-                          "buffer")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::Buffer",
+                          "buffer"
+                        |))
                     ]
                   |)
                 ]
@@ -1025,10 +1034,11 @@ Module iter.
                     [
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::Buffer"
-                          "buffer")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::Buffer",
+                          "buffer"
+                        |))
                     ]
                   |)
                 ]
@@ -1077,10 +1087,11 @@ Module iter.
                                             (BinOp.Pure.le
                                               (BinOp.Panic.add (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::map_windows::Buffer"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::map_windows::Buffer",
                                                     "start"
+                                                  |)
                                                 |),
                                                 M.read (|
                                                   M.get_constant (|
@@ -1150,10 +1161,11 @@ Module iter.
                             [ M.read (| self |) ]
                           |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::map_windows::Buffer"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::map_windows::Buffer",
                               "start"
+                            |)
                           |)
                         ]
                       |)
@@ -1205,10 +1217,11 @@ Module iter.
                                             (BinOp.Pure.le
                                               (BinOp.Panic.add (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::map_windows::Buffer"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::map_windows::Buffer",
                                                     "start"
+                                                  |)
                                                 |),
                                                 M.read (|
                                                   M.get_constant (|
@@ -1282,10 +1295,11 @@ Module iter.
                             [ M.read (| self |) ]
                           |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::map_windows::Buffer"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::map_windows::Buffer",
                               "start"
+                            |)
                           |)
                         ]
                       |)
@@ -1398,10 +1412,11 @@ Module iter.
                                             (BinOp.Pure.le
                                               (BinOp.Panic.add (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::map_windows::Buffer"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::map_windows::Buffer",
                                                     "start"
+                                                  |)
                                                 |),
                                                 M.read (|
                                                   M.get_constant (|
@@ -1455,10 +1470,11 @@ Module iter.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::map_windows::Buffer"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::map_windows::Buffer",
                                         "start"
+                                      |)
                                     |))
                                     (M.read (|
                                       M.get_constant (| "core::iter::adapters::map_windows::N" |)
@@ -1498,10 +1514,11 @@ Module iter.
                                               M.read (| buffer_mut_ptr |);
                                               BinOp.Panic.add (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::iter::adapters::map_windows::Buffer"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::iter::adapters::map_windows::Buffer",
                                                     "start"
+                                                  |)
                                                 |),
                                                 Value.Integer Integer.Usize 1
                                               |)
@@ -1574,10 +1591,11 @@ Module iter.
                                     [
                                       M.read (| buffer_mut_ptr |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::map_windows::Buffer"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::map_windows::Buffer",
                                           "start"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1585,10 +1603,11 @@ Module iter.
                               |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::map_windows::Buffer"
-                                  "start",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::map_windows::Buffer",
+                                  "start"
+                                |),
                                 Value.Integer Integer.Usize 0
                               |) in
                             to_drop));
@@ -1623,10 +1642,11 @@ Module iter.
                                             M.read (| buffer_mut_ptr |);
                                             BinOp.Panic.add (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::map_windows::Buffer"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::map_windows::Buffer",
                                                   "start"
+                                                |)
                                               |),
                                               M.read (|
                                                 M.get_constant (|
@@ -1656,10 +1676,11 @@ Module iter.
                                     [
                                       M.read (| buffer_mut_ptr |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::map_windows::Buffer"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::map_windows::Buffer",
                                           "start"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1667,10 +1688,11 @@ Module iter.
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::map_windows::Buffer"
-                                  "start" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::map_windows::Buffer",
+                                  "start"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1755,10 +1777,11 @@ Module iter.
                             ]);
                         ("start",
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::map_windows::Buffer"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::map_windows::Buffer",
                               "start"
+                            |)
                           |))
                       ]
                   |) in
@@ -1847,10 +1870,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::MapWindowsInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::MapWindowsInner",
                           "iter"
+                        |)
                       ]
                     |));
                   ("buffer",
@@ -1869,10 +1893,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::MapWindowsInner"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::MapWindowsInner",
                           "buffer"
+                        |)
                       ]
                     |))
                 ]))
@@ -1947,10 +1972,11 @@ Module iter.
                                   [ M.read (| self |) ]
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::map_windows::Buffer"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::map_windows::Buffer",
                                     "start"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2035,10 +2061,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::map_windows::MapWindows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::map_windows::MapWindows",
                                       "inner"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -2048,7 +2075,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -2079,7 +2106,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -2107,10 +2134,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::map_windows::MapWindows"
-                              "f";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::map_windows::MapWindows",
+                              "f"
+                            |);
                             Value.Tuple [ M.read (| window |) ]
                           ]
                         |)
@@ -2141,10 +2169,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::map_windows::MapWindows"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::map_windows::MapWindows",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -2233,13 +2262,15 @@ Module iter.
                       M.read (| Value.String "iter" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::map_windows::MapWindows"
-                            "inner")
-                          "core::iter::adapters::map_windows::MapWindowsInner"
-                          "iter")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::map_windows::MapWindows",
+                            "inner"
+                          |),
+                          "core::iter::adapters::map_windows::MapWindowsInner",
+                          "iter"
+                        |))
                     ]
                   |)
                 ]
@@ -2278,10 +2309,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::MapWindows"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::MapWindows",
                           "f"
+                        |)
                       ]
                     |));
                   ("inner",
@@ -2296,10 +2328,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::map_windows::MapWindows"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::map_windows::MapWindows",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))

--- a/CoqOfRust/core/iter/adapters/mod.v
+++ b/CoqOfRust/core/iter/adapters/mod.v
@@ -68,7 +68,7 @@ Module iter.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -193,10 +193,11 @@ Module iter.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::GenericShunt"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::GenericShunt",
                                     "residual"
+                                  |)
                                 |)
                               ]
                             |)
@@ -224,18 +225,19 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::GenericShunt"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::GenericShunt",
                                 "iter"
+                              |)
                             ]
                           |)
                         |),
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let upper := M.copy (| γ0_1 |) in
                               M.alloc (|
                                 Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -295,10 +297,11 @@ Module iter.
                     ]
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::GenericShunt"
-                      "iter";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::GenericShunt",
+                      "iter"
+                    |);
                     M.read (| init |);
                     M.closure
                       (fun γ =>
@@ -335,7 +338,7 @@ Module iter.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                           0
@@ -373,7 +376,7 @@ Module iter.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Break",
                                                           0
@@ -382,10 +385,11 @@ Module iter.
                                                       let _ :=
                                                         M.write (|
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              (M.read (| self |))
-                                                              "core::iter::adapters::GenericShunt"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              M.read (| self |),
+                                                              "core::iter::adapters::GenericShunt",
                                                               "residual"
+                                                            |)
                                                           |),
                                                           Value.StructTuple
                                                             "core::option::Option::Some"
@@ -442,8 +446,8 @@ Module iter.
             let init := M.alloc (| init |) in
             let fold := M.alloc (| fold |) in
             M.read (|
-              M.get_struct_tuple_field
-                (M.alloc (|
+              M.SubPointer.get_struct_tuple_field (|
+                M.alloc (|
                   M.call_closure (|
                     M.get_trait_method (|
                       "core::iter::traits::iterator::Iterator",
@@ -469,9 +473,10 @@ Module iter.
                       |)
                     ]
                   |)
-                |))
-                "core::ops::try_trait::NeverShortCircuit"
+                |),
+                "core::ops::try_trait::NeverShortCircuit",
                 0
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -514,10 +519,11 @@ Module iter.
             M.call_closure (|
               M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::iter::adapters::GenericShunt"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::iter::adapters::GenericShunt",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/peekable.v
+++ b/CoqOfRust/core/iter/adapters/peekable.v
@@ -36,10 +36,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "iter"
+                        |)
                       ]
                     |));
                   ("peeked",
@@ -54,10 +55,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |))
                 ]))
@@ -97,18 +99,20 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::peekable::Peekable"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::peekable::Peekable",
+                      "iter"
+                    |));
                   M.read (| Value.String "peeked" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::peekable::Peekable"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::peekable::Peekable",
                         "peeked"
+                      |)
                     |))
                 ]
               |)))
@@ -166,10 +170,11 @@ Module iter.
               M.read (|
                 let iter :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::peekable::Peekable"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::peekable::Peekable",
                       "iter"
+                    |)
                   |) in
                 M.alloc (|
                   M.call_closure (|
@@ -192,10 +197,11 @@ Module iter.
                           ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::peekable::Peekable"
-                            "peeked";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::peekable::Peekable",
+                            "peeked"
+                          |);
                           M.closure
                             (fun γ =>
                               ltac:(M.monadic
@@ -248,10 +254,11 @@ Module iter.
               M.read (|
                 let iter :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::peekable::Peekable"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::peekable::Peekable",
                       "iter"
+                    |)
                   |) in
                 M.alloc (|
                   M.call_closure (|
@@ -274,10 +281,11 @@ Module iter.
                           ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::peekable::Peekable"
-                            "peeked";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::peekable::Peekable",
+                            "peeked"
+                          |);
                           M.closure
                             (fun γ =>
                               ltac:(M.monadic
@@ -353,7 +361,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -403,10 +411,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::peekable::Peekable"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::peekable::Peekable",
                                                 "peeked"
+                                              |)
                                             ]
                                           |))
                                       |)) in
@@ -432,10 +441,11 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::peekable::Peekable"
-                              "peeked",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::peekable::Peekable",
+                              "peeked"
+                            |),
                             Value.StructTuple "core::option::Option::Some" [ M.read (| other |) ]
                           |) in
                         M.alloc (| Value.StructTuple "core::option::Option::None" [] |)))
@@ -545,10 +555,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |)
                   |),
@@ -556,7 +567,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -575,10 +586,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::peekable::Peekable"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::peekable::Peekable",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)))
@@ -615,10 +627,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          self
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |)
                   |),
@@ -626,7 +639,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -635,13 +648,13 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -659,10 +672,11 @@ Module iter.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::peekable::Peekable"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::peekable::Peekable",
                                     "iter"
+                                  |)
                                 |)
                               ]
                             |)
@@ -681,10 +695,11 @@ Module iter.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::peekable::Peekable"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::peekable::Peekable",
                                   "iter"
+                                |)
                               |)
                             ]
                           |)
@@ -724,10 +739,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |)
                   |),
@@ -735,7 +751,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -744,14 +760,14 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let v := M.copy (| γ0_0 |) in
                         let γ2_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -766,13 +782,13 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -787,10 +803,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::peekable::Peekable"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::peekable::Peekable",
+                                "iter"
+                              |);
                               BinOp.Panic.sub (| M.read (| n |), Value.Integer Integer.Usize 1 |)
                             ]
                           |)
@@ -807,10 +824,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::peekable::Peekable"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::peekable::Peekable",
+                                "iter"
+                              |);
                               M.read (| n |)
                             ]
                           |)
@@ -853,10 +871,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::peekable::Peekable"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::peekable::Peekable",
                                   "peeked"
+                                |)
                               ]
                             |)
                           |),
@@ -864,7 +883,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -881,7 +900,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -912,10 +931,11 @@ Module iter.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::peekable::Peekable"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::peekable::Peekable",
                                   "iter"
+                                |)
                               |)
                             ]
                           |);
@@ -956,15 +976,16 @@ Module iter.
                     let peek_len :=
                       M.copy (|
                         M.match_operator (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::peekable::Peekable"
-                            "peeked",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::peekable::Peekable",
+                            "peeked"
+                          |),
                           [
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -987,13 +1008,13 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "core::option::Option::Some",
                                     0
@@ -1014,18 +1035,19 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::peekable::Peekable"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::peekable::Peekable",
                               "iter"
+                            |)
                           ]
                         |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let lo := M.copy (| γ0_0 |) in
                             let hi := M.copy (| γ0_1 |) in
                             let lo :=
@@ -1047,7 +1069,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1118,10 +1140,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::peekable::Peekable"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::peekable::Peekable",
                                   "peeked"
+                                |)
                               ]
                             |)
                           |),
@@ -1129,7 +1152,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1155,13 +1178,13 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "core::option::Option::Some",
                                     0
@@ -1195,7 +1218,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -1222,7 +1245,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -1245,10 +1268,11 @@ Module iter.
                           [ B; F; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::peekable::Peekable"
-                            "iter";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::peekable::Peekable",
+                            "iter"
+                          |);
                           M.read (| acc |);
                           M.read (| f |)
                         ]
@@ -1286,15 +1310,16 @@ Module iter.
                     let acc :=
                       M.copy (|
                         M.match_operator (|
-                          M.get_struct_record_field
-                            self
-                            "core::iter::adapters::peekable::Peekable"
-                            "peeked",
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::peekable::Peekable",
+                            "peeked"
+                          |),
                           [
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1307,13 +1332,13 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
                                 let γ1_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "core::option::Option::Some",
                                     0
@@ -1346,10 +1371,11 @@ Module iter.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::peekable::Peekable"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::peekable::Peekable",
                               "iter"
+                            |)
                           |);
                           M.read (| acc |);
                           M.read (| fold |)
@@ -1411,10 +1437,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |)
                   |),
@@ -1422,7 +1449,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1430,7 +1457,7 @@ Module iter.
                         let v := M.copy (| γ0_0 |) in
                         let γ0_0 := M.read (| γ0_0 |) in
                         let γ3_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -1456,10 +1483,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::peekable::Peekable"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::peekable::Peekable",
                                     "iter"
+                                  |)
                                 ]
                               |);
                               M.closure
@@ -1492,7 +1520,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1511,10 +1539,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::peekable::Peekable"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::peekable::Peekable",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)))
@@ -1564,10 +1593,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::peekable::Peekable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::peekable::Peekable",
                           "peeked"
+                        |)
                       ]
                     |)
                   |),
@@ -1575,7 +1605,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1595,13 +1625,13 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -1627,10 +1657,11 @@ Module iter.
                                     [ B; Ty.apply (Ty.path "&mut") [ F ]; R ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::peekable::Peekable"
-                                      "iter";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::peekable::Peekable",
+                                      "iter"
+                                    |);
                                     M.read (| init |);
                                     f
                                   ]
@@ -1642,7 +1673,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1663,7 +1694,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1671,10 +1702,11 @@ Module iter.
                                 let r := M.copy (| γ0_0 |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::peekable::Peekable"
-                                      "peeked",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::peekable::Peekable",
+                                      "peeked"
+                                    |),
                                     Value.StructTuple
                                       "core::option::Option::Some"
                                       [
@@ -1709,10 +1741,11 @@ Module iter.
                               [ B; F; R ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::peekable::Peekable"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::peekable::Peekable",
+                                "iter"
+                              |);
                               M.read (| init |);
                               M.read (| f |)
                             ]
@@ -1749,15 +1782,16 @@ Module iter.
               let fold := M.alloc (| fold |) in
               M.read (|
                 M.match_operator (|
-                  M.get_struct_record_field
-                    self
-                    "core::iter::adapters::peekable::Peekable"
-                    "peeked",
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::iter::adapters::peekable::Peekable",
+                    "peeked"
+                  |),
                   [
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1766,13 +1800,13 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
@@ -1790,10 +1824,11 @@ Module iter.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::peekable::Peekable"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::peekable::Peekable",
                                     "iter"
+                                  |)
                                 |);
                                 M.read (| init |);
                                 fold
@@ -1825,10 +1860,11 @@ Module iter.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::peekable::Peekable"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::peekable::Peekable",
                                   "iter"
+                                |)
                               |);
                               M.read (| init |);
                               M.read (| fold |)
@@ -1917,10 +1953,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::peekable::Peekable"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::peekable::Peekable",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/rev.v
+++ b/CoqOfRust/core/iter/adapters/rev.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::rev::Rev"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::rev::Rev",
                           "iter"
+                        |)
                       ]
                     |))
                 ]))
@@ -73,10 +74,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::rev::Rev"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::rev::Rev",
                         "iter"
+                      |)
                     |))
                 ]
               |)))
@@ -143,10 +145,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -172,10 +175,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -202,10 +206,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -233,10 +238,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -270,10 +276,11 @@ Module iter.
                   [ B; F; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.read (| f |)
                 ]
@@ -307,7 +314,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::rev::Rev" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::rev::Rev",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| f |)
@@ -340,10 +351,11 @@ Module iter.
                   [ P ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| predicate |)
                 ]
               |)))
@@ -393,10 +405,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -423,10 +436,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -448,10 +462,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::traits::iterator::Iterator", I, [], "nth", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| n |)
                 ]
               |)))
@@ -485,10 +500,11 @@ Module iter.
                   [ B; F; R ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| init |);
                   M.read (| f |)
                 ]
@@ -522,7 +538,11 @@ Module iter.
                 |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "core::iter::adapters::rev::Rev" "iter"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::rev::Rev",
+                      "iter"
+                    |)
                   |);
                   M.read (| init |);
                   M.read (| f |)
@@ -555,10 +575,11 @@ Module iter.
                   [ P ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
+                    "iter"
+                  |);
                   M.read (| predicate |)
                 ]
               |)))
@@ -606,10 +627,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -635,10 +657,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::rev::Rev"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::rev::Rev",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/scan.v
+++ b/CoqOfRust/core/iter/adapters/scan.v
@@ -29,30 +29,33 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::scan::Scan"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::scan::Scan",
                           "iter"
+                        |)
                       ]
                     |));
                   ("f",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::scan::Scan"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::scan::Scan",
                           "f"
+                        |)
                       ]
                     |));
                   ("state",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", St, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::scan::Scan"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::scan::Scan",
                           "state"
+                        |)
                       ]
                     |))
                 ]))
@@ -147,19 +150,21 @@ Module iter.
                           M.read (| Value.String "iter" |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::scan::Scan"
-                              "iter")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::scan::Scan",
+                              "iter"
+                            |))
                         ]
                       |);
                       M.read (| Value.String "state" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::scan::Scan"
-                          "state")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::scan::Scan",
+                          "state"
+                        |))
                     ]
                   |)
                 ]
@@ -220,10 +225,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::scan::Scan"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::scan::Scan",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -233,7 +239,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -264,7 +270,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -284,16 +290,18 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::scan::Scan"
-                            "f";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::scan::Scan",
+                            "f"
+                          |);
                           Value.Tuple
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::scan::Scan"
-                                "state";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::scan::Scan",
+                                "state"
+                              |);
                               M.read (| a |)
                             ]
                         ]
@@ -328,18 +336,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::scan::Scan"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::scan::Scan",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
                           Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -384,17 +393,19 @@ Module iter.
               M.read (|
                 let state :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::scan::Scan"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::scan::Scan",
                       "state"
+                    |)
                   |) in
                 let f :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::scan::Scan"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::scan::Scan",
                       "f"
+                    |)
                   |) in
                 M.alloc (|
                   M.call_closure (|
@@ -419,10 +430,11 @@ Module iter.
                           ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::scan::Scan"
-                            "iter";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::scan::Scan",
+                            "iter"
+                          |);
                           M.read (| init |);
                           M.call_closure (|
                             M.get_associated_function (| Self, "scan.try_fold", [] |),
@@ -456,8 +468,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -483,9 +495,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -528,10 +541,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::scan::Scan"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::scan::Scan",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/skip.v
+++ b/CoqOfRust/core/iter/adapters/skip.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
                           "iter"
+                        |)
                       ]
                     |));
                   ("n",
@@ -45,10 +46,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
                           "n"
+                        |)
                       ]
                     |))
                 ]))
@@ -88,18 +90,20 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::skip::Skip"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::skip::Skip",
+                      "iter"
+                    |));
                   M.read (| Value.String "n" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::skip::Skip"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::skip::Skip",
                         "n"
+                      |)
                     |))
                 ]
               |)))
@@ -178,10 +182,11 @@ Module iter.
                                 [
                                   BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::skip::Skip"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::skip::Skip",
                                         "n"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 ]
@@ -199,17 +204,19 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::skip::Skip"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::skip::Skip",
+                                "iter"
+                              |);
                               M.call_closure (|
                                 M.get_function (| "core::mem::take", [ Ty.path "usize" ] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::skip::Skip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::skip::Skip",
                                     "n"
+                                  |)
                                 ]
                               |)
                             ]
@@ -227,10 +234,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::skip::Skip"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::skip::Skip",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)))
@@ -282,10 +290,11 @@ Module iter.
                                 (M.alloc (|
                                   BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::skip::Skip"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::skip::Skip",
                                         "n"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -296,10 +305,11 @@ Module iter.
                                 M.call_closure (|
                                   M.get_function (| "core::mem::take", [ Ty.path "usize" ] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::skip::Skip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::skip::Skip",
                                       "n"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -320,7 +330,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -352,10 +362,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::iter::adapters::skip::Skip"
-                                                        "iter";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::iter::adapters::skip::Skip",
+                                                        "iter"
+                                                      |);
                                                       BinOp.Panic.sub (|
                                                         M.read (| skip |),
                                                         Value.Integer Integer.Usize 1
@@ -369,7 +380,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -405,7 +416,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -428,10 +439,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::skip::Skip"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::skip::Skip",
+                                    "iter"
+                                  |);
                                   M.read (| n |)
                                 ]
                               |)
@@ -448,10 +460,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::skip::Skip"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::skip::Skip",
+                                    "iter"
+                                  |);
                                   M.read (| n |)
                                 ]
                               |)
@@ -494,10 +507,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.gt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::skip::Skip"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::skip::Skip",
                                           "n"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -533,16 +547,18 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        self
-                                                        "core::iter::adapters::skip::Skip"
-                                                        "iter";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        self,
+                                                        "core::iter::adapters::skip::Skip",
+                                                        "iter"
+                                                      |);
                                                       BinOp.Panic.sub (|
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            self
-                                                            "core::iter::adapters::skip::Skip"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            self,
+                                                            "core::iter::adapters::skip::Skip",
                                                             "n"
+                                                          |)
                                                         |),
                                                         Value.Integer Integer.Usize 1
                                                       |)
@@ -579,7 +595,11 @@ Module iter.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field self "core::iter::adapters::skip::Skip" "iter"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::skip::Skip",
+                              "iter"
+                            |)
                           |)
                         ]
                       |)
@@ -618,10 +638,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.gt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::skip::Skip"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::skip::Skip",
                                           "n"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -651,16 +672,18 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              self
-                                              "core::iter::adapters::skip::Skip"
-                                              "iter";
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "core::iter::adapters::skip::Skip",
+                                              "iter"
+                                            |);
                                             BinOp.Panic.sub (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::iter::adapters::skip::Skip"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::iter::adapters::skip::Skip",
                                                   "n"
+                                                |)
                                               |),
                                               Value.Integer Integer.Usize 1
                                             |)
@@ -673,7 +696,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -706,7 +729,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -730,7 +753,11 @@ Module iter.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field self "core::iter::adapters::skip::Skip" "iter"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::skip::Skip",
+                              "iter"
+                            |)
                           |)
                         ]
                       |)
@@ -771,18 +798,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let lower := M.copy (| γ0_0 |) in
                         let upper := M.copy (| γ0_1 |) in
                         let lower :=
@@ -792,10 +820,11 @@ Module iter.
                               [
                                 M.read (| lower |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::skip::Skip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::skip::Skip",
                                     "n"
+                                  |)
                                 |)
                               ]
                             |)
@@ -808,7 +837,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -827,10 +856,11 @@ Module iter.
                                             [
                                               M.read (| x |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::skip::Skip"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::skip::Skip",
                                                   "n"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -882,17 +912,19 @@ Module iter.
                   (M.read (|
                     let n :=
                       M.copy (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
                           "n"
+                        |)
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
-                          "n",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
+                          "n"
+                        |),
                         Value.Integer Integer.Usize 0
                       |) in
                     let _ :=
@@ -938,10 +970,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::iter::adapters::skip::Skip"
-                                                        "iter";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::iter::adapters::skip::Skip",
+                                                        "iter"
+                                                      |);
                                                       BinOp.Panic.sub (|
                                                         M.read (| n |),
                                                         Value.Integer Integer.Usize 1
@@ -991,10 +1024,11 @@ Module iter.
                           [ Acc; Fold; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::skip::Skip"
-                            "iter";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::skip::Skip",
+                            "iter"
+                          |);
                           M.read (| init |);
                           M.read (| fold |)
                         ]
@@ -1041,10 +1075,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.gt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::skip::Skip"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::skip::Skip",
                                           "n"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -1080,16 +1115,18 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        self
-                                                        "core::iter::adapters::skip::Skip"
-                                                        "iter";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        self,
+                                                        "core::iter::adapters::skip::Skip",
+                                                        "iter"
+                                                      |);
                                                       BinOp.Panic.sub (|
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            self
-                                                            "core::iter::adapters::skip::Skip"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            self,
+                                                            "core::iter::adapters::skip::Skip",
                                                             "n"
+                                                          |)
                                                         |),
                                                         Value.Integer Integer.Usize 1
                                                       |)
@@ -1126,7 +1163,11 @@ Module iter.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field self "core::iter::adapters::skip::Skip" "iter"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::skip::Skip",
+                              "iter"
+                            |)
                           |);
                           M.read (| init |);
                           M.read (| fold |)
@@ -1172,10 +1213,11 @@ Module iter.
               M.read (|
                 let skip_inner :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::skip::Skip"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::skip::Skip",
                       "n"
+                    |)
                   |) in
                 let skip_and_advance :=
                   M.alloc (|
@@ -1197,10 +1239,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::skip::Skip"
-                              "iter";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::skip::Skip",
+                              "iter"
+                            |);
                             M.read (| skip_and_advance |)
                           ]
                         |)
@@ -1209,7 +1252,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -1218,7 +1261,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -1255,18 +1298,20 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::skip::Skip"
-                      "n",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::skip::Skip",
+                      "n"
+                    |),
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "usize", "saturating_sub", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::skip::Skip"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::skip::Skip",
                             "n"
+                          |)
                         |);
                         M.read (| advanced_inner |)
                       ]
@@ -1312,10 +1357,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::skip::Skip"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::skip::Skip",
+                                        "iter"
+                                      |);
                                       M.read (| n |)
                                     ]
                                   |)
@@ -1324,7 +1370,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::result::Result::Ok",
                                           0
@@ -1333,7 +1379,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::result::Result::Err",
                                           0
@@ -1477,10 +1523,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::skip::Skip"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::skip::Skip",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)));
@@ -1549,10 +1596,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::skip::Skip"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::skip::Skip",
+                                "iter"
+                              |);
                               M.read (| n |)
                             ]
                           |)
@@ -1588,10 +1636,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::skip::Skip"
-                                            "iter";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::skip::Skip",
+                                            "iter"
+                                          |);
                                           BinOp.Panic.sub (|
                                             M.read (| len |),
                                             Value.Integer Integer.Usize 1
@@ -1707,10 +1756,11 @@ Module iter.
                                   ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::skip::Skip"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::skip::Skip",
+                                    "iter"
+                                  |);
                                   M.read (| init |);
                                   M.call_closure (|
                                     M.get_associated_function (| Self, "check.try_rfold", [] |),
@@ -1746,8 +1796,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::double_ended::DoubleEndedIterator",
@@ -1773,9 +1823,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -1828,10 +1879,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip::Skip"
-                          "iter";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip::Skip",
+                          "iter"
+                        |);
                         M.read (| min |)
                       ]
                     |)
@@ -1990,10 +2042,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::skip::Skip"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::skip::Skip",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/skip_while.v
+++ b/CoqOfRust/core/iter/adapters/skip_while.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip_while::SkipWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip_while::SkipWhile",
                           "iter"
+                        |)
                       ]
                     |));
                   ("flag",
@@ -45,20 +46,22 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip_while::SkipWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip_while::SkipWhile",
                           "flag"
+                        |)
                       ]
                     |));
                   ("predicate",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip_while::SkipWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip_while::SkipWhile",
                           "predicate"
+                        |)
                       ]
                     |))
                 ]))
@@ -155,19 +158,21 @@ Module iter.
                           M.read (| Value.String "iter" |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::skip_while::SkipWhile"
-                              "iter")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::skip_while::SkipWhile",
+                              "iter"
+                            |))
                         ]
                       |);
                       M.read (| Value.String "flag" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip_while::SkipWhile"
-                          "flag")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip_while::SkipWhile",
+                          "flag"
+                        |))
                     ]
                   |)
                 ]
@@ -221,17 +226,19 @@ Module iter.
               M.read (|
                 let flag :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::skip_while::SkipWhile"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::skip_while::SkipWhile",
                       "flag"
+                    |)
                   |) in
                 let pred :=
                   M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::skip_while::SkipWhile"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::skip_while::SkipWhile",
                       "predicate"
+                    |)
                   |) in
                 M.alloc (|
                   M.call_closure (|
@@ -243,10 +250,11 @@ Module iter.
                       [ Ty.associated ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::skip_while::SkipWhile"
-                        "iter";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::skip_while::SkipWhile",
+                        "iter"
+                      |);
                       M.call_closure (|
                         M.get_associated_function (| Self, "check.next", [] |),
                         [ M.read (| flag |); M.read (| pred |) ]
@@ -282,18 +290,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::skip_while::SkipWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::skip_while::SkipWhile",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let upper := M.copy (| γ0_1 |) in
                         M.alloc (|
                           Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -342,10 +351,11 @@ Module iter.
                                   (M.alloc (|
                                     UnOp.Pure.not
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::skip_while::SkipWhile"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::skip_while::SkipWhile",
                                           "flag"
+                                        |)
                                       |))
                                   |)) in
                               let _ :=
@@ -372,7 +382,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -413,7 +423,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -440,7 +450,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -486,10 +496,11 @@ Module iter.
                           [ Acc; Fold; R ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::skip_while::SkipWhile"
-                            "iter";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::skip_while::SkipWhile",
+                            "iter"
+                          |);
                           M.read (| init |);
                           M.read (| fold |)
                         ]
@@ -536,10 +547,11 @@ Module iter.
                                   (M.alloc (|
                                     UnOp.Pure.not
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::skip_while::SkipWhile"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::skip_while::SkipWhile",
                                           "flag"
+                                        |)
                                       |))
                                   |)) in
                               let _ :=
@@ -566,7 +578,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -609,10 +621,11 @@ Module iter.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              self
-                              "core::iter::adapters::skip_while::SkipWhile"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::skip_while::SkipWhile",
                               "iter"
+                            |)
                           |);
                           M.read (| init |);
                           M.read (| fold |)
@@ -688,10 +701,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::skip_while::SkipWhile"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::skip_while::SkipWhile",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/step_by.v
+++ b/CoqOfRust/core/iter/adapters/step_by.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::step_by::StepBy"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::step_by::StepBy",
                           "iter"
+                        |)
                       ]
                     |));
                   ("step",
@@ -45,10 +46,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::step_by::StepBy"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::step_by::StepBy",
                           "step"
+                        |)
                       ]
                     |));
                   ("first_take",
@@ -61,10 +63,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::step_by::StepBy"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::step_by::StepBy",
                           "first_take"
+                        |)
                       ]
                     |))
                 ]))
@@ -104,25 +107,28 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::step_by::StepBy"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::step_by::StepBy",
+                      "iter"
+                    |));
                   M.read (| Value.String "step" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::step_by::StepBy"
-                      "step");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::step_by::StepBy",
+                      "step"
+                    |));
                   M.read (| Value.String "first_take" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
                         "first_take"
+                      |)
                     |))
                 ]
               |)))
@@ -239,18 +245,20 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
                             "iter"
+                          |)
                         ]
                       |),
                       BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
                             "step"
+                          |)
                         |),
                         Value.Integer Integer.Usize 1
                       |)
@@ -263,10 +271,11 @@ Module iter.
                       ltac:(M.monadic
                         (let γ :=
                           M.use
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::step_by::StepBy"
-                              "first_take") in
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::step_by::StepBy",
+                              "first_take"
+                            |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         M.match_operator (|
@@ -286,10 +295,11 @@ Module iter.
                                     M.read (| γ |),
                                     Value.Bool true
                                   |) in
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
-                                  "step"));
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
+                                  "step"
+                                |)));
                             fun γ =>
                               ltac:(M.monadic
                                 (M.alloc (|
@@ -677,28 +687,31 @@ Module iter.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
-                                  "first_take") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
+                                  "first_take"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (| Value.Integer Integer.Usize 0 |)));
                         fun γ =>
                           ltac:(M.monadic
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::step_by::StepBy"
-                              "step"))
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::step_by::StepBy",
+                              "step"
+                            |)))
                       ]
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::step_by::StepBy"
-                      "first_take",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::step_by::StepBy",
+                      "first_take"
+                    |),
                     Value.Bool false
                   |) in
                 M.alloc (|
@@ -711,10 +724,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |);
                       M.read (| step_size |)
                     ]
                   |)
@@ -764,18 +778,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::step_by::StepBy"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::step_by::StepBy",
                           "iter"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let low := M.copy (| γ0_0 |) in
                         let high := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -785,10 +800,11 @@ Module iter.
                               ltac:(M.monadic
                                 (let γ :=
                                   M.use
-                                    (M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::step_by::StepBy"
-                                      "first_take") in
+                                    (M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::step_by::StepBy",
+                                      "first_take"
+                                    |)) in
                                 let _ :=
                                   M.is_constant_or_break_match (|
                                     M.read (| γ |),
@@ -804,10 +820,11 @@ Module iter.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::step_by::StepBy"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::step_by::StepBy",
                                             "step"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -849,10 +866,11 @@ Module iter.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::step_by::StepBy"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::step_by::StepBy",
                                             "step"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -953,10 +971,11 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.use
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take") in
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |)) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ |),
@@ -964,10 +983,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |),
                                   Value.Bool false
                                 |) in
                               let first :=
@@ -981,10 +1001,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::step_by::StepBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::step_by::StepBy",
                                         "iter"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -1031,10 +1052,11 @@ Module iter.
                       M.alloc (|
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::step_by::StepBy"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::step_by::StepBy",
                               "step"
+                            |)
                           |),
                           Value.Integer Integer.Usize 1
                         |)
@@ -1068,10 +1090,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::step_by::StepBy"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::step_by::StepBy",
+                                        "iter"
+                                      |);
                                       BinOp.Panic.sub (|
                                         M.read (| step |),
                                         Value.Integer Integer.Usize 1
@@ -1153,10 +1176,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::step_by::StepBy"
-                                                      "iter";
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::step_by::StepBy",
+                                                      "iter"
+                                                    |);
                                                     BinOp.Panic.sub (|
                                                       M.call_closure (|
                                                         M.get_associated_function (|
@@ -1256,10 +1280,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::step_by::StepBy"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::step_by::StepBy",
+                                        "iter"
+                                      |);
                                       BinOp.Panic.sub (|
                                         M.read (| nth |),
                                         Value.Integer Integer.Usize 1
@@ -1317,10 +1342,11 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.use
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take") in
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |)) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ |),
@@ -1328,10 +1354,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |),
                                   Value.Bool false
                                 |) in
                               M.match_operator (|
@@ -1345,10 +1372,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::step_by::StepBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::step_by::StepBy",
                                         "iter"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -1376,7 +1404,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -1417,7 +1445,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -1444,7 +1472,7 @@ Module iter.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -1482,15 +1510,17 @@ Module iter.
                                 M.call_closure (|
                                   M.get_associated_function (| Self, "nth.spec_try_fold", [] |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::step_by::StepBy"
-                                      "iter";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::step_by::StepBy",
+                                      "iter"
+                                    |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::step_by::StepBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::step_by::StepBy",
                                         "step"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -1546,10 +1576,11 @@ Module iter.
                             ltac:(M.monadic
                               (let γ :=
                                 M.use
-                                  (M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take") in
+                                  (M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |)) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ |),
@@ -1557,10 +1588,11 @@ Module iter.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "first_take",
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "first_take"
+                                  |),
                                   Value.Bool false
                                 |) in
                               M.match_operator (|
@@ -1574,10 +1606,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        self
-                                        "core::iter::adapters::step_by::StepBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::iter::adapters::step_by::StepBy",
                                         "iter"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -1592,7 +1625,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -1637,15 +1670,17 @@ Module iter.
                               M.call_closure (|
                                 M.get_associated_function (| Self, "nth.spec_fold", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::step_by::StepBy"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::step_by::StepBy",
+                                    "iter"
+                                  |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::iter::adapters::step_by::StepBy"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::iter::adapters::step_by::StepBy",
                                       "step"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -1705,10 +1740,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::step_by::StepBy"
-                    "iter";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::step_by::StepBy",
+                    "iter"
+                  |);
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "core::iter::adapters::step_by::StepBy") [ I ],
@@ -1751,10 +1787,11 @@ Module iter.
                             M.read (| n |);
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -1781,10 +1818,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |);
                       M.read (| n |)
                     ]
                   |)
@@ -1858,7 +1896,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -1894,7 +1932,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -1921,7 +1959,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -1957,15 +1995,17 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::step_by::StepBy"
-                                              "iter";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::step_by::StepBy",
+                                              "iter"
+                                            |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::step_by::StepBy"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::step_by::StepBy",
                                                 "step"
+                                              |)
                                             |)
                                           ]
                                         |)
@@ -2034,7 +2074,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -2074,15 +2114,17 @@ Module iter.
                                   M.call_closure (|
                                     M.get_associated_function (| Self, "nth_back.spec_rfold", [] |),
                                     [
-                                      M.get_struct_record_field
-                                        self
-                                        "core::iter::adapters::step_by::StepBy"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::iter::adapters::step_by::StepBy",
+                                        "iter"
+                                      |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::step_by::StepBy"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::step_by::StepBy",
                                           "step"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -2138,8 +2180,8 @@ Module iter.
               M.read (|
                 let inner_len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::traits::iterator::Iterator",
@@ -2150,8 +2192,9 @@ Module iter.
                           |),
                           [ r ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let yield_count :=
                   M.alloc (|
@@ -2162,7 +2205,7 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field r "core::ops::range::Range" "end",
+                    M.SubPointer.get_struct_record_field (| r, "core::ops::range::Range", "end" |),
                     M.rust_cast (M.read (| yield_count |))
                   |) in
                 r
@@ -2232,10 +2275,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -2247,13 +2291,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -2269,23 +2315,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let val :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "start",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "start"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (| Ty.path "u8", "wrapping_add", [] |),
                               [ M.read (| val |); M.read (| step |) ]
@@ -2293,13 +2343,15 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (| M.read (| remaining |), Value.Integer Integer.U8 1 |)
                           |) in
                         M.alloc (|
@@ -2330,13 +2382,15 @@ Module iter.
                   M.alloc (|
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
-                            "iter")
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
+                            "iter"
+                          |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |))
                   |) in
                 M.alloc (|
@@ -2411,7 +2465,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -2444,7 +2498,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -2524,7 +2578,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -2566,7 +2620,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -2593,7 +2647,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -2688,10 +2742,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -2703,24 +2758,28 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 let acc := M.copy (| init |) in
                 let val :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "start"
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -2775,7 +2834,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -2874,8 +2933,8 @@ Module iter.
               M.read (|
                 let inner_len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::traits::iterator::Iterator",
@@ -2886,8 +2945,9 @@ Module iter.
                           |),
                           [ r ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let yield_count :=
                   M.alloc (|
@@ -2898,7 +2958,7 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field r "core::ops::range::Range" "end",
+                    M.SubPointer.get_struct_record_field (| r, "core::ops::range::Range", "end" |),
                     M.rust_cast (M.read (| yield_count |))
                   |) in
                 r
@@ -2968,10 +3028,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -2983,13 +3044,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -3005,23 +3068,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let val :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "start",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "start"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (| Ty.path "u16", "wrapping_add", [] |),
                               [ M.read (| val |); M.read (| step |) ]
@@ -3029,13 +3096,15 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.U16 1
@@ -3069,13 +3138,15 @@ Module iter.
                   M.alloc (|
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
-                            "iter")
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
+                            "iter"
+                          |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |))
                   |) in
                 M.alloc (|
@@ -3150,7 +3221,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -3183,7 +3254,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -3263,7 +3334,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -3305,7 +3376,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -3332,7 +3403,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -3427,10 +3498,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -3442,24 +3514,28 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 let acc := M.copy (| init |) in
                 let val :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "start"
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -3514,7 +3590,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -3613,8 +3689,8 @@ Module iter.
               M.read (|
                 let inner_len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::traits::iterator::Iterator",
@@ -3625,8 +3701,9 @@ Module iter.
                           |),
                           [ r ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let yield_count :=
                   M.alloc (|
@@ -3637,7 +3714,7 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field r "core::ops::range::Range" "end",
+                    M.SubPointer.get_struct_record_field (| r, "core::ops::range::Range", "end" |),
                     M.rust_cast (M.read (| yield_count |))
                   |) in
                 r
@@ -3707,10 +3784,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -3722,13 +3800,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -3744,23 +3824,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let val :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "start",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "start"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (| Ty.path "u32", "wrapping_add", [] |),
                               [ M.read (| val |); M.read (| step |) ]
@@ -3768,13 +3852,15 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.U32 1
@@ -3808,13 +3894,15 @@ Module iter.
                   M.alloc (|
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
-                            "iter")
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
+                            "iter"
+                          |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |))
                   |) in
                 M.alloc (|
@@ -3889,7 +3977,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -3922,7 +4010,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -4002,7 +4090,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -4044,7 +4132,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -4071,7 +4159,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -4166,10 +4254,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -4181,24 +4270,28 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 let acc := M.copy (| init |) in
                 let val :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "start"
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -4253,7 +4346,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -4352,8 +4445,8 @@ Module iter.
               M.read (|
                 let inner_len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::traits::iterator::Iterator",
@@ -4364,8 +4457,9 @@ Module iter.
                           |),
                           [ r ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let yield_count :=
                   M.alloc (|
@@ -4376,7 +4470,7 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field r "core::ops::range::Range" "end",
+                    M.SubPointer.get_struct_record_field (| r, "core::ops::range::Range", "end" |),
                     M.rust_cast (M.read (| yield_count |))
                   |) in
                 r
@@ -4446,10 +4540,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -4461,13 +4556,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -4483,23 +4580,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let val :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "start",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "start"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                               [ M.read (| val |); M.read (| step |) ]
@@ -4507,13 +4608,15 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.U64 1
@@ -4547,13 +4650,15 @@ Module iter.
                   M.alloc (|
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
-                            "iter")
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
+                            "iter"
+                          |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |))
                   |) in
                 M.alloc (|
@@ -4628,7 +4733,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -4661,7 +4766,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -4741,7 +4846,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -4783,7 +4888,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -4810,7 +4915,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -4905,10 +5010,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -4920,24 +5026,28 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 let acc := M.copy (| init |) in
                 let val :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "start"
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -4992,7 +5102,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -5091,8 +5201,8 @@ Module iter.
               M.read (|
                 let inner_len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::traits::iterator::Iterator",
@@ -5103,8 +5213,9 @@ Module iter.
                           |),
                           [ r ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let yield_count :=
                   M.alloc (|
@@ -5115,7 +5226,7 @@ Module iter.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field r "core::ops::range::Range" "end",
+                    M.SubPointer.get_struct_record_field (| r, "core::ops::range::Range", "end" |),
                     M.read (| M.use yield_count |)
                   |) in
                 r
@@ -5185,10 +5296,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -5200,13 +5312,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -5222,23 +5336,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let val :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "start",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "start"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (| Ty.path "usize", "wrapping_add", [] |),
                               [ M.read (| val |); M.read (| step |) ]
@@ -5246,13 +5364,15 @@ Module iter.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.Usize 1
@@ -5285,13 +5405,15 @@ Module iter.
                 let remaining :=
                   M.copy (|
                     M.use
-                      (M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::step_by::StepBy"
-                          "iter")
-                        "core::ops::range::Range"
-                        "end")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::step_by::StepBy",
+                          "iter"
+                        |),
+                        "core::ops::range::Range",
+                        "end"
+                      |))
                   |) in
                 M.alloc (|
                   Value.Tuple
@@ -5365,7 +5487,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -5398,7 +5520,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -5478,7 +5600,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -5520,7 +5642,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -5547,7 +5669,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -5642,10 +5764,11 @@ Module iter.
                           [
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::step_by::StepBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::step_by::StepBy",
                                   "step"
+                                |)
                               |),
                               Value.Integer Integer.Usize 1
                             |)
@@ -5657,24 +5780,28 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 let acc := M.copy (| init |) in
                 let val :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        self
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "start"
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -5729,7 +5856,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -5837,23 +5964,26 @@ Module iter.
                     M.rust_cast
                       (BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
                             "step"
+                          |)
                         |),
                         Value.Integer Integer.Usize 1
                       |))
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -5869,23 +5999,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let start :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (| M.read (| remaining |), Value.Integer Integer.U8 1 |)
                           |) in
                         M.alloc (|
@@ -6061,7 +6195,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -6103,7 +6237,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -6130,7 +6264,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -6225,7 +6359,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -6314,23 +6448,26 @@ Module iter.
                     M.rust_cast
                       (BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
                             "step"
+                          |)
                         |),
                         Value.Integer Integer.Usize 1
                       |))
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -6346,23 +6483,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let start :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.U16 1
@@ -6541,7 +6682,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -6583,7 +6724,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -6610,7 +6751,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -6705,7 +6846,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -6794,23 +6935,26 @@ Module iter.
                     M.rust_cast
                       (BinOp.Panic.add (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::step_by::StepBy"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::step_by::StepBy",
                             "step"
+                          |)
                         |),
                         Value.Integer Integer.Usize 1
                       |))
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -6826,23 +6970,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let start :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.U32 1
@@ -7021,7 +7169,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -7063,7 +7211,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -7090,7 +7238,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -7185,7 +7333,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -7275,10 +7423,11 @@ Module iter.
                       (M.alloc (|
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::step_by::StepBy"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::step_by::StepBy",
                               "step"
+                            |)
                           |),
                           Value.Integer Integer.Usize 1
                         |)
@@ -7286,13 +7435,15 @@ Module iter.
                   |) in
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::step_by::StepBy"
-                        "iter")
-                      "core::ops::range::Range"
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::step_by::StepBy",
+                        "iter"
+                      |),
+                      "core::ops::range::Range",
                       "end"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -7308,23 +7459,27 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let start :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
                               "start"
+                            |)
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::step_by::StepBy"
-                                "iter")
-                              "core::ops::range::Range"
-                              "end",
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::step_by::StepBy",
+                                "iter"
+                              |),
+                              "core::ops::range::Range",
+                              "end"
+                            |),
                             BinOp.Panic.sub (|
                               M.read (| remaining |),
                               Value.Integer Integer.Usize 1
@@ -7503,7 +7658,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -7545,7 +7700,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -7572,7 +7727,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -7667,7 +7822,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0

--- a/CoqOfRust/core/iter/adapters/take.v
+++ b/CoqOfRust/core/iter/adapters/take.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take::Take"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take::Take",
                           "iter"
+                        |)
                       ]
                     |));
                   ("n",
@@ -45,10 +46,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take::Take"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take::Take",
                           "n"
+                        |)
                       ]
                     |))
                 ]))
@@ -88,18 +90,20 @@ Module iter.
                   M.read (| Value.String "iter" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::take::Take"
-                      "iter");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::take::Take",
+                      "iter"
+                    |));
                   M.read (| Value.String "n" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::adapters::take::Take"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::adapters::take::Take",
                         "n"
+                      |)
                     |))
                 ]
               |)))
@@ -176,10 +180,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.ne
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -187,10 +192,11 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "n" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "n"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -205,10 +211,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::take::Take"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::take::Take",
                                 "iter"
+                              |)
                             ]
                           |)
                         |)));
@@ -253,10 +260,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (M.read (| n |))
                             |)) in
@@ -264,10 +272,11 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "n" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "n"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (|
@@ -285,10 +294,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::take::Take"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::take::Take",
+                                "iter"
+                              |);
                               M.read (| n |)
                             ]
                           |)
@@ -306,10 +316,11 @@ Module iter.
                                       (M.alloc (|
                                         BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::take::Take"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::take::Take",
                                               "n"
+                                            |)
                                           |))
                                           (Value.Integer Integer.Usize 0)
                                       |)) in
@@ -329,16 +340,18 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::take::Take"
-                                            "iter";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::take::Take",
+                                            "iter"
+                                          |);
                                           BinOp.Panic.sub (|
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::take::Take"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::take::Take",
                                                 "n"
+                                              |)
                                             |),
                                             Value.Integer Integer.Usize 1
                                           |)
@@ -347,10 +360,11 @@ Module iter.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::take::Take"
-                                        "n",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::take::Take",
+                                        "n"
+                                      |),
                                       Value.Integer Integer.Usize 0
                                     |) in
                                   M.alloc (| Value.Tuple [] |)));
@@ -402,10 +416,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::take::Take"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::take::Take",
                                           "n"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -443,18 +458,19 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
                               "iter"
+                            |)
                           ]
                         |)
                       |),
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let lower := M.copy (| γ0_0 |) in
                             let upper := M.copy (| γ0_1 |) in
                             let lower :=
@@ -464,10 +480,11 @@ Module iter.
                                   [
                                     M.read (| lower |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::take::Take"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::take::Take",
                                         "n"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -480,7 +497,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -491,10 +508,11 @@ Module iter.
                                             BinOp.Pure.lt
                                               (M.read (| x |))
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::take::Take"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::take::Take",
                                                   "n"
+                                                |)
                                               |))
                                           |) in
                                         let _ :=
@@ -514,10 +532,11 @@ Module iter.
                                             "core::option::Option::Some"
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::take::Take"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::take::Take",
                                                   "n"
+                                                |)
                                               |)
                                             ]
                                         |)))
@@ -576,10 +595,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -601,10 +621,11 @@ Module iter.
                       ltac:(M.monadic
                         (let n :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
                               "n"
+                            |)
                           |) in
                         M.alloc (|
                           M.call_closure (|
@@ -631,10 +652,11 @@ Module iter.
                                   ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
+                                    "iter"
+                                  |);
                                   M.read (| init |);
                                   M.call_closure (|
                                     M.get_associated_function (| Self, "check.try_fold", [] |),
@@ -732,10 +754,11 @@ Module iter.
                       M.get_trait_method (| "core::cmp::Ord", Ty.path "usize", [], "min", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::take::Take"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::take::Take",
                             "n"
+                          |)
                         |);
                         M.read (| n |)
                       ]
@@ -754,10 +777,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "iter";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "iter"
+                            |);
                             M.read (| min |)
                           ]
                         |)
@@ -766,7 +790,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -775,7 +799,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -798,10 +822,11 @@ Module iter.
                   M.alloc (| BinOp.Panic.sub (| M.read (| min |), M.read (| rem |) |) |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::take::Take"
-                      "n" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::take::Take",
+                      "n"
+                    |) in
                   M.write (| β, BinOp.Panic.sub (| M.read (| β |), M.read (| advanced |) |) |) in
                 M.alloc (|
                   M.call_closure (|
@@ -880,10 +905,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::take::Take"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::take::Take",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -971,10 +997,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -985,17 +1012,19 @@ Module iter.
                       ltac:(M.monadic
                         (let n :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
                               "n"
+                            |)
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "n" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "n"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -1010,10 +1039,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::take::Take"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::take::Take",
+                                "iter"
+                              |);
                               M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.path "usize",
@@ -1030,10 +1060,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::take::Take"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::take::Take",
                                         "iter"
+                                      |)
                                     ]
                                   |);
                                   M.read (| n |)
@@ -1082,10 +1113,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take::Take"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take::Take",
                           "iter"
+                        |)
                       ]
                     |)
                   |) in
@@ -1099,10 +1131,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (M.read (| n |))
                             |)) in
@@ -1120,10 +1153,11 @@ Module iter.
                                 [
                                   M.read (| len |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::take::Take"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::take::Take",
                                       "n"
+                                    |)
                                   |)
                                 ]
                               |),
@@ -1132,10 +1166,11 @@ Module iter.
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "n" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "n"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (|
@@ -1153,10 +1188,11 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::iter::adapters::take::Take"
-                                "iter";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::iter::adapters::take::Take",
+                                "iter"
+                              |);
                               M.read (| m |)
                             ]
                           |)
@@ -1192,10 +1228,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::take::Take"
-                                            "iter";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::take::Take",
+                                            "iter"
+                                          |);
                                           BinOp.Panic.sub (|
                                             M.read (| len |),
                                             Value.Integer Integer.Usize 1
@@ -1252,10 +1289,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -1286,10 +1324,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::take::Take"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::take::Take",
                                   "iter"
+                                |)
                               ]
                             |)
                           |) in
@@ -1305,10 +1344,11 @@ Module iter.
                                         BinOp.Pure.gt
                                           (M.read (| len |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::take::Take"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::take::Take",
                                               "n"
+                                            |)
                                           |)),
                                         ltac:(M.monadic
                                           (M.call_closure (|
@@ -1330,18 +1370,20 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::iter::adapters::take::Take"
-                                                      "iter";
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::iter::adapters::take::Take",
+                                                      "iter"
+                                                    |);
                                                     BinOp.Panic.sub (|
                                                       BinOp.Panic.sub (|
                                                         M.read (| len |),
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::iter::adapters::take::Take"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::iter::adapters::take::Take",
                                                             "n"
+                                                          |)
                                                         |)
                                                       |),
                                                       Value.Integer Integer.Usize 1
@@ -1382,10 +1424,11 @@ Module iter.
                                       [ Acc; Fold; R ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::take::Take"
-                                        "iter";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::take::Take",
+                                        "iter"
+                                      |);
                                       M.read (| init |);
                                       M.read (| fold |)
                                     ]
@@ -1436,10 +1479,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::iter::adapters::take::Take"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::iter::adapters::take::Take",
                                     "n"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -1459,10 +1503,11 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::take::Take"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::take::Take",
                                   "iter"
+                                |)
                               ]
                             |)
                           |) in
@@ -1478,10 +1523,11 @@ Module iter.
                                         BinOp.Pure.gt
                                           (M.read (| len |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              self
-                                              "core::iter::adapters::take::Take"
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "core::iter::adapters::take::Take",
                                               "n"
+                                            |)
                                           |)),
                                         ltac:(M.monadic
                                           (M.call_closure (|
@@ -1503,18 +1549,20 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      self
-                                                      "core::iter::adapters::take::Take"
-                                                      "iter";
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      self,
+                                                      "core::iter::adapters::take::Take",
+                                                      "iter"
+                                                    |);
                                                     BinOp.Panic.sub (|
                                                       BinOp.Panic.sub (|
                                                         M.read (| len |),
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            self
-                                                            "core::iter::adapters::take::Take"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            self,
+                                                            "core::iter::adapters::take::Take",
                                                             "n"
+                                                          |)
                                                         |)
                                                       |),
                                                       Value.Integer Integer.Usize 1
@@ -1545,10 +1593,11 @@ Module iter.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::iter::adapters::take::Take"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::iter::adapters::take::Take",
                                           "iter"
+                                        |)
                                       |);
                                       M.read (| init |);
                                       M.read (| fold |)
@@ -1605,17 +1654,19 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
                               "iter"
+                            |)
                           ]
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::take::Take"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::take::Take",
                             "n"
+                          |)
                         |)
                       ]
                     |)
@@ -1640,10 +1691,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take::Take"
-                              "iter";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take::Take",
+                              "iter"
+                            |);
                             M.read (| advance_by |)
                           ]
                         |)
@@ -1652,7 +1704,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Ok",
                                 0
@@ -1661,7 +1713,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::result::Result::Err",
                                 0
@@ -1690,10 +1742,11 @@ Module iter.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::adapters::take::Take"
-                      "n" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::adapters::take::Take",
+                      "n"
+                    |) in
                   M.write (| β, BinOp.Panic.sub (| M.read (| β |), M.read (| advanced_by |) |) |) in
                 M.alloc (|
                   M.call_closure (|
@@ -1825,8 +1878,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let f := M.alloc (| f |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -1852,9 +1905,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -1889,7 +1943,11 @@ Module iter.
               M.read (|
                 let remaining :=
                   M.copy (|
-                    M.get_struct_record_field self "core::iter::adapters::take::Take" "n"
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::iter::adapters::take::Take",
+                      "n"
+                    |)
                   |) in
                 M.match_operator (|
                   M.alloc (| Value.Tuple [] |),
@@ -1918,10 +1976,11 @@ Module iter.
                                 ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  self
-                                  "core::iter::adapters::take::Take"
-                                  "iter";
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::iter::adapters::take::Take",
+                                  "iter"
+                                |);
                                 BinOp.Panic.sub (|
                                   M.read (| remaining |),
                                   Value.Integer Integer.Usize 1
@@ -1990,7 +2049,11 @@ Module iter.
                       M.get_trait_method (| "core::cmp::Ord", Ty.path "usize", [], "min", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field self "core::iter::adapters::take::Take" "n"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::take::Take",
+                            "n"
+                          |)
                         |);
                         M.call_closure (|
                           M.get_trait_method (|
@@ -2000,7 +2063,12 @@ Module iter.
                             "size",
                             []
                           |),
-                          [ M.get_struct_record_field self "core::iter::adapters::take::Take" "iter"
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::take::Take",
+                              "iter"
+                            |)
                           ]
                         |)
                       ]
@@ -2059,7 +2127,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -2076,10 +2144,11 @@ Module iter.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "core::iter::adapters::take::Take"
-                                                    "iter";
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "core::iter::adapters::take::Take",
+                                                    "iter"
+                                                  |);
                                                   M.read (| i |)
                                                 ]
                                               |)
@@ -2137,7 +2206,11 @@ Module iter.
                       M.get_trait_method (| "core::cmp::Ord", Ty.path "usize", [], "min", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field self "core::iter::adapters::take::Take" "n"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::iter::adapters::take::Take",
+                            "n"
+                          |)
                         |);
                         M.call_closure (|
                           M.get_trait_method (|
@@ -2147,7 +2220,12 @@ Module iter.
                             "size",
                             []
                           |),
-                          [ M.get_struct_record_field self "core::iter::adapters::take::Take" "iter"
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::iter::adapters::take::Take",
+                              "iter"
+                            |)
                           ]
                         |)
                       ]
@@ -2203,7 +2281,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2220,10 +2298,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::iter::adapters::take::Take"
-                                                  "iter";
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::iter::adapters::take::Take",
+                                                  "iter"
+                                                |);
                                                 M.read (| i |)
                                               ]
                                             |)

--- a/CoqOfRust/core/iter/adapters/take_while.v
+++ b/CoqOfRust/core/iter/adapters/take_while.v
@@ -29,10 +29,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", I, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take_while::TakeWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take_while::TakeWhile",
                           "iter"
+                        |)
                       ]
                     |));
                   ("flag",
@@ -45,20 +46,22 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take_while::TakeWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take_while::TakeWhile",
                           "flag"
+                        |)
                       ]
                     |));
                   ("predicate",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take_while::TakeWhile"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take_while::TakeWhile",
                           "predicate"
+                        |)
                       ]
                     |))
                 ]))
@@ -155,19 +158,21 @@ Module iter.
                           M.read (| Value.String "iter" |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take_while::TakeWhile"
-                              "iter")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take_while::TakeWhile",
+                              "iter"
+                            |))
                         ]
                       |);
                       M.read (| Value.String "flag" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::take_while::TakeWhile"
-                          "flag")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::take_while::TakeWhile",
+                          "flag"
+                        |))
                     ]
                   |)
                 ]
@@ -222,10 +227,11 @@ Module iter.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::take_while::TakeWhile"
-                                  "flag") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::take_while::TakeWhile",
+                                  "flag"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -253,10 +259,11 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::iter::adapters::take_while::TakeWhile"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::iter::adapters::take_while::TakeWhile",
                                               "iter"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -266,7 +273,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -299,7 +306,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -329,10 +336,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::take_while::TakeWhile"
-                                                "predicate";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::take_while::TakeWhile",
+                                                "predicate"
+                                              |);
                                               Value.Tuple [ x ]
                                             ]
                                           |)
@@ -351,10 +359,11 @@ Module iter.
                                   ltac:(M.monadic
                                     (let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::take_while::TakeWhile"
-                                          "flag",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::take_while::TakeWhile",
+                                          "flag"
+                                        |),
                                         Value.Bool true
                                       |) in
                                     M.alloc (|
@@ -393,10 +402,11 @@ Module iter.
                       ltac:(M.monadic
                         (let γ :=
                           M.use
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take_while::TakeWhile"
-                              "flag") in
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take_while::TakeWhile",
+                              "flag"
+                            |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         M.alloc (|
@@ -421,18 +431,19 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::take_while::TakeWhile"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::take_while::TakeWhile",
                                   "iter"
+                                |)
                               ]
                             |)
                           |),
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let upper := M.copy (| γ0_1 |) in
                                 M.alloc (|
                                   Value.Tuple [ Value.Integer Integer.Usize 0; M.read (| upper |) ]
@@ -492,10 +503,11 @@ Module iter.
                       ltac:(M.monadic
                         (let γ :=
                           M.use
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take_while::TakeWhile"
-                              "flag") in
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take_while::TakeWhile",
+                              "flag"
+                            |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         M.alloc (|
@@ -514,17 +526,19 @@ Module iter.
                       ltac:(M.monadic
                         (let flag :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take_while::TakeWhile"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take_while::TakeWhile",
                               "flag"
+                            |)
                           |) in
                         let p :=
                           M.alloc (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::take_while::TakeWhile"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::take_while::TakeWhile",
                               "predicate"
+                            |)
                           |) in
                         M.alloc (|
                           M.call_closure (|
@@ -551,10 +565,11 @@ Module iter.
                                   ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::take_while::TakeWhile"
-                                    "iter";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::take_while::TakeWhile",
+                                    "iter"
+                                  |);
                                   M.read (| init |);
                                   M.call_closure (|
                                     M.get_associated_function (| Self, "check.try_fold", [] |),
@@ -590,8 +605,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -617,9 +632,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -688,10 +704,11 @@ Module iter.
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", I, [], "as_inner", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::adapters::take_while::TakeWhile"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::take_while::TakeWhile",
                     "iter"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/adapters/zip.v
+++ b/CoqOfRust/core/iter/adapters/zip.v
@@ -36,20 +36,22 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "a"
+                        |)
                       ]
                     |));
                   ("b",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", B, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "b"
+                        |)
                       ]
                     |));
                   ("index",
@@ -62,10 +64,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "index"
+                        |)
                       ]
                     |));
                   ("len",
@@ -78,10 +81,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "len"
+                        |)
                       ]
                     |));
                   ("a_len",
@@ -94,10 +98,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "a_len"
+                        |)
                       ]
                     |))
                 ]))
@@ -191,7 +196,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -588,10 +593,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
                                       "a"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -601,7 +607,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -634,7 +640,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -666,10 +672,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
                                       "b"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -679,7 +686,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -712,7 +719,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -804,10 +811,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "a"
+                        |)
                       ]
                     |)
                   |) in
@@ -822,10 +830,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "b"
+                        |)
                       ]
                     |)
                   |) in
@@ -917,7 +926,7 @@ Module iter.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
@@ -933,10 +942,11 @@ Module iter.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::iter::adapters::zip::Zip"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::iter::adapters::zip::Zip",
                                                                     "a"
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |) in
@@ -1009,7 +1019,7 @@ Module iter.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
@@ -1025,10 +1035,11 @@ Module iter.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::iter::adapters::zip::Zip"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::iter::adapters::zip::Zip",
                                                                     "b"
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |) in
@@ -1057,10 +1068,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "a"
+                            |)
                           ]
                         |);
                         M.call_closure (|
@@ -1072,10 +1084,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "b"
+                            |)
                           ]
                         |)
                       ]
@@ -1083,17 +1096,17 @@ Module iter.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
                           |) in
                         let x := M.copy (| γ1_0 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "core::option::Option::Some",
                             0
@@ -1106,8 +1119,8 @@ Module iter.
                         |)));
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                     fun γ =>
                       ltac:(M.monadic
@@ -1161,18 +1174,19 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "a"
+                        |)
                       ]
                     |)
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a_lower := M.copy (| γ0_0 |) in
                         let a_upper := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -1186,18 +1200,19 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::iter::adapters::zip::Zip"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::iter::adapters::zip::Zip",
                                   "b"
+                                |)
                               ]
                             |)
                           |),
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let b_lower := M.copy (| γ0_0 |) in
                                 let b_upper := M.copy (| γ0_1 |) in
                                 let lower :=
@@ -1216,17 +1231,17 @@ Module iter.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_0,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
                                             let x := M.copy (| γ1_0 |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_1,
                                                 "core::option::Option::Some",
                                                 0
@@ -1247,10 +1262,10 @@ Module iter.
                                             |)));
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_0,
                                                 "core::option::Option::Some",
                                                 0
@@ -1263,10 +1278,10 @@ Module iter.
                                             |)));
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let γ1_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ0_1,
                                                 "core::option::Option::Some",
                                                 0
@@ -1279,8 +1294,8 @@ Module iter.
                                             |)));
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             M.alloc (|
                                               Value.StructTuple "core::option::Option::None" []
                                             |)))
@@ -1471,10 +1486,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
                                       "a"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1484,7 +1500,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1517,7 +1533,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1549,10 +1565,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
                                       "b"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -1562,7 +1579,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1595,7 +1612,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1687,10 +1704,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "a"
+                        |)
                       ]
                     |)
                   |) in
@@ -1705,10 +1723,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "b"
+                        |)
                       ]
                     |)
                   |) in
@@ -1800,7 +1819,7 @@ Module iter.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
@@ -1816,10 +1835,11 @@ Module iter.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::iter::adapters::zip::Zip"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::iter::adapters::zip::Zip",
                                                                     "a"
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |) in
@@ -1892,7 +1912,7 @@ Module iter.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
@@ -1908,10 +1928,11 @@ Module iter.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::iter::adapters::zip::Zip"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::iter::adapters::zip::Zip",
                                                                     "b"
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |) in
@@ -1940,10 +1961,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "a"
+                            |)
                           ]
                         |);
                         M.call_closure (|
@@ -1955,10 +1977,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "b"
+                            |)
                           ]
                         |)
                       ]
@@ -1966,17 +1989,17 @@ Module iter.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_0,
                             "core::option::Option::Some",
                             0
                           |) in
                         let x := M.copy (| γ1_0 |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ0_1,
                             "core::option::Option::Some",
                             0
@@ -1989,8 +2012,8 @@ Module iter.
                         |)));
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                     fun γ =>
                       ltac:(M.monadic
@@ -2036,10 +2059,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "a"
+                            |)
                           ]
                         |);
                         M.call_closure (|
@@ -2051,10 +2075,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "b"
+                            |)
                           ]
                         |)
                       ]
@@ -2091,10 +2116,11 @@ Module iter.
                   M.alloc (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "index"
+                        |)
                       |),
                       M.read (| idx |)
                     |)
@@ -2111,10 +2137,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::zip::Zip"
-                            "a";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::zip::Zip",
+                            "a"
+                          |);
                           M.read (| idx |)
                         ]
                       |);
@@ -2127,10 +2154,11 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::iter::adapters::zip::Zip"
-                            "b";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::iter::adapters::zip::Zip",
+                            "b"
+                          |);
                           M.read (| idx |)
                         ]
                       |)
@@ -2170,8 +2198,8 @@ Module iter.
                 let accum := M.copy (| init |) in
                 let len :=
                   M.copy (|
-                    M.get_tuple_field
-                      (M.alloc (|
+                    M.SubPointer.get_tuple_field (|
+                      M.alloc (|
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::iter::adapters::zip::ZipImpl",
@@ -2182,8 +2210,9 @@ Module iter.
                           |),
                           [ self ]
                         |)
-                      |))
+                      |),
                       0
+                    |)
                   |) in
                 let _ :=
                   M.use
@@ -2236,7 +2265,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -2421,33 +2450,37 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.lt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "index"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "len"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let i :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "index"
+                            |)
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
-                              "index" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
+                              "index"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -2467,10 +2500,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::zip::Zip"
-                                        "a";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::zip::Zip",
+                                        "a"
+                                      |);
                                       M.read (| i |)
                                     ]
                                   |);
@@ -2483,10 +2517,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::zip::Zip"
-                                        "b";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::zip::Zip",
+                                        "b"
+                                      |);
                                       M.read (| i |)
                                     ]
                                   |)
@@ -2512,16 +2547,18 @@ Module iter.
                                         ltac:(M.monadic
                                           (BinOp.Pure.lt
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::zip::Zip"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::zip::Zip",
                                                 "index"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::zip::Zip"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::zip::Zip",
                                                 "a_len"
+                                              |)
                                             |))))
                                       |)
                                     |)) in
@@ -2532,17 +2569,19 @@ Module iter.
                                   |) in
                                 let i :=
                                   M.copy (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
                                       "index"
+                                    |)
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
-                                      "index" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
+                                      "index"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -2552,10 +2591,11 @@ Module iter.
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::adapters::zip::Zip"
-                                      "len" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::adapters::zip::Zip",
+                                      "len"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -2575,10 +2615,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::zip::Zip"
-                                            "a";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::zip::Zip",
+                                            "a"
+                                          |);
                                           M.read (| i |)
                                         ]
                                       |)
@@ -2613,16 +2654,18 @@ Module iter.
                   M.alloc (|
                     BinOp.Panic.sub (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "len"
+                        |)
                       |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "index"
+                        |)
                       |)
                     |)
                   |) in
@@ -2681,16 +2724,18 @@ Module iter.
                         M.read (| n |);
                         BinOp.Panic.sub (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "len"
+                            |)
                           |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "index"
+                            |)
                           |)
                         |)
                       ]
@@ -2700,10 +2745,11 @@ Module iter.
                   M.alloc (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
                           "index"
+                        |)
                       |),
                       M.read (| delta |)
                     |)
@@ -2721,10 +2767,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.lt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::adapters::zip::Zip"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::adapters::zip::Zip",
                                           "index"
+                                        |)
                                       |))
                                       (M.read (| end_ |))
                                   |)) in
@@ -2735,17 +2782,19 @@ Module iter.
                                 |) in
                               let i :=
                                 M.copy (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "index"
+                                  |)
                                 |) in
                               let _ :=
                                 let β :=
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
-                                    "index" in
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
+                                    "index"
+                                  |) in
                                 M.write (|
                                   β,
                                   BinOp.Panic.add (|
@@ -2780,10 +2829,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::iter::adapters::zip::Zip"
-                                                  "a";
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::iter::adapters::zip::Zip",
+                                                  "a"
+                                                |);
                                                 M.read (| i |)
                                               ]
                                             |)
@@ -2818,10 +2868,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::adapters::zip::Zip"
-                                                "b";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::adapters::zip::Zip",
+                                                "b"
+                                              |);
                                               M.read (| i |)
                                             ]
                                           |)
@@ -2950,10 +3001,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "a"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -2968,10 +3020,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "b"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -3001,10 +3054,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::zip::Zip"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::zip::Zip",
                                             "a"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -3027,10 +3081,11 @@ Module iter.
                                                       (BinOp.Pure.gt
                                                         (M.read (| sz_a |))
                                                         (M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::iter::adapters::zip::Zip"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::iter::adapters::zip::Zip",
                                                             "len"
+                                                          |)
                                                         |))))
                                                   |)
                                                 |)) in
@@ -3063,10 +3118,11 @@ Module iter.
                                                               BinOp.Panic.sub (|
                                                                 M.read (| sz_a |),
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::iter::adapters::zip::Zip"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::iter::adapters::zip::Zip",
                                                                     "len"
+                                                                  |)
                                                                 |)
                                                               |))
                                                           ]
@@ -3107,17 +3163,18 @@ Module iter.
                                                                   fun γ =>
                                                                     ltac:(M.monadic
                                                                       (let γ0_0 :=
-                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                           γ,
                                                                           "core::option::Option::Some",
                                                                           0
                                                                         |) in
                                                                       let _ :=
                                                                         let β :=
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::iter::adapters::zip::Zip"
-                                                                            "a_len" in
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::iter::adapters::zip::Zip",
+                                                                            "a_len"
+                                                                          |) in
                                                                         M.write (|
                                                                           β,
                                                                           BinOp.Panic.sub (|
@@ -3138,10 +3195,11 @@ Module iter.
                                                                               []
                                                                             |),
                                                                             [
-                                                                              M.get_struct_record_field
-                                                                                (M.read (| self |))
-                                                                                "core::iter::adapters::zip::Zip"
+                                                                              M.SubPointer.get_struct_record_field (|
+                                                                                M.read (| self |),
+                                                                                "core::iter::adapters::zip::Zip",
                                                                                 "a"
+                                                                              |)
                                                                             ]
                                                                           |)
                                                                         |) in
@@ -3170,22 +3228,31 @@ Module iter.
                                                           M.alloc (|
                                                             Value.Tuple
                                                               [
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::iter::adapters::zip::Zip"
-                                                                  "a_len";
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::iter::adapters::zip::Zip"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::iter::adapters::zip::Zip",
+                                                                  "a_len"
+                                                                |);
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::iter::adapters::zip::Zip",
                                                                   "len"
+                                                                |)
                                                               ]
                                                           |),
                                                           [
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let left_val := M.copy (| γ0_0 |) in
                                                                 let right_val :=
                                                                   M.copy (| γ0_1 |) in
@@ -3283,10 +3350,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::adapters::zip::Zip"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::adapters::zip::Zip",
                                             "b"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -3308,10 +3376,11 @@ Module iter.
                                                     (BinOp.Pure.gt
                                                       (M.read (| sz_b |))
                                                       (M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::iter::adapters::zip::Zip"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::iter::adapters::zip::Zip",
                                                           "len"
+                                                        |)
                                                       |))))
                                                 |)
                                               |)) in
@@ -3342,10 +3411,11 @@ Module iter.
                                                           BinOp.Panic.sub (|
                                                             M.read (| sz_b |),
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::iter::adapters::zip::Zip"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::iter::adapters::zip::Zip",
                                                                 "len"
+                                                              |)
                                                             |)
                                                           |))
                                                       ]
@@ -3386,7 +3456,7 @@ Module iter.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0
@@ -3402,10 +3472,11 @@ Module iter.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::iter::adapters::zip::Zip"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::iter::adapters::zip::Zip",
                                                                             "b"
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |) in
@@ -3435,46 +3506,51 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.lt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "index"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::adapters::zip::Zip"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::adapters::zip::Zip",
                                     "len"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
-                              "len" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
+                              "len"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
-                              "a_len" in
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
+                              "a_len"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
                           |) in
                         let i :=
                           M.copy (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
                               "len"
+                            |)
                           |) in
                         M.alloc (|
                           Value.StructTuple
@@ -3491,10 +3567,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::zip::Zip"
-                                        "a";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::zip::Zip",
+                                        "a"
+                                      |);
                                       M.read (| i |)
                                     ]
                                   |);
@@ -3507,10 +3584,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::iter::adapters::zip::Zip"
-                                        "b";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::iter::adapters::zip::Zip",
+                                        "b"
+                                      |);
                                       M.read (| i |)
                                     ]
                                   |)
@@ -3680,7 +3758,12 @@ Module iter.
               (let self := M.alloc (| self |) in
               M.call_closure (|
                 M.get_trait_method (| "core::iter::adapters::SourceIter", A, [], "as_inner", [] |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::iter::adapters::zip::Zip" "a"
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::adapters::zip::Zip",
+                    "a"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -3827,19 +3910,21 @@ Module iter.
                           M.read (| Value.String "a" |);
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::adapters::zip::Zip"
-                              "a")
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::adapters::zip::Zip",
+                              "a"
+                            |))
                         ]
                       |);
                       M.read (| Value.String "b" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::adapters::zip::Zip"
-                          "b")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::adapters::zip::Zip",
+                          "b"
+                        |))
                     ]
                   |)
                 ]
@@ -3916,8 +4001,8 @@ Module iter.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::Iterator",
@@ -3928,8 +4013,9 @@ Module iter.
                       |),
                       [ M.read (| self |) ]
                     |)
-                  |))
+                  |),
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -4121,7 +4207,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -4226,8 +4312,8 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ :=
-                                  M.get_tuple_field
-                                    (M.alloc (|
+                                  M.SubPointer.get_tuple_field (|
+                                    M.alloc (|
                                       M.call_closure (|
                                         M.get_trait_method (|
                                           "core::iter::adapters::zip::ZipImpl",
@@ -4240,10 +4326,11 @@ Module iter.
                                         |),
                                         [ self ]
                                       |)
-                                    |))
-                                    1 in
+                                    |),
+                                    1
+                                  |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -4266,8 +4353,8 @@ Module iter.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let upper := M.copy (| γ0_0 |) in
                               let more := M.copy (| γ0_1 |) in
                               let _ :=
@@ -4327,7 +4414,7 @@ Module iter.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -4355,10 +4442,11 @@ Module iter.
                                                                         []
                                                                       |),
                                                                       [
-                                                                        M.get_struct_record_field
-                                                                          self
-                                                                          "core::iter::adapters::zip::Zip"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          self,
+                                                                          "core::iter::adapters::zip::Zip",
                                                                           "a"
+                                                                        |)
                                                                       ]
                                                                     |)
                                                                   ]
@@ -4382,10 +4470,11 @@ Module iter.
                                                                         []
                                                                       |),
                                                                       [
-                                                                        M.get_struct_record_field
-                                                                          self
-                                                                          "core::iter::adapters::zip::Zip"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          self,
+                                                                          "core::iter::adapters::zip::Zip",
                                                                           "b"
+                                                                        |)
                                                                       ]
                                                                     |)
                                                                   ]

--- a/CoqOfRust/core/iter/range.v
+++ b/CoqOfRust/core/iter/range.v
@@ -543,7 +543,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -558,7 +558,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -602,7 +602,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -617,7 +617,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -935,7 +935,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -976,7 +976,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1033,7 +1033,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1074,7 +1074,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1372,7 +1372,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1387,7 +1387,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1431,7 +1431,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1446,7 +1446,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1764,7 +1764,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1805,7 +1805,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1862,7 +1862,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1903,7 +1903,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -2201,7 +2201,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -2216,7 +2216,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -2260,7 +2260,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -2275,7 +2275,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -2593,7 +2593,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -2634,7 +2634,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -2691,7 +2691,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -2732,7 +2732,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3030,7 +3030,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3045,7 +3045,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3089,7 +3089,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3104,7 +3104,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3422,7 +3422,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3463,7 +3463,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3520,7 +3520,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3561,7 +3561,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3863,7 +3863,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3878,7 +3878,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3922,7 +3922,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3937,7 +3937,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -4255,7 +4255,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -4296,7 +4296,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -4353,7 +4353,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -4394,7 +4394,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -4961,7 +4961,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -5277,7 +5277,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -5310,7 +5310,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -5375,7 +5375,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -5408,7 +5408,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -5514,7 +5514,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -5547,7 +5547,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -5612,7 +5612,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -5645,7 +5645,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -5983,7 +5983,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -6016,7 +6016,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -6098,7 +6098,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -6131,7 +6131,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -6867,14 +6867,16 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           |)) in
@@ -6906,10 +6908,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::Range"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::Range",
                                         "start"
+                                      |)
                                     ]
                                   |);
                                   Value.Integer Integer.Usize 1
@@ -6926,10 +6929,11 @@ Module iter.
                             M.call_closure (|
                               M.get_function (| "core::mem::replace", [ A ] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
                                 M.read (| n |)
                               ]
                             |)
@@ -6994,10 +6998,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::Range"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::Range",
                                           "start"
+                                        |)
                                       ]
                                     |);
                                     M.read (| n |)
@@ -7005,7 +7010,7 @@ Module iter.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -7029,10 +7034,11 @@ Module iter.
                                             |),
                                             [
                                               plus_n;
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             ]
                                           |)
                                         |)) in
@@ -7046,10 +7052,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
-                                                "start",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
+                                                "start"
+                                              |),
                                               M.call_closure (|
                                                 M.get_associated_function (|
                                                   Ty.apply (Ty.path "core::option::Option") [ A ],
@@ -7101,17 +7108,19 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::Range"
-                        "start",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "start"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
@@ -7164,14 +7173,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |)
                               |)) in
@@ -7194,14 +7205,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |);
                                 M.read (| M.get_constant (| "core::num::MAX" |) |)
@@ -7221,7 +7234,11 @@ Module iter.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "start"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "core::option::Option") [ A ],
@@ -7241,10 +7258,11 @@ Module iter.
                           M.call_closure (|
                             M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ops::range::Range"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ops::range::Range",
                                 "start"
+                              |)
                             ]
                           |);
                           M.read (| taken |)
@@ -7319,24 +7337,27 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
-                            "end",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
+                            "end"
+                          |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply (Ty.path "core::option::Option") [ A ],
@@ -7362,10 +7383,11 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::Range"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::Range",
                                         "end"
+                                      |)
                                     ]
                                   |);
                                   Value.Integer Integer.Usize 1
@@ -7382,10 +7404,11 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           ]
@@ -7449,10 +7472,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::Range"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::Range",
                                           "end"
+                                        |)
                                       ]
                                     |);
                                     M.read (| n |)
@@ -7460,7 +7484,7 @@ Module iter.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -7484,10 +7508,11 @@ Module iter.
                                             |),
                                             [
                                               minus_n;
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             ]
                                           |)
                                         |)) in
@@ -7501,10 +7526,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
-                                                "end",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
+                                                "end"
+                                              |),
                                               M.call_closure (|
                                                 M.get_associated_function (|
                                                   Ty.apply (Ty.path "core::option::Option") [ A ],
@@ -7544,10 +7570,11 @@ Module iter.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::ops::range::Range"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::ops::range::Range",
                                                       "end"
+                                                    |)
                                                   ]
                                                 |)
                                               ]
@@ -7563,14 +7590,19 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "end"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
                             "start"
+                          |)
                         ]
                       |)
                     |) in
@@ -7623,14 +7655,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |)
                               |)) in
@@ -7653,14 +7687,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |);
                                 M.read (| M.get_constant (| "core::num::MAX" |) |)
@@ -7680,7 +7716,11 @@ Module iter.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "end"
+                  |),
                   M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply (Ty.path "core::option::Option") [ A ],
@@ -7700,10 +7740,11 @@ Module iter.
                           M.call_closure (|
                             M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ops::range::Range"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ops::range::Range",
                                 "end"
+                              |)
                             ]
                           |);
                           M.read (| taken |)
@@ -7800,31 +7841,35 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let old :=
                         M.copy (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
                             "start"
+                          |)
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
-                            "start",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
+                            "start"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::iter::range::Step",
@@ -7890,17 +7935,18 @@ Module iter.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::Range"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::Range",
                                         "start"
+                                      |)
                                     |);
                                     M.read (| n |)
                                   ]
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -7924,10 +7970,11 @@ Module iter.
                                             |),
                                             [
                                               plus_n;
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             ]
                                           |)
                                         |)) in
@@ -7941,10 +7988,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
-                                                "start",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
+                                                "start"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::iter::range::Step",
@@ -7973,15 +8021,17 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::Range"
-                        "start",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "start"
+                      |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |)
                     |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)
@@ -8036,14 +8086,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |)
                               |)) in
@@ -8066,14 +8118,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |);
                                 M.read (| M.get_constant (| "core::num::MAX" |) |)
@@ -8093,7 +8147,11 @@ Module iter.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "start"
+                  |),
                   M.call_closure (|
                     M.get_trait_method (|
                       "core::iter::range::Step",
@@ -8104,10 +8162,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::range::Range",
                           "start"
+                        |)
                       |);
                       M.read (| taken |)
                     ]
@@ -8178,24 +8237,27 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::Range"
-                            "end",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::Range",
+                            "end"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::iter::range::Step",
@@ -8206,10 +8268,11 @@ Module iter.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               |);
                               Value.Integer Integer.Usize 1
                             ]
@@ -8220,10 +8283,11 @@ Module iter.
                           "core::option::Option::Some"
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ops::range::Range"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ops::range::Range",
                                 "end"
+                              |)
                             |)
                           ]
                       |)));
@@ -8278,17 +8342,18 @@ Module iter.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::Range"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::Range",
                                         "end"
+                                      |)
                                     |);
                                     M.read (| n |)
                                   ]
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -8312,10 +8377,11 @@ Module iter.
                                             |),
                                             [
                                               minus_n;
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             ]
                                           |)
                                         |)) in
@@ -8329,10 +8395,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::Range"
-                                                "end",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::Range",
+                                                "end"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::iter::range::Step",
@@ -8352,10 +8419,11 @@ Module iter.
                                               "core::option::Option::Some"
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::ops::range::Range"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::ops::range::Range",
                                                     "end"
+                                                  |)
                                                 |)
                                               ]
                                           |)
@@ -8370,12 +8438,17 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "end"
+                      |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::range::Range",
                           "start"
+                        |)
                       |)
                     |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)
@@ -8427,14 +8500,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |)
                               |)) in
@@ -8457,14 +8532,16 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
-                                      "start";
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::Range"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::Range",
                                       "end"
+                                    |)
                                   ]
                                 |);
                                 M.read (| M.get_constant (| "core::num::MAX" |) |)
@@ -8484,7 +8561,11 @@ Module iter.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "end"
+                  |),
                   M.call_closure (|
                     M.get_trait_method (|
                       "core::iter::range::Step",
@@ -8495,10 +8576,11 @@ Module iter.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::range::Range"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::range::Range",
                           "end"
+                        |)
                       |);
                       M.read (| taken |)
                     ]
@@ -8615,14 +8697,16 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
                                   "end"
+                                |)
                               ]
                             |)
                           |)) in
@@ -8638,14 +8722,16 @@ Module iter.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ops::range::Range"
-                                "start";
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::ops::range::Range"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ops::range::Range",
+                                "start"
+                              |);
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::ops::range::Range",
                                 "end"
+                              |)
                             ]
                           |)
                         |) in
@@ -8710,8 +8796,16 @@ Module iter.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                               [
-                                M.get_struct_record_field self "core::ops::range::Range" "start";
-                                M.get_struct_record_field self "core::ops::range::Range" "end"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "end"
+                                |)
                               ]
                             |)
                           |)) in
@@ -8733,8 +8827,16 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field self "core::ops::range::Range" "start";
-                                M.get_struct_record_field self "core::ops::range::Range" "end"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "end"
+                                |)
                               ]
                             |);
                             M.read (| Value.String "count overflowed usize" |)
@@ -8915,7 +9017,12 @@ Module iter.
               [
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::Range",
+                      "start"
+                    |)
                   ]
                 |);
                 M.read (| idx |)
@@ -9504,10 +9611,11 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeFrom"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeFrom",
                             "start"
+                          |)
                         ]
                       |);
                       Value.Integer Integer.Usize 1
@@ -9521,10 +9629,11 @@ Module iter.
                     M.call_closure (|
                       M.get_function (| "core::mem::replace", [ A ] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::range::RangeFrom"
-                          "start";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |);
                         M.read (| n |)
                       ]
                     |)
@@ -9576,10 +9685,11 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeFrom"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeFrom",
                             "start"
+                          |)
                         ]
                       |);
                       M.read (| n |)
@@ -9588,10 +9698,11 @@ Module iter.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::range::RangeFrom"
-                    "start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeFrom",
+                    "start"
+                  |),
                   M.call_closure (|
                     M.get_trait_method (| "core::iter::range::Step", A, [], "forward", [] |),
                     [
@@ -9717,14 +9828,16 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "start";
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
@@ -9771,10 +9884,11 @@ Module iter.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::ops::range::RangeInclusive"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::ops::range::RangeInclusive",
                                                     "start"
+                                                  |)
                                                 ]
                                               |);
                                               Value.Integer Integer.Usize 1
@@ -9788,10 +9902,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ A ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "start";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "start"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -9800,10 +9915,11 @@ Module iter.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "exhausted",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "exhausted"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -9816,10 +9932,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "start"
+                                        |)
                                       ]
                                     |)
                                   |)))
@@ -9935,14 +10052,16 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
-                                            "start";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
+                                            "start"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
                                             "end"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -9978,10 +10097,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::ops::range::RangeInclusive"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::ops::range::RangeInclusive",
                                                   "start"
+                                                |)
                                               ]
                                             |);
                                             Value.Integer Integer.Usize 1
@@ -9996,10 +10116,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ A ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "start";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "start"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -10039,7 +10160,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -10066,7 +10187,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -10096,10 +10217,11 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   let _ :=
@@ -10120,14 +10242,16 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "start";
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "start"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
                                         "end"
+                                      |)
                                     ]
                                   |)
                                 |)) in
@@ -10170,10 +10294,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::ops::range::RangeInclusive"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::ops::range::RangeInclusive",
                                                         "start"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -10186,7 +10311,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -10213,7 +10338,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -10305,14 +10430,16 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "lt", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "start";
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
@@ -10359,10 +10486,11 @@ Module iter.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::ops::range::RangeInclusive"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::ops::range::RangeInclusive",
                                                     "end"
+                                                  |)
                                                 ]
                                               |);
                                               Value.Integer Integer.Usize 1
@@ -10376,10 +10504,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ A ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "end";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "end"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -10388,10 +10517,11 @@ Module iter.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "exhausted",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "exhausted"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -10404,10 +10534,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "end"
+                                        |)
                                       ]
                                     |)
                                   |)))
@@ -10523,14 +10654,16 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
-                                            "start";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
+                                            "start"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
                                             "end"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -10566,10 +10699,11 @@ Module iter.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::ops::range::RangeInclusive"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::ops::range::RangeInclusive",
                                                   "end"
+                                                |)
                                               ]
                                             |);
                                             Value.Integer Integer.Usize 1
@@ -10584,10 +10718,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ A ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "end";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "end"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -10627,7 +10762,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -10654,7 +10789,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -10684,10 +10819,11 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   let _ :=
@@ -10708,14 +10844,16 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "start";
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "start"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
                                         "end"
+                                      |)
                                     ]
                                   |)
                                 |)) in
@@ -10758,10 +10896,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::ops::range::RangeInclusive"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::ops::range::RangeInclusive",
                                                         "start"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -10774,7 +10913,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -10801,7 +10940,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -10913,14 +11052,16 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "start";
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
@@ -10960,10 +11101,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
                                                 "start"
+                                              |)
                                             ]
                                           |);
                                           Value.Integer Integer.Usize 1
@@ -10974,10 +11116,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ T ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "start";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "start"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -10986,10 +11129,11 @@ Module iter.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "exhausted",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "exhausted"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -11002,10 +11146,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "start"
+                                        |)
                                       ]
                                     |)
                                   |)))
@@ -11121,14 +11266,16 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
-                                            "start";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
+                                            "start"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
                                             "end"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -11157,10 +11304,11 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::ops::range::RangeInclusive"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::ops::range::RangeInclusive",
                                               "start"
+                                            |)
                                           ]
                                         |);
                                         Value.Integer Integer.Usize 1
@@ -11172,10 +11320,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ T ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "start";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "start"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -11215,7 +11364,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -11242,7 +11391,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -11272,10 +11421,11 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   let _ :=
@@ -11296,14 +11446,16 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "start";
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "start"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
                                         "end"
+                                      |)
                                     ]
                                   |)
                                 |)) in
@@ -11346,10 +11498,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::ops::range::RangeInclusive"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::ops::range::RangeInclusive",
                                                         "start"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -11362,7 +11515,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -11389,7 +11542,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -11481,14 +11634,16 @@ Module iter.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "start";
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
@@ -11528,10 +11683,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
                                                 "end"
+                                              |)
                                             ]
                                           |);
                                           Value.Integer Integer.Usize 1
@@ -11542,10 +11698,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ T ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "end";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "end"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -11554,10 +11711,11 @@ Module iter.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "exhausted",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "exhausted"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -11570,10 +11728,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "end"
+                                        |)
                                       ]
                                     |)
                                   |)))
@@ -11689,14 +11848,16 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
-                                            "start";
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::ops::range::RangeInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
+                                            "start"
+                                          |);
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::ops::range::RangeInclusive",
                                             "end"
+                                          |)
                                         ]
                                       |)
                                     |)) in
@@ -11725,10 +11886,11 @@ Module iter.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::ops::range::RangeInclusive"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::ops::range::RangeInclusive",
                                               "end"
+                                            |)
                                           ]
                                         |);
                                         Value.Integer Integer.Usize 1
@@ -11740,10 +11902,11 @@ Module iter.
                                     M.call_closure (|
                                       M.get_function (| "core::mem::replace", [ T ] |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
-                                          "end";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
+                                          "end"
+                                        |);
                                         M.read (| n |)
                                       ]
                                     |)
@@ -11783,7 +11946,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -11810,7 +11973,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -11840,10 +12003,11 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   let _ :=
@@ -11864,14 +12028,16 @@ Module iter.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
-                                        "start";
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::ops::range::RangeInclusive"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
+                                        "start"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::ops::range::RangeInclusive",
                                         "end"
+                                      |)
                                     ]
                                   |)
                                 |)) in
@@ -11914,10 +12080,11 @@ Module iter.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::ops::range::RangeInclusive"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::ops::range::RangeInclusive",
                                                         "start"
+                                                      |)
                                                     ]
                                                   |)
                                                 ]
@@ -11930,7 +12097,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -11957,7 +12124,7 @@ Module iter.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -12105,14 +12272,16 @@ Module iter.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "start";
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |),
@@ -12120,7 +12289,7 @@ Module iter.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -12240,14 +12409,16 @@ Module iter.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  self
-                                  "core::ops::range::RangeInclusive"
-                                  "start";
-                                M.get_struct_record_field
-                                  self
-                                  "core::ops::range::RangeInclusive"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::RangeInclusive",
+                                  "start"
+                                |);
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::RangeInclusive",
                                   "end"
+                                |)
                               ]
                             |);
                             M.closure
@@ -12378,10 +12549,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "start"
+                                        |)
                                       ]
                                     |);
                                     M.read (| n |)
@@ -12389,7 +12561,7 @@ Module iter.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -12407,10 +12579,11 @@ Module iter.
                                   |),
                                   [
                                     plus_n;
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::RangeInclusive"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::RangeInclusive",
                                       "end"
+                                    |)
                                   ]
                                 |)
                               |),
@@ -12418,7 +12591,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -12428,10 +12601,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "start",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "start"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::iter::range::Step",
@@ -12466,7 +12640,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -12476,10 +12650,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "start",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "start"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::clone::Clone",
@@ -12493,10 +12668,11 @@ Module iter.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "exhausted",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "exhausted"
+                                              |),
                                               Value.Bool true
                                             |) in
                                           M.return_ (|
@@ -12515,26 +12691,29 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "start",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "start"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "end"
+                          |)
                         ]
                       |)
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)
@@ -12593,8 +12772,8 @@ Module iter.
             let init := M.alloc (| init |) in
             let fold := M.alloc (| fold |) in
             M.read (|
-              M.get_struct_tuple_field
-                (M.alloc (|
+              M.SubPointer.get_struct_tuple_field (|
+                M.alloc (|
                   M.call_closure (|
                     M.get_trait_method (|
                       "core::iter::traits::iterator::Iterator",
@@ -12620,9 +12799,10 @@ Module iter.
                       |)
                     ]
                   |)
-                |))
-                "core::ops::try_trait::NeverShortCircuit"
+                |),
+                "core::ops::try_trait::NeverShortCircuit",
                 0
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -12864,10 +13044,11 @@ Module iter.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::ops::range::RangeInclusive"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::ops::range::RangeInclusive",
                                           "end"
+                                        |)
                                       ]
                                     |);
                                     M.read (| n |)
@@ -12875,7 +13056,7 @@ Module iter.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -12893,10 +13074,11 @@ Module iter.
                                   |),
                                   [
                                     minus_n;
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::ops::range::RangeInclusive"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::ops::range::RangeInclusive",
                                       "start"
+                                    |)
                                   ]
                                 |)
                               |),
@@ -12904,7 +13086,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -12914,10 +13096,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "end",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "end"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::iter::range::Step",
@@ -12952,7 +13135,7 @@ Module iter.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -12962,10 +13145,11 @@ Module iter.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "end",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "end"
+                                              |),
                                               M.call_closure (|
                                                 M.get_trait_method (|
                                                   "core::clone::Clone",
@@ -12979,10 +13163,11 @@ Module iter.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::range::RangeInclusive"
-                                                "exhausted",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::range::RangeInclusive",
+                                                "exhausted"
+                                              |),
                                               Value.Bool true
                                             |) in
                                           M.return_ (|
@@ -13001,26 +13186,29 @@ Module iter.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "end",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "end"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
                             "start"
+                          |)
                         ]
                       |)
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "exhausted",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "exhausted"
+                      |),
                       Value.Bool true
                     |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)
@@ -13079,8 +13267,8 @@ Module iter.
             let init := M.alloc (| init |) in
             let fold := M.alloc (| fold |) in
             M.read (|
-              M.get_struct_tuple_field
-                (M.alloc (|
+              M.SubPointer.get_struct_tuple_field (|
+                M.alloc (|
                   M.call_closure (|
                     M.get_trait_method (|
                       "core::iter::traits::double_ended::DoubleEndedIterator",
@@ -13106,9 +13294,10 @@ Module iter.
                       |)
                     ]
                   |)
-                |))
-                "core::ops::try_trait::NeverShortCircuit"
+                |),
+                "core::ops::try_trait::NeverShortCircuit",
                 0
+              |)
             |)))
         | _, _ => M.impossible
         end.

--- a/CoqOfRust/core/iter/sources/from_coroutine.v
+++ b/CoqOfRust/core/iter/sources/from_coroutine.v
@@ -44,10 +44,11 @@ Module iter.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", G, [], "clone", [] |),
                     [
-                      M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::iter::sources::from_coroutine::FromCoroutine"
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::iter::sources::from_coroutine::FromCoroutine",
                         0
+                      |)
                     ]
                   |)
                 ]))
@@ -103,10 +104,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_tuple_field
-                              (M.read (| self |))
-                              "core::iter::sources::from_coroutine::FromCoroutine"
+                            M.SubPointer.get_struct_tuple_field (|
+                              M.read (| self |),
+                              "core::iter::sources::from_coroutine::FromCoroutine",
                               0
+                            |)
                           ]
                         |);
                         Value.Tuple []
@@ -117,7 +119,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::coroutine::CoroutineState::Yielded",
                             0
@@ -129,7 +131,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::coroutine::CoroutineState::Complete",
                             0

--- a/CoqOfRust/core/iter/sources/from_fn.v
+++ b/CoqOfRust/core/iter/sources/from_fn.v
@@ -45,10 +45,11 @@ Module iter.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                     [
-                      M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::iter::sources::from_fn::FromFn"
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::iter::sources::from_fn::FromFn",
                         0
+                      |)
                     ]
                   |)
                 ]))
@@ -91,10 +92,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_tuple_field
-                    (M.read (| self |))
-                    "core::iter::sources::from_fn::FromFn"
-                    0;
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::iter::sources::from_fn::FromFn",
+                    0
+                  |);
                   Value.Tuple []
                 ]
               |)))

--- a/CoqOfRust/core/iter/sources/once.v
+++ b/CoqOfRust/core/iter/sources/once.v
@@ -63,10 +63,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::once::Once"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::once::Once",
                           "inner"
+                        |)
                       ]
                     |))
                 ]))
@@ -107,10 +108,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::once::Once"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::once::Once",
                         "inner"
+                      |)
                     |))
                 ]
               |)))
@@ -153,10 +155,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::sources::once::Once"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::sources::once::Once",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -182,10 +185,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::sources::once::Once"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::sources::once::Once",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -229,10 +233,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::sources::once::Once"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::sources::once::Once",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible
@@ -271,10 +276,11 @@ Module iter.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::iter::sources::once::Once"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::iter::sources::once::Once",
                     "inner"
+                  |)
                 ]
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/iter/sources/once_with.v
+++ b/CoqOfRust/core/iter/sources/once_with.v
@@ -51,10 +51,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::once_with::OnceWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::once_with::OnceWith",
                           "gen"
+                        |)
                       ]
                     |))
                 ]))
@@ -106,10 +107,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::once_with::OnceWith"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::once_with::OnceWith",
                                     "gen"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -194,10 +196,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::sources::once_with::OnceWith"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::sources::once_with::OnceWith",
                                       "gen"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -207,7 +210,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -238,7 +241,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -297,10 +300,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::once_with::OnceWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::once_with::OnceWith",
                           "gen"
+                        |)
                       ]
                     |)
                   |)
@@ -392,10 +396,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::once_with::OnceWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::once_with::OnceWith",
                           "gen"
+                        |)
                       ]
                     |)
                   |)

--- a/CoqOfRust/core/iter/sources/repeat.v
+++ b/CoqOfRust/core/iter/sources/repeat.v
@@ -45,10 +45,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::repeat::Repeat"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::repeat::Repeat",
                           "element"
+                        |)
                       ]
                     |))
                 ]))
@@ -89,10 +90,11 @@ Module iter.
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::repeat::Repeat"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::repeat::Repeat",
                         "element"
+                      |)
                     |))
                 ]
               |)))
@@ -132,10 +134,11 @@ Module iter.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::repeat::Repeat"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::repeat::Repeat",
                         "element"
+                      |)
                     ]
                   |)
                 ]))
@@ -216,10 +219,11 @@ Module iter.
                               M.call_closure (|
                                 M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::repeat::Repeat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::repeat::Repeat",
                                     "element"
+                                  |)
                                 ]
                               |)
                             ]
@@ -303,10 +307,11 @@ Module iter.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::repeat::Repeat"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::repeat::Repeat",
                         "element"
+                      |)
                     ]
                   |)
                 ]))
@@ -368,10 +373,11 @@ Module iter.
                               M.call_closure (|
                                 M.get_trait_method (| "core::clone::Clone", A, [], "clone", [] |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::repeat::Repeat"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::repeat::Repeat",
                                     "element"
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/core/iter/sources/repeat_n.v
+++ b/CoqOfRust/core/iter/sources/repeat_n.v
@@ -108,10 +108,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::repeat_n::RepeatN"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::repeat_n::RepeatN",
                           "count"
+                        |)
                       ]
                     |));
                   ("element",
@@ -124,10 +125,11 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::repeat_n::RepeatN"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::repeat_n::RepeatN",
                           "element"
+                        |)
                       ]
                     |))
                 ]))
@@ -167,18 +169,20 @@ Module iter.
                   M.read (| Value.String "count" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::sources::repeat_n::RepeatN"
-                      "count");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::sources::repeat_n::RepeatN",
+                      "count"
+                    |));
                   M.read (| Value.String "element" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::repeat_n::RepeatN"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::repeat_n::RepeatN",
                         "element"
+                      |)
                     |))
                 ]
               |)))
@@ -227,10 +231,11 @@ Module iter.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::repeat_n::RepeatN"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::repeat_n::RepeatN",
                                     "count"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -238,10 +243,11 @@ Module iter.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::sources::repeat_n::RepeatN"
-                              "count",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::sources::repeat_n::RepeatN",
+                              "count"
+                            |),
                             Value.Integer Integer.Usize 0
                           |) in
                         M.alloc (|
@@ -255,10 +261,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::repeat_n::RepeatN"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::repeat_n::RepeatN",
                                     "element"
+                                  |)
                                 ]
                               |)
                             ]
@@ -362,10 +369,11 @@ Module iter.
                                   (M.alloc (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::iter::sources::repeat_n::RepeatN"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::iter::sources::repeat_n::RepeatN",
                                           "count"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -388,10 +396,11 @@ Module iter.
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::repeat_n::RepeatN"
-                          "count" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::repeat_n::RepeatN",
+                          "count"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -411,10 +420,11 @@ Module iter.
                                         (M.alloc (|
                                           BinOp.Pure.eq
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::sources::repeat_n::RepeatN"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::sources::repeat_n::RepeatN",
                                                 "count"
+                                              |)
                                             |))
                                             (Value.Integer Integer.Usize 0)
                                         |)) in
@@ -433,10 +443,11 @@ Module iter.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::iter::sources::repeat_n::RepeatN"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::iter::sources::repeat_n::RepeatN",
                                             "element"
+                                          |)
                                         ]
                                       |)
                                     |)));
@@ -463,10 +474,11 @@ Module iter.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::iter::sources::repeat_n::RepeatN"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::iter::sources::repeat_n::RepeatN",
                                                 "element"
+                                              |)
                                             ]
                                           |)
                                         ]
@@ -546,10 +558,11 @@ Module iter.
               M.read (|
                 let len :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::iter::sources::repeat_n::RepeatN"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::iter::sources::repeat_n::RepeatN",
                       "count"
+                    |)
                   |) in
                 let _ :=
                   M.match_operator (|
@@ -607,10 +620,11 @@ Module iter.
                       ltac:(M.monadic
                         (let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::sources::repeat_n::RepeatN"
-                              "count",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::sources::repeat_n::RepeatN",
+                              "count"
+                            |),
                             BinOp.Panic.sub (| M.read (| len |), M.read (| skip |) |)
                           |) in
                         M.alloc (|
@@ -701,10 +715,11 @@ Module iter.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::iter::sources::repeat_n::RepeatN"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::iter::sources::repeat_n::RepeatN",
                   "count"
+                |)
               |)))
           | _, _ => M.impossible
           end.

--- a/CoqOfRust/core/iter/sources/repeat_with.v
+++ b/CoqOfRust/core/iter/sources/repeat_with.v
@@ -58,10 +58,11 @@ Module iter.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::repeat_with::RepeatWith"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::repeat_with::RepeatWith",
                           "repeater"
+                        |)
                       ]
                     |))
                 ]))
@@ -154,10 +155,11 @@ Module iter.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::iter::sources::repeat_with::RepeatWith"
-                        "repeater";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::iter::sources::repeat_with::RepeatWith",
+                        "repeater"
+                      |);
                       Value.Tuple []
                     ]
                   |)
@@ -225,10 +227,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::repeat_with::RepeatWith"
-                                    "repeater";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::repeat_with::RepeatWith",
+                                    "repeater"
+                                  |);
                                   Value.Tuple []
                                 ]
                               |)
@@ -268,7 +271,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -295,7 +298,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0

--- a/CoqOfRust/core/iter/sources/successors.v
+++ b/CoqOfRust/core/iter/sources/successors.v
@@ -58,20 +58,22 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::successors::Successors"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::successors::Successors",
                           "next"
+                        |)
                       ]
                     |));
                   ("succ",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", F, [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::successors::Successors"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::successors::Successors",
                           "succ"
+                        |)
                       ]
                     |))
                 ]))
@@ -130,10 +132,11 @@ Module iter.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::iter::sources::successors::Successors"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::iter::sources::successors::Successors",
                                       "next"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -143,7 +146,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -174,7 +177,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -186,10 +189,11 @@ Module iter.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::successors::Successors"
-                          "next",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::successors::Successors",
+                          "next"
+                        |),
                         M.call_closure (|
                           M.get_trait_method (|
                             "core::ops::function::FnMut",
@@ -199,10 +203,11 @@ Module iter.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::iter::sources::successors::Successors"
-                              "succ";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::iter::sources::successors::Successors",
+                              "succ"
+                            |);
                             Value.Tuple [ item ]
                           ]
                         |)
@@ -242,10 +247,11 @@ Module iter.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::iter::sources::successors::Successors"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::iter::sources::successors::Successors",
                                     "next"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -345,10 +351,11 @@ Module iter.
                       M.read (| Value.String "next" |);
                       (* Unsize *)
                       M.pointer_coercion
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::iter::sources::successors::Successors"
-                          "next")
+                        (M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::iter::sources::successors::Successors",
+                          "next"
+                        |))
                     ]
                   |)
                 ]

--- a/CoqOfRust/core/iter/traits/collect.v
+++ b/CoqOfRust/core/iter/traits/collect.v
@@ -207,8 +207,8 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
-                        let γ1_0 := M.get_tuple_field γ 0 in
-                        let γ1_1 := M.get_tuple_field γ 1 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let a := M.alloc (| γ1_0 |) in
                         let b := M.alloc (| γ1_1 |) in
                         let iter :=
@@ -240,8 +240,8 @@ Module iter.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let lower_bound := M.copy (| γ0_0 |) in
                                 let _ :=
                                   M.match_operator (|
@@ -345,8 +345,8 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 0;
-                        M.read (| M.get_tuple_field item 0 |)
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                        M.read (| M.SubPointer.get_tuple_field (| item, 0 |) |)
                       ]
                     |)
                   |) in
@@ -361,8 +361,8 @@ Module iter.
                         []
                       |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 1;
-                        M.read (| M.get_tuple_field item 1 |)
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                        M.read (| M.SubPointer.get_tuple_field (| item, 1 |) |)
                       ]
                     |)
                   |) in
@@ -399,7 +399,10 @@ Module iter.
                         "extend_reserve",
                         []
                       |),
-                      [ M.get_tuple_field (M.read (| self |)) 0; M.read (| additional |) ]
+                      [
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                        M.read (| additional |)
+                      ]
                     |)
                   |) in
                 let _ :=
@@ -412,7 +415,10 @@ Module iter.
                         "extend_reserve",
                         []
                       |),
-                      [ M.get_tuple_field (M.read (| self |)) 1; M.read (| additional |) ]
+                      [
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                        M.read (| additional |)
+                      ]
                     |)
                   |) in
                 M.alloc (| Value.Tuple [] |)

--- a/CoqOfRust/core/iter/traits/double_ended.v
+++ b/CoqOfRust/core/iter/traits/double_ended.v
@@ -68,7 +68,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -273,7 +273,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -315,7 +315,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -342,7 +342,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -423,7 +423,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -716,7 +716,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -805,7 +805,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -847,7 +847,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -874,7 +874,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -954,8 +954,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::double_ended::DoubleEndedIteratorRefSpec",
@@ -981,9 +981,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.

--- a/CoqOfRust/core/iter/traits/exact_size.v
+++ b/CoqOfRust/core/iter/traits/exact_size.v
@@ -28,8 +28,8 @@ Module iter.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let lower := M.copy (| γ0_0 |) in
                         let upper := M.copy (| γ0_1 |) in
                         let _ :=
@@ -48,8 +48,8 @@ Module iter.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let left_val := M.copy (| γ0_0 |) in
                                   let right_val := M.copy (| γ0_1 |) in
                                   M.match_operator (|

--- a/CoqOfRust/core/iter/traits/iterator.v
+++ b/CoqOfRust/core/iter/traits/iterator.v
@@ -186,7 +186,7 @@ Module iter.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -322,7 +322,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -355,7 +355,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1068,7 +1068,7 @@ Module iter.
                                           |)
                                         |) in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -1103,7 +1103,7 @@ Module iter.
                                                   |)
                                                 |) in
                                               let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -1232,7 +1232,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -1274,7 +1274,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -1301,7 +1301,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -1407,7 +1407,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1490,7 +1490,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -1523,7 +1523,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -1584,7 +1584,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1636,7 +1636,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1657,7 +1657,7 @@ Module iter.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1924,7 +1924,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1934,7 +1934,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2193,7 +2193,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -2226,7 +2226,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -2238,8 +2238,8 @@ Module iter.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let x := M.copy (| γ0_1 |) in
                             M.alloc (|
                               Value.StructTuple "core::option::Option::Some" [ M.read (| x |) ]
@@ -2347,7 +2347,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -2380,7 +2380,7 @@ Module iter.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -2392,8 +2392,8 @@ Module iter.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let x := M.copy (| γ0_1 |) in
                             M.alloc (|
                               Value.StructTuple "core::option::Option::Some" [ M.read (| x |) ]
@@ -2703,7 +2703,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2713,7 +2713,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2835,7 +2835,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2847,7 +2847,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2960,7 +2960,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2981,7 +2981,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -3080,7 +3080,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -3171,7 +3171,7 @@ Module iter.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -3263,7 +3263,7 @@ Module iter.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -3463,7 +3463,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -3495,7 +3495,7 @@ Module iter.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -3511,7 +3511,7 @@ Module iter.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -3589,7 +3589,7 @@ Module iter.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -3870,7 +3870,7 @@ Module iter.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -3959,7 +3959,7 @@ Module iter.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -4001,7 +4001,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Break",
                                                     0
@@ -4028,7 +4028,7 @@ Module iter.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                     0
@@ -4108,8 +4108,8 @@ Module iter.
               let init := M.alloc (| init |) in
               let fold := M.alloc (| fold |) in
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
                         "core::iter::traits::iterator::IteratorRefSpec",
@@ -4135,9 +4135,10 @@ Module iter.
                         |)
                       ]
                     |)
-                  |))
-                  "core::ops::try_trait::NeverShortCircuit"
+                  |),
+                  "core::ops::try_trait::NeverShortCircuit",
                   0
+                |)
               |)))
           | _, _ => M.impossible
           end.

--- a/CoqOfRust/core/mem/manually_drop.v
+++ b/CoqOfRust/core/mem/manually_drop.v
@@ -41,10 +41,11 @@ Module mem.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::mem::manually_drop::ManuallyDrop"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::mem::manually_drop::ManuallyDrop",
                         "value"
+                      |)
                     ]
                   |))
               ]))
@@ -85,10 +86,11 @@ Module mem.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::mem::manually_drop::ManuallyDrop"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::mem::manually_drop::ManuallyDrop",
                       "value"
+                    |)
                   |))
               ]
             |)))
@@ -163,14 +165,16 @@ Module mem.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::mem::manually_drop::ManuallyDrop"
-                  "value";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::mem::manually_drop::ManuallyDrop"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::mem::manually_drop::ManuallyDrop",
                   "value"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::mem::manually_drop::ManuallyDrop",
+                  "value"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -243,14 +247,16 @@ Module mem.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "partial_cmp", [] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::mem::manually_drop::ManuallyDrop"
-                  "value";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::mem::manually_drop::ManuallyDrop"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::mem::manually_drop::ManuallyDrop",
                   "value"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::mem::manually_drop::ManuallyDrop",
+                  "value"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -280,14 +286,16 @@ Module mem.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::mem::manually_drop::ManuallyDrop"
-                  "value";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::mem::manually_drop::ManuallyDrop"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::mem::manually_drop::ManuallyDrop",
                   "value"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::mem::manually_drop::ManuallyDrop",
+                  "value"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -317,10 +325,11 @@ Module mem.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", T, [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::mem::manually_drop::ManuallyDrop"
-                  "value";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::mem::manually_drop::ManuallyDrop",
+                  "value"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -373,7 +382,11 @@ Module mem.
           ltac:(M.monadic
             (let slot := M.alloc (| slot |) in
             M.read (|
-              M.get_struct_record_field slot "core::mem::manually_drop::ManuallyDrop" "value"
+              M.SubPointer.get_struct_record_field (|
+                slot,
+                "core::mem::manually_drop::ManuallyDrop",
+                "value"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -398,10 +411,11 @@ Module mem.
             M.call_closure (|
               M.get_function (| "core::ptr::read", [ T ] |),
               [
-                M.get_struct_record_field
-                  (M.read (| slot |))
-                  "core::mem::manually_drop::ManuallyDrop"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| slot |),
+                  "core::mem::manually_drop::ManuallyDrop",
                   "value"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -427,10 +441,11 @@ Module mem.
             M.call_closure (|
               M.get_function (| "core::ptr::drop_in_place", [ T ] |),
               [
-                M.get_struct_record_field
-                  (M.read (| slot |))
-                  "core::mem::manually_drop::ManuallyDrop"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| slot |),
+                  "core::mem::manually_drop::ManuallyDrop",
                   "value"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -460,10 +475,11 @@ Module mem.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::mem::manually_drop::ManuallyDrop"
-              "value"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::mem::manually_drop::ManuallyDrop",
+              "value"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -492,10 +508,11 @@ Module mem.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::mem::manually_drop::ManuallyDrop"
-              "value"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::mem::manually_drop::ManuallyDrop",
+              "value"
+            |)))
         | _, _ => M.impossible
         end.
       

--- a/CoqOfRust/core/mem/maybe_uninit.v
+++ b/CoqOfRust/core/mem/maybe_uninit.v
@@ -364,7 +364,11 @@ Module mem.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field self "core::mem::maybe_uninit::MaybeUninit" "value"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::maybe_uninit::MaybeUninit",
+                        "value"
+                      |)
                     |)
                   ]
                 |)
@@ -853,8 +857,8 @@ Module mem.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let left_val := M.copy (| γ0_0 |) in
                         let right_val := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -1012,7 +1016,7 @@ Module mem.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1029,12 +1033,13 @@ Module mem.
                                                 []
                                               |),
                                               [
-                                                M.get_array_field (|
+                                                M.SubPointer.get_array_field (|
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      guard
-                                                      "core::mem::maybe_uninit::write_slice_cloned::Guard"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      guard,
+                                                      "core::mem::maybe_uninit::write_slice_cloned::Guard",
                                                       "slice"
+                                                    |)
                                                   |),
                                                   i
                                                 |);
@@ -1046,17 +1051,23 @@ Module mem.
                                                     "clone",
                                                     []
                                                   |),
-                                                  [ M.get_array_field (| M.read (| src |), i |) ]
+                                                  [
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| src |),
+                                                      i
+                                                    |)
+                                                  ]
                                                 |)
                                               ]
                                             |)
                                           |) in
                                         let _ :=
                                           let β :=
-                                            M.get_struct_record_field
-                                              guard
-                                              "core::mem::maybe_uninit::write_slice_cloned::Guard"
-                                              "initialized" in
+                                            M.SubPointer.get_struct_record_field (|
+                                              guard,
+                                              "core::mem::maybe_uninit::write_slice_cloned::Guard",
+                                              "initialized"
+                                            |) in
                                           M.write (|
                                             β,
                                             BinOp.Panic.add (|

--- a/CoqOfRust/core/mem/mod.v
+++ b/CoqOfRust/core/mem/mod.v
@@ -750,8 +750,16 @@ Module mem.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::mem::Discriminant" 0;
-              M.get_struct_tuple_field (M.read (| rhs |)) "core::mem::Discriminant" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::mem::Discriminant",
+                0
+              |);
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| rhs |),
+                "core::mem::Discriminant",
+                0
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -795,7 +803,11 @@ Module mem.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.associated, [], "hash", [ H ] |),
                   [
-                    M.get_struct_tuple_field (M.read (| self |)) "core::mem::Discriminant" 0;
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::mem::Discriminant",
+                      0
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -851,7 +863,11 @@ Module mem.
                   |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_tuple_field (M.read (| self |)) "core::mem::Discriminant" 0)
+                    (M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::mem::Discriminant",
+                      0
+                    |))
                 ]
               |)
             ]

--- a/CoqOfRust/core/mem/transmutability.v
+++ b/CoqOfRust/core/mem/transmutability.v
@@ -45,60 +45,68 @@ Module mem.
                 LogicalOp.and (|
                   BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::mem::transmutability::Assume",
                         "alignment"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::mem::transmutability::Assume",
                         "alignment"
+                      |)
                     |)),
                   ltac:(M.monadic
                     (BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::mem::transmutability::Assume",
                           "lifetimes"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::mem::transmutability::Assume",
                           "lifetimes"
+                        |)
                       |))))
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::mem::transmutability::Assume",
                         "safety"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::mem::transmutability::Assume",
                         "safety"
+                      |)
                     |))))
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::mem::transmutability::Assume"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::mem::transmutability::Assume",
                       "validity"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::mem::transmutability::Assume"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::mem::transmutability::Assume",
                       "validity"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -209,32 +217,36 @@ Module mem.
                 M.read (| Value.String "alignment" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::mem::transmutability::Assume"
-                    "alignment");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::mem::transmutability::Assume",
+                    "alignment"
+                  |));
                 M.read (| Value.String "lifetimes" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::mem::transmutability::Assume"
-                    "lifetimes");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::mem::transmutability::Assume",
+                    "lifetimes"
+                  |));
                 M.read (| Value.String "safety" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::mem::transmutability::Assume"
-                    "safety");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::mem::transmutability::Assume",
+                    "safety"
+                  |));
                 M.read (| Value.String "validity" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::mem::transmutability::Assume"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::mem::transmutability::Assume",
                       "validity"
+                    |)
                   |))
               ]
             |)))
@@ -363,59 +375,73 @@ Module mem.
                 ("alignment",
                   LogicalOp.or (|
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
                         "alignment"
+                      |)
                     |),
                     ltac:(M.monadic
                       (M.read (|
-                        M.get_struct_record_field
-                          other_assumptions
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          other_assumptions,
+                          "core::mem::transmutability::Assume",
                           "alignment"
+                        |)
                       |)))
                   |));
                 ("lifetimes",
                   LogicalOp.or (|
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
                         "lifetimes"
+                      |)
                     |),
                     ltac:(M.monadic
                       (M.read (|
-                        M.get_struct_record_field
-                          other_assumptions
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          other_assumptions,
+                          "core::mem::transmutability::Assume",
                           "lifetimes"
+                        |)
                       |)))
                   |));
                 ("safety",
                   LogicalOp.or (|
                     M.read (|
-                      M.get_struct_record_field self "core::mem::transmutability::Assume" "safety"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
+                        "safety"
+                      |)
                     |),
                     ltac:(M.monadic
                       (M.read (|
-                        M.get_struct_record_field
-                          other_assumptions
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          other_assumptions,
+                          "core::mem::transmutability::Assume",
                           "safety"
+                        |)
                       |)))
                   |));
                 ("validity",
                   LogicalOp.or (|
                     M.read (|
-                      M.get_struct_record_field self "core::mem::transmutability::Assume" "validity"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
+                        "validity"
+                      |)
                     |),
                     ltac:(M.monadic
                       (M.read (|
-                        M.get_struct_record_field
-                          other_assumptions
-                          "core::mem::transmutability::Assume"
+                        M.SubPointer.get_struct_record_field (|
+                          other_assumptions,
+                          "core::mem::transmutability::Assume",
                           "validity"
+                        |)
                       |)))
                   |))
               ]))
@@ -446,63 +472,77 @@ Module mem.
                 ("alignment",
                   LogicalOp.and (|
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
                         "alignment"
+                      |)
                     |),
                     ltac:(M.monadic
                       (UnOp.Pure.not
                         (M.read (|
-                          M.get_struct_record_field
-                            other_assumptions
-                            "core::mem::transmutability::Assume"
+                          M.SubPointer.get_struct_record_field (|
+                            other_assumptions,
+                            "core::mem::transmutability::Assume",
                             "alignment"
+                          |)
                         |))))
                   |));
                 ("lifetimes",
                   LogicalOp.and (|
                     M.read (|
-                      M.get_struct_record_field
-                        self
-                        "core::mem::transmutability::Assume"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
                         "lifetimes"
+                      |)
                     |),
                     ltac:(M.monadic
                       (UnOp.Pure.not
                         (M.read (|
-                          M.get_struct_record_field
-                            other_assumptions
-                            "core::mem::transmutability::Assume"
+                          M.SubPointer.get_struct_record_field (|
+                            other_assumptions,
+                            "core::mem::transmutability::Assume",
                             "lifetimes"
+                          |)
                         |))))
                   |));
                 ("safety",
                   LogicalOp.and (|
                     M.read (|
-                      M.get_struct_record_field self "core::mem::transmutability::Assume" "safety"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
+                        "safety"
+                      |)
                     |),
                     ltac:(M.monadic
                       (UnOp.Pure.not
                         (M.read (|
-                          M.get_struct_record_field
-                            other_assumptions
-                            "core::mem::transmutability::Assume"
+                          M.SubPointer.get_struct_record_field (|
+                            other_assumptions,
+                            "core::mem::transmutability::Assume",
                             "safety"
+                          |)
                         |))))
                   |));
                 ("validity",
                   LogicalOp.and (|
                     M.read (|
-                      M.get_struct_record_field self "core::mem::transmutability::Assume" "validity"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::mem::transmutability::Assume",
+                        "validity"
+                      |)
                     |),
                     ltac:(M.monadic
                       (UnOp.Pure.not
                         (M.read (|
-                          M.get_struct_record_field
-                            other_assumptions
-                            "core::mem::transmutability::Assume"
+                          M.SubPointer.get_struct_record_field (|
+                            other_assumptions,
+                            "core::mem::transmutability::Assume",
                             "validity"
+                          |)
                         |))))
                   |))
               ]))

--- a/CoqOfRust/core/net/display_buffer.v
+++ b/CoqOfRust/core/net/display_buffer.v
@@ -88,19 +88,21 @@ Module net.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::net::display_buffer::DisplayBuffer"
-                            "buf";
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::net::display_buffer::DisplayBuffer",
+                            "buf"
+                          |);
                           Value.StructRecord
                             "core::ops::range::RangeTo"
                             [
                               ("end_",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::net::display_buffer::DisplayBuffer"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::net::display_buffer::DisplayBuffer",
                                     "len"
+                                  |)
                                 |))
                             ]
                         ]
@@ -173,27 +175,30 @@ Module net.
                             [
                               (* Unsize *)
                               M.pointer_coercion
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::net::display_buffer::DisplayBuffer"
-                                  "buf");
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::net::display_buffer::DisplayBuffer",
+                                  "buf"
+                                |));
                               Value.StructRecord
                                 "core::ops::range::Range"
                                 [
                                   ("start",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::net::display_buffer::DisplayBuffer"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::net::display_buffer::DisplayBuffer",
                                         "len"
+                                      |)
                                     |));
                                   ("end_",
                                     BinOp.Panic.add (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::net::display_buffer::DisplayBuffer"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::net::display_buffer::DisplayBuffer",
                                           "len"
+                                        |)
                                       |),
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -209,7 +214,7 @@ Module net.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -230,10 +235,11 @@ Module net.
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::net::display_buffer::DisplayBuffer"
-                            "len" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::net::display_buffer::DisplayBuffer",
+                            "len"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (|

--- a/CoqOfRust/core/net/ip_addr.v
+++ b/CoqOfRust/core/net/ip_addr.v
@@ -164,11 +164,11 @@ Module net.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::ip_addr::IpAddr::V4",
                                   0
@@ -176,7 +176,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::ip_addr::IpAddr::V4",
                                   0
@@ -196,11 +196,11 @@ Module net.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::ip_addr::IpAddr::V6",
                                   0
@@ -208,7 +208,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::ip_addr::IpAddr::V6",
                                   0
@@ -294,7 +294,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -316,7 +316,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -384,11 +384,11 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -396,7 +396,7 @@ Module net.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -416,11 +416,11 @@ Module net.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -428,7 +428,7 @@ Module net.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -520,11 +520,11 @@ Module net.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::ip_addr::IpAddr::V4",
                                   0
@@ -532,7 +532,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::ip_addr::IpAddr::V4",
                                   0
@@ -552,11 +552,11 @@ Module net.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::ip_addr::IpAddr::V6",
                                   0
@@ -564,7 +564,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::ip_addr::IpAddr::V6",
                                   0
@@ -686,14 +686,16 @@ Module net.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::net::ip_addr::Ipv4Addr"
-                  "octets";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::net::ip_addr::Ipv4Addr"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::net::ip_addr::Ipv4Addr",
                   "octets"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::net::ip_addr::Ipv4Addr",
+                  "octets"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -764,10 +766,11 @@ Module net.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::net::ip_addr::Ipv4Addr"
-                  "octets";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::net::ip_addr::Ipv4Addr",
+                  "octets"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -856,14 +859,16 @@ Module net.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::net::ip_addr::Ipv6Addr"
-                  "octets";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::net::ip_addr::Ipv6Addr"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::net::ip_addr::Ipv6Addr",
                   "octets"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::net::ip_addr::Ipv6Addr",
+                  "octets"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -934,10 +939,11 @@ Module net.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::net::ip_addr::Ipv6Addr"
-                  "octets";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::net::ip_addr::Ipv6Addr",
+                  "octets"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -1242,7 +1248,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1262,7 +1268,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1308,7 +1314,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1328,7 +1334,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1373,7 +1379,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1393,7 +1399,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1438,7 +1444,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1458,7 +1464,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1504,7 +1510,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1524,7 +1530,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1570,7 +1576,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1590,7 +1596,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1633,7 +1639,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1666,7 +1672,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1702,7 +1708,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1712,7 +1718,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1784,7 +1790,14 @@ Module net.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "from_be_bytes", [] |),
-              [ M.read (| M.get_struct_record_field self "core::net::ip_addr::Ipv4Addr" "octets" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::net::ip_addr::Ipv4Addr",
+                    "octets"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1887,7 +1900,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::net::ip_addr::Ipv4Addr" "octets"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::ip_addr::Ipv4Addr",
+                "octets"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -1909,10 +1926,11 @@ Module net.
                 M.get_associated_function (| Ty.path "u32", "from_be_bytes", [] |),
                 [
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::net::ip_addr::Ipv4Addr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::net::ip_addr::Ipv4Addr",
                       "octets"
+                    |)
                   |)
                 ]
               |))
@@ -1935,7 +1953,7 @@ Module net.
             (let self := M.alloc (| self |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (|
@@ -1985,8 +2003,8 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -1995,9 +2013,9 @@ Module net.
                       M.alloc (| Value.Bool true |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_rest := M.get_slice_rest_or_break_match (| γ, 2, 0 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_rest := M.SubPointer.get_slice_rest (| γ, 2, 0 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -2017,9 +2035,9 @@ Module net.
                       M.alloc (| Value.Bool true |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_rest := M.get_slice_rest_or_break_match (| γ, 2, 0 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_rest := M.SubPointer.get_slice_rest (| γ, 2, 0 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -2065,9 +2083,9 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_rest := M.get_slice_rest_or_break_match (| γ, 2, 0 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_rest := M.SubPointer.get_slice_rest (| γ, 2, 0 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -2121,7 +2139,7 @@ Module net.
                               LogicalOp.or (|
                                 BinOp.Pure.eq
                                   (M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
@@ -2181,7 +2199,7 @@ Module net.
                             LogicalOp.and (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     M.alloc (|
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -2199,7 +2217,7 @@ Module net.
                               ltac:(M.monadic
                                 (BinOp.Pure.eq
                                   (M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       M.alloc (|
                                         M.call_closure (|
                                           M.get_associated_function (|
@@ -2218,7 +2236,7 @@ Module net.
                             ltac:(M.monadic
                               (BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     M.alloc (|
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -2293,7 +2311,7 @@ Module net.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -2312,7 +2330,7 @@ Module net.
                 (BinOp.Pure.eq
                   (BinOp.Pure.bit_and
                     (M.read (|
-                      M.get_array_field (|
+                      M.SubPointer.get_array_field (|
                         M.alloc (|
                           M.call_closure (|
                             M.get_associated_function (|
@@ -2347,7 +2365,7 @@ Module net.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -2366,7 +2384,7 @@ Module net.
                 (BinOp.Pure.eq
                   (BinOp.Pure.bit_and
                     (M.read (|
-                      M.get_array_field (|
+                      M.SubPointer.get_array_field (|
                         M.alloc (|
                           M.call_closure (|
                             M.get_associated_function (|
@@ -2403,7 +2421,7 @@ Module net.
               BinOp.Pure.eq
                 (BinOp.Pure.bit_and
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.alloc (|
                         M.call_closure (|
                           M.get_associated_function (|
@@ -2448,7 +2466,7 @@ Module net.
             LogicalOp.and (|
               BinOp.Pure.ge
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -2466,7 +2484,7 @@ Module net.
               ltac:(M.monadic
                 (BinOp.Pure.le
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.alloc (|
                         M.call_closure (|
                           M.get_associated_function (|
@@ -2561,10 +2579,10 @@ Module net.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                              let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                              let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                              let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                              (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                              let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),
@@ -2583,10 +2601,10 @@ Module net.
                               Value.Tuple []));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                              let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                              let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                              let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                              (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                              let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),
@@ -2605,10 +2623,10 @@ Module net.
                               Value.Tuple []));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                              let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                              let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                              let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                              (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                              let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),
@@ -2670,10 +2688,10 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       let c := M.copy (| γ0_2 |) in
@@ -2739,10 +2757,10 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       let c := M.copy (| γ0_2 |) in
@@ -2808,7 +2826,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -2830,7 +2848,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -3077,7 +3095,7 @@ Module net.
                                             [ Ty.path "u8" ]
                                           |),
                                           [
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               octets,
                                               M.alloc (| Value.Integer Integer.Usize 0 |)
                                             |)
@@ -3090,7 +3108,7 @@ Module net.
                                             [ Ty.path "u8" ]
                                           |),
                                           [
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               octets,
                                               M.alloc (| Value.Integer Integer.Usize 1 |)
                                             |)
@@ -3103,7 +3121,7 @@ Module net.
                                             [ Ty.path "u8" ]
                                           |),
                                           [
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               octets,
                                               M.alloc (| Value.Integer Integer.Usize 2 |)
                                             |)
@@ -3116,7 +3134,7 @@ Module net.
                                             [ Ty.path "u8" ]
                                           |),
                                           [
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               octets,
                                               M.alloc (| Value.Integer Integer.Usize 3 |)
                                             |)
@@ -3193,7 +3211,7 @@ Module net.
                                                   [ Ty.path "u8" ]
                                                 |),
                                                 [
-                                                  M.get_array_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     octets,
                                                     M.alloc (| Value.Integer Integer.Usize 0 |)
                                                   |)
@@ -3206,7 +3224,7 @@ Module net.
                                                   [ Ty.path "u8" ]
                                                 |),
                                                 [
-                                                  M.get_array_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     octets,
                                                     M.alloc (| Value.Integer Integer.Usize 1 |)
                                                   |)
@@ -3219,7 +3237,7 @@ Module net.
                                                   [ Ty.path "u8" ]
                                                 |),
                                                 [
-                                                  M.get_array_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     octets,
                                                     M.alloc (| Value.Integer Integer.Usize 2 |)
                                                   |)
@@ -3232,7 +3250,7 @@ Module net.
                                                   [ Ty.path "u8" ]
                                                 |),
                                                 [
-                                                  M.get_array_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     octets,
                                                     M.alloc (| Value.Integer Integer.Usize 3 |)
                                                   |)
@@ -3337,7 +3355,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -3359,7 +3377,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -3404,7 +3422,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -3426,7 +3444,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -3510,7 +3528,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -3532,7 +3550,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -3581,7 +3599,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -3603,7 +3621,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -3650,14 +3668,16 @@ Module net.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::net::ip_addr::Ipv4Addr"
-                  "octets";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::net::ip_addr::Ipv4Addr"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::net::ip_addr::Ipv4Addr",
                   "octets"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::net::ip_addr::Ipv4Addr",
+                  "octets"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3942,7 +3962,14 @@ Module net.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "from_be_bytes", [] |),
-              [ M.read (| M.get_struct_record_field self "core::net::ip_addr::Ipv6Addr" "octets" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::net::ip_addr::Ipv6Addr",
+                    "octets"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4058,10 +4085,11 @@ Module net.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::net::ip_addr::Ipv6Addr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::net::ip_addr::Ipv6Addr",
                           "octets"
+                        |)
                       |)
                     ]
                   |)
@@ -4069,14 +4097,14 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                      let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                      let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                      let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                      let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       let c := M.copy (| γ0_2 |) in
@@ -4292,14 +4320,14 @@ Module net.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                        let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                                        let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                                        let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                                        let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                                        let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                                        let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                                        let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                                        (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                        let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                        let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                        let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                        let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                        let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                        let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                         let _ :=
                                           M.is_constant_or_break_match (|
                                             M.read (| γ0_0 |),
@@ -4352,14 +4380,14 @@ Module net.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                                      let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                                      let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                                      let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                                      let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                      let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                      let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                      let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                      let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                       let _ :=
                                         M.is_constant_or_break_match (|
                                           M.read (| γ0_0 |),
@@ -4397,14 +4425,14 @@ Module net.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                     let _ :=
                                       M.is_constant_or_break_match (|
                                         M.read (| γ0_0 |),
@@ -4448,14 +4476,14 @@ Module net.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                     let _ :=
                                       M.is_constant_or_break_match (|
                                         M.read (| γ0_0 |),
@@ -4545,21 +4573,21 @@ Module net.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_slice_index_or_break_match (| γ, 0 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 0 |) in
                                                 let γ0_1 :=
-                                                  M.get_slice_index_or_break_match (| γ, 1 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 1 |) in
                                                 let γ0_2 :=
-                                                  M.get_slice_index_or_break_match (| γ, 2 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 2 |) in
                                                 let γ0_3 :=
-                                                  M.get_slice_index_or_break_match (| γ, 3 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 3 |) in
                                                 let γ0_4 :=
-                                                  M.get_slice_index_or_break_match (| γ, 4 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 4 |) in
                                                 let γ0_5 :=
-                                                  M.get_slice_index_or_break_match (| γ, 5 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 5 |) in
                                                 let γ0_6 :=
-                                                  M.get_slice_index_or_break_match (| γ, 6 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 6 |) in
                                                 let γ0_7 :=
-                                                  M.get_slice_index_or_break_match (| γ, 7 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 7 |) in
                                                 let _ :=
                                                   M.is_constant_or_break_match (|
                                                     M.read (| γ0_0 |),
@@ -4594,21 +4622,14 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_slice_index_or_break_match (| γ, 0 |) in
-                                              let γ0_1 :=
-                                                M.get_slice_index_or_break_match (| γ, 1 |) in
-                                              let γ0_2 :=
-                                                M.get_slice_index_or_break_match (| γ, 2 |) in
-                                              let γ0_3 :=
-                                                M.get_slice_index_or_break_match (| γ, 3 |) in
-                                              let γ0_4 :=
-                                                M.get_slice_index_or_break_match (| γ, 4 |) in
-                                              let γ0_5 :=
-                                                M.get_slice_index_or_break_match (| γ, 5 |) in
-                                              let γ0_6 :=
-                                                M.get_slice_index_or_break_match (| γ, 6 |) in
-                                              let γ0_7 :=
-                                                M.get_slice_index_or_break_match (| γ, 7 |) in
+                                                M.SubPointer.get_slice_index (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                              let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                              let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                              let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                              let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                              let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                              let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                               let _ :=
                                                 M.is_constant_or_break_match (|
                                                   M.read (| γ0_0 |),
@@ -4646,22 +4667,14 @@ Module net.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 :=
-                                              M.get_slice_index_or_break_match (| γ, 0 |) in
-                                            let γ0_1 :=
-                                              M.get_slice_index_or_break_match (| γ, 1 |) in
-                                            let γ0_2 :=
-                                              M.get_slice_index_or_break_match (| γ, 2 |) in
-                                            let γ0_3 :=
-                                              M.get_slice_index_or_break_match (| γ, 3 |) in
-                                            let γ0_4 :=
-                                              M.get_slice_index_or_break_match (| γ, 4 |) in
-                                            let γ0_5 :=
-                                              M.get_slice_index_or_break_match (| γ, 5 |) in
-                                            let γ0_6 :=
-                                              M.get_slice_index_or_break_match (| γ, 6 |) in
-                                            let γ0_7 :=
-                                              M.get_slice_index_or_break_match (| γ, 7 |) in
+                                            (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                                            let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                                            let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                                            let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                                            let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                                            let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                                            let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                                             let _ :=
                                               M.is_constant_or_break_match (|
                                                 M.read (| γ0_0 |),
@@ -4746,7 +4759,7 @@ Module net.
             BinOp.Pure.eq
               (BinOp.Pure.bit_and
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -4805,7 +4818,7 @@ Module net.
             BinOp.Pure.eq
               (BinOp.Pure.bit_and
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -4840,7 +4853,7 @@ Module net.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -4858,7 +4871,7 @@ Module net.
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.alloc (|
                         M.call_closure (|
                           M.get_associated_function (|
@@ -4894,7 +4907,7 @@ Module net.
               LogicalOp.and (|
                 BinOp.Pure.eq
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.alloc (|
                         M.call_closure (|
                           M.get_associated_function (|
@@ -4912,7 +4925,7 @@ Module net.
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_array_field (|
+                      M.SubPointer.get_array_field (|
                         M.alloc (|
                           M.call_closure (|
                             M.get_associated_function (|
@@ -4931,7 +4944,7 @@ Module net.
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.alloc (|
                         M.call_closure (|
                           M.get_associated_function (|
@@ -5101,7 +5114,7 @@ Module net.
                         M.alloc (|
                           BinOp.Pure.bit_and
                             (M.read (|
-                              M.get_array_field (|
+                              M.SubPointer.get_array_field (|
                                 M.alloc (|
                                   M.call_closure (|
                                     M.get_associated_function (|
@@ -5260,7 +5273,7 @@ Module net.
             BinOp.Pure.eq
               (BinOp.Pure.bit_and
                 (M.read (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (|
@@ -5312,22 +5325,22 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                      let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                      let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                      let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                      let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
-                      let γ0_8 := M.get_slice_index_or_break_match (| γ, 8 |) in
-                      let γ0_9 := M.get_slice_index_or_break_match (| γ, 9 |) in
-                      let γ0_10 := M.get_slice_index_or_break_match (| γ, 10 |) in
-                      let γ0_11 := M.get_slice_index_or_break_match (| γ, 11 |) in
-                      let γ0_12 := M.get_slice_index_or_break_match (| γ, 12 |) in
-                      let γ0_13 := M.get_slice_index_or_break_match (| γ, 13 |) in
-                      let γ0_14 := M.get_slice_index_or_break_match (| γ, 14 |) in
-                      let γ0_15 := M.get_slice_index_or_break_match (| γ, 15 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
+                      let γ0_8 := M.SubPointer.get_slice_index (| γ, 8 |) in
+                      let γ0_9 := M.SubPointer.get_slice_index (| γ, 9 |) in
+                      let γ0_10 := M.SubPointer.get_slice_index (| γ, 10 |) in
+                      let γ0_11 := M.SubPointer.get_slice_index (| γ, 11 |) in
+                      let γ0_12 := M.SubPointer.get_slice_index (| γ, 12 |) in
+                      let γ0_13 := M.SubPointer.get_slice_index (| γ, 13 |) in
+                      let γ0_14 := M.SubPointer.get_slice_index (| γ, 14 |) in
+                      let γ0_15 := M.SubPointer.get_slice_index (| γ, 15 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -5451,14 +5464,14 @@ Module net.
                             [ M.read (| self |) ]
                           |)
                         |) in
-                      let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                      let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                      let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                      let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                      let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                      let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                       let _ :=
                         M.is_constant_or_break_match (|
                           M.read (| γ0_0 |),
@@ -5525,8 +5538,8 @@ Module net.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                        let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
+                                        (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
                                         let a := M.copy (| γ0_0 |) in
                                         let b := M.copy (| γ0_1 |) in
                                         M.match_operator (|
@@ -5544,9 +5557,9 @@ Module net.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_slice_index_or_break_match (| γ, 0 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 0 |) in
                                                 let γ0_1 :=
-                                                  M.get_slice_index_or_break_match (| γ, 1 |) in
+                                                  M.SubPointer.get_slice_index (| γ, 1 |) in
                                                 let c := M.copy (| γ0_0 |) in
                                                 let d := M.copy (| γ0_1 |) in
                                                 M.alloc (|
@@ -5620,7 +5633,7 @@ Module net.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -5664,7 +5677,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::net::ip_addr::Ipv6Addr" "octets"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::ip_addr::Ipv6Addr",
+                "octets"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -5838,7 +5855,7 @@ Module net.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -6000,15 +6017,21 @@ Module net.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                     γ,
                                                                     "core::option::Option::Some",
                                                                     0
                                                                   |) in
                                                                 let γ1_0 :=
-                                                                  M.get_tuple_field γ0_0 0 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ0_0,
+                                                                    0
+                                                                  |) in
                                                                 let γ1_1 :=
-                                                                  M.get_tuple_field γ0_0 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ0_0,
+                                                                    1
+                                                                  |) in
                                                                 let i := M.copy (| γ1_0 |) in
                                                                 let γ1_1 := M.read (| γ1_1 |) in
                                                                 let segment := M.copy (| γ1_1 |) in
@@ -6046,10 +6069,11 @@ Module net.
                                                                                       (M.alloc (|
                                                                                         BinOp.Pure.eq
                                                                                           (M.read (|
-                                                                                            M.get_struct_record_field
-                                                                                              current
-                                                                                              "core::net::ip_addr::fmt::Span"
+                                                                                            M.SubPointer.get_struct_record_field (|
+                                                                                              current,
+                                                                                              "core::net::ip_addr::fmt::Span",
                                                                                               "len"
+                                                                                            |)
                                                                                           |))
                                                                                           (Value.Integer
                                                                                             Integer.Usize
@@ -6065,10 +6089,11 @@ Module net.
                                                                                     |) in
                                                                                   let _ :=
                                                                                     M.write (|
-                                                                                      M.get_struct_record_field
-                                                                                        current
-                                                                                        "core::net::ip_addr::fmt::Span"
-                                                                                        "start",
+                                                                                      M.SubPointer.get_struct_record_field (|
+                                                                                        current,
+                                                                                        "core::net::ip_addr::fmt::Span",
+                                                                                        "start"
+                                                                                      |),
                                                                                       M.read (| i |)
                                                                                     |) in
                                                                                   M.alloc (|
@@ -6083,10 +6108,11 @@ Module net.
                                                                           |) in
                                                                         let _ :=
                                                                           let β :=
-                                                                            M.get_struct_record_field
-                                                                              current
-                                                                              "core::net::ip_addr::fmt::Span"
-                                                                              "len" in
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              current,
+                                                                              "core::net::ip_addr::fmt::Span",
+                                                                              "len"
+                                                                            |) in
                                                                           M.write (|
                                                                             β,
                                                                             BinOp.Panic.add (|
@@ -6108,16 +6134,18 @@ Module net.
                                                                                     (M.alloc (|
                                                                                       BinOp.Pure.gt
                                                                                         (M.read (|
-                                                                                          M.get_struct_record_field
-                                                                                            current
-                                                                                            "core::net::ip_addr::fmt::Span"
+                                                                                          M.SubPointer.get_struct_record_field (|
+                                                                                            current,
+                                                                                            "core::net::ip_addr::fmt::Span",
                                                                                             "len"
+                                                                                          |)
                                                                                         |))
                                                                                         (M.read (|
-                                                                                          M.get_struct_record_field
-                                                                                            longest
-                                                                                            "core::net::ip_addr::fmt::Span"
+                                                                                          M.SubPointer.get_struct_record_field (|
+                                                                                            longest,
+                                                                                            "core::net::ip_addr::fmt::Span",
                                                                                             "len"
+                                                                                          |)
                                                                                         |))
                                                                                     |)) in
                                                                                 let _ :=
@@ -6182,10 +6210,11 @@ Module net.
                                               (M.alloc (|
                                                 BinOp.Pure.gt
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      zeroes
-                                                      "core::net::ip_addr::fmt::Span"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      zeroes,
+                                                      "core::net::ip_addr::fmt::Span",
                                                       "len"
+                                                    |)
                                                   |))
                                                   (Value.Integer Integer.Usize 1)
                                               |)) in
@@ -6238,10 +6267,11 @@ Module net.
                                                               [
                                                                 ("end_",
                                                                   M.read (|
-                                                                    M.get_struct_record_field
-                                                                      zeroes
-                                                                      "core::net::ip_addr::fmt::Span"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      zeroes,
+                                                                      "core::net::ip_addr::fmt::Span",
                                                                       "start"
+                                                                    |)
                                                                   |))
                                                               ]
                                                           ]
@@ -6255,7 +6285,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -6295,7 +6325,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -6336,7 +6366,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -6376,7 +6406,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -6414,16 +6444,18 @@ Module net.
                                                         ("start",
                                                           BinOp.Panic.add (|
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                zeroes
-                                                                "core::net::ip_addr::fmt::Span"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                zeroes,
+                                                                "core::net::ip_addr::fmt::Span",
                                                                 "start"
+                                                              |)
                                                             |),
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                zeroes
-                                                                "core::net::ip_addr::fmt::Span"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                zeroes,
+                                                                "core::net::ip_addr::fmt::Span",
                                                                 "len"
+                                                              |)
                                                             |)
                                                           |))
                                                       ]
@@ -6618,7 +6650,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -6628,7 +6660,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -6685,7 +6717,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -6695,7 +6727,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -6791,7 +6823,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -6805,7 +6837,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -6862,7 +6894,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -6876,7 +6908,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -7069,14 +7101,14 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                      let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                      let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                      let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                      let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                      let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                      let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                      let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                      (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                      let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                      let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                      let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                      let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                      let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                       let a := M.copy (| γ0_0 |) in
                       let b := M.copy (| γ0_1 |) in
                       let c := M.copy (| γ0_2 |) in
@@ -7189,7 +7221,13 @@ Module net.
                           "into_iter",
                           []
                         |),
-                        [ M.get_struct_record_field self "core::net::ip_addr::Ipv4Addr" "octets" ]
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::net::ip_addr::Ipv4Addr",
+                            "octets"
+                          |)
+                        ]
                       |)
                     |),
                     [
@@ -7223,7 +7261,7 @@ Module net.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -7325,7 +7363,13 @@ Module net.
                           "into_iter",
                           []
                         |),
-                        [ M.get_struct_record_field self "core::net::ip_addr::Ipv6Addr" "octets" ]
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::net::ip_addr::Ipv6Addr",
+                            "octets"
+                          |)
+                        ]
                       |)
                     |),
                     [
@@ -7359,7 +7403,7 @@ Module net.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -7474,12 +7518,17 @@ Module net.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::ip_addr::Ipv4Addr"
-                              "octets";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::ip_addr::Ipv4Addr",
+                              "octets"
+                            |);
                             M.read (|
-                              M.get_struct_record_field rhs "core::net::ip_addr::Ipv4Addr" "octets"
+                              M.SubPointer.get_struct_record_field (|
+                                rhs,
+                                "core::net::ip_addr::Ipv4Addr",
+                                "octets"
+                              |)
                             |)
                           ]
                         |)
@@ -7524,13 +7573,13 @@ Module net.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let lhs := M.copy (| γ1_0 |) in
                                       let rhs := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -7842,12 +7891,17 @@ Module net.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::ip_addr::Ipv4Addr"
-                              "octets";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::ip_addr::Ipv4Addr",
+                              "octets"
+                            |);
                             M.read (|
-                              M.get_struct_record_field rhs "core::net::ip_addr::Ipv4Addr" "octets"
+                              M.SubPointer.get_struct_record_field (|
+                                rhs,
+                                "core::net::ip_addr::Ipv4Addr",
+                                "octets"
+                              |)
                             |)
                           ]
                         |)
@@ -7892,13 +7946,13 @@ Module net.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let lhs := M.copy (| γ1_0 |) in
                                       let rhs := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -8210,12 +8264,17 @@ Module net.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::ip_addr::Ipv6Addr"
-                              "octets";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::ip_addr::Ipv6Addr",
+                              "octets"
+                            |);
                             M.read (|
-                              M.get_struct_record_field rhs "core::net::ip_addr::Ipv6Addr" "octets"
+                              M.SubPointer.get_struct_record_field (|
+                                rhs,
+                                "core::net::ip_addr::Ipv6Addr",
+                                "octets"
+                              |)
                             |)
                           ]
                         |)
@@ -8260,13 +8319,13 @@ Module net.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let lhs := M.copy (| γ1_0 |) in
                                       let rhs := M.copy (| γ1_1 |) in
                                       let _ :=
@@ -8578,12 +8637,17 @@ Module net.
                             ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::ip_addr::Ipv6Addr"
-                              "octets";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::ip_addr::Ipv6Addr",
+                              "octets"
+                            |);
                             M.read (|
-                              M.get_struct_record_field rhs "core::net::ip_addr::Ipv6Addr" "octets"
+                              M.SubPointer.get_struct_record_field (|
+                                rhs,
+                                "core::net::ip_addr::Ipv6Addr",
+                                "octets"
+                              |)
                             |)
                           ]
                         |)
@@ -8628,13 +8692,13 @@ Module net.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
-                                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                       let lhs := M.copy (| γ1_0 |) in
                                       let rhs := M.copy (| γ1_1 |) in
                                       let _ :=

--- a/CoqOfRust/core/net/parser.v
+++ b/CoqOfRust/core/net/parser.v
@@ -71,7 +71,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -104,7 +104,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -177,7 +177,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -210,7 +210,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -304,7 +304,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -337,7 +337,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -410,7 +410,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -443,7 +443,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -537,7 +537,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -570,7 +570,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -643,7 +643,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -676,7 +676,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -754,7 +754,11 @@ Module net.
             M.read (|
               let state :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::net::parser::Parser" "state"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::parser::Parser",
+                    "state"
+                  |)
                 |) in
               let result :=
                 M.alloc (|
@@ -794,10 +798,11 @@ Module net.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::parser::Parser"
-                              "state",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::parser::Parser",
+                              "state"
+                            |),
                             M.read (| state |)
                           |) in
                         M.alloc (| Value.Tuple [] |)));
@@ -870,10 +875,11 @@ Module net.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::net::parser::Parser"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::net::parser::Parser",
                                             "state"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -932,10 +938,11 @@ Module net.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::parser::Parser"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::parser::Parser",
                         "state"
+                      |)
                     |)
                   ]
                 |);
@@ -1022,10 +1029,11 @@ Module net.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::parser::Parser"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::parser::Parser",
                         "state"
+                      |)
                     |)
                   ]
                 |);
@@ -1039,18 +1047,19 @@ Module net.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let γ0_0 := M.read (| γ0_0 |) in
                                 let b := M.copy (| γ0_0 |) in
                                 let tail := M.copy (| γ0_1 |) in
                                 M.read (|
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::net::parser::Parser"
-                                        "state",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::net::parser::Parser",
+                                        "state"
+                                      |),
                                       M.read (| tail |)
                                     |) in
                                   M.alloc (|
@@ -1291,7 +1300,7 @@ Module net.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Break",
                                                           0
@@ -1328,7 +1337,7 @@ Module net.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                           0
@@ -1573,7 +1582,7 @@ Module net.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                                           γ,
                                                                                           "core::ops::control_flow::ControlFlow::Break",
                                                                                           0
@@ -1622,7 +1631,7 @@ Module net.
                                                                                   fun γ =>
                                                                                     ltac:(M.monadic
                                                                                       (let γ0_0 :=
-                                                                                        M.get_struct_tuple_field_or_break_match (|
+                                                                                        M.SubPointer.get_struct_tuple_field (|
                                                                                           γ,
                                                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                                                           0
@@ -1646,7 +1655,7 @@ Module net.
                                                     |)
                                                   |) in
                                                 let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -1686,7 +1695,7 @@ Module net.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                   0
@@ -1724,7 +1733,7 @@ Module net.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                   0
@@ -1769,7 +1778,7 @@ Module net.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                   0
@@ -1807,7 +1816,7 @@ Module net.
                                                           fun γ =>
                                                             ltac:(M.monadic
                                                               (let γ0_0 :=
-                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                M.SubPointer.get_struct_tuple_field (|
                                                                   γ,
                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                   0
@@ -1834,7 +1843,7 @@ Module net.
                                                       ltac:(M.monadic
                                                         (let γ := max_digits in
                                                         let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -2107,13 +2116,21 @@ Module net.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
                                                               |) in
-                                                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                                            let γ1_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ0_0,
+                                                                0
+                                                              |) in
+                                                            let γ1_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ0_0,
+                                                                1
+                                                              |) in
                                                             let i := M.copy (| γ1_0 |) in
                                                             let slot := M.copy (| γ1_1 |) in
                                                             let _ :=
@@ -2224,7 +2241,7 @@ Module net.
                                                                       fun γ =>
                                                                         ltac:(M.monadic
                                                                           (let γ0_0 :=
-                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                               γ,
                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                               0
@@ -2270,7 +2287,7 @@ Module net.
                                                                       fun γ =>
                                                                         ltac:(M.monadic
                                                                           (let γ0_0 :=
-                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                               γ,
                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                               0
@@ -2434,8 +2451,8 @@ Module net.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let head_size := M.copy (| γ0_0 |) in
                                           let head_ipv4 := M.copy (| γ0_1 |) in
                                           let _ :=
@@ -2543,7 +2560,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -2582,7 +2599,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -2620,7 +2637,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -2659,7 +2676,7 @@ Module net.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -2715,8 +2732,10 @@ Module net.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let tail_size := M.copy (| γ0_0 |) in
                                                   let _ :=
                                                     M.alloc (|
@@ -2983,7 +3002,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -3016,7 +3035,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -3120,7 +3139,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -3153,7 +3172,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -3262,7 +3281,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -3299,7 +3318,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -3339,7 +3358,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -3376,7 +3395,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -3488,7 +3507,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -3524,7 +3543,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -3563,7 +3582,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -3600,7 +3619,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -3662,7 +3681,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -3698,7 +3717,7 @@ Module net.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -3737,7 +3756,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -3774,7 +3793,7 @@ Module net.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -4877,10 +4896,11 @@ Module net.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::net::parser::AddrParseError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::net::parser::AddrParseError",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -4916,10 +4936,11 @@ Module net.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::net::parser::AddrParseError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::net::parser::AddrParseError",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -4964,8 +4985,16 @@ Module net.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::net::parser::AddrParseError" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::net::parser::AddrParseError" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::net::parser::AddrParseError",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::net::parser::AddrParseError",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5080,7 +5109,11 @@ Module net.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::net::parser::AddrParseError" 0,
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::net::parser::AddrParseError",
+                  0
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic

--- a/CoqOfRust/core/net/socket_addr.v
+++ b/CoqOfRust/core/net/socket_addr.v
@@ -119,11 +119,11 @@ Module net.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::socket_addr::SocketAddr::V4",
                                   0
@@ -131,7 +131,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::socket_addr::SocketAddr::V4",
                                   0
@@ -151,11 +151,11 @@ Module net.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::socket_addr::SocketAddr::V6",
                                   0
@@ -163,7 +163,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::socket_addr::SocketAddr::V6",
                                   0
@@ -294,7 +294,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -316,7 +316,7 @@ Module net.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -384,11 +384,11 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -396,7 +396,7 @@ Module net.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -416,11 +416,11 @@ Module net.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -428,7 +428,7 @@ Module net.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -520,11 +520,11 @@ Module net.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::socket_addr::SocketAddr::V4",
                                   0
@@ -532,7 +532,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::socket_addr::SocketAddr::V4",
                                   0
@@ -552,11 +552,11 @@ Module net.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::net::socket_addr::SocketAddr::V6",
                                   0
@@ -564,7 +564,7 @@ Module net.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::net::socket_addr::SocketAddr::V6",
                                   0
@@ -739,29 +739,33 @@ Module net.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV4"
-                    "ip";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::net::socket_addr::SocketAddrV4"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV4",
                     "ip"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::net::socket_addr::SocketAddrV4",
+                    "ip"
+                  |)
                 ]
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::net::socket_addr::SocketAddrV4"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::net::socket_addr::SocketAddrV4",
                       "port"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::net::socket_addr::SocketAddrV4"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::net::socket_addr::SocketAddrV4",
                       "port"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -797,14 +801,16 @@ Module net.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV4"
-                        "ip";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV4"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV4",
                         "ip"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV4",
+                        "ip"
+                      |)
                     ]
                   |)
                 |),
@@ -815,14 +821,16 @@ Module net.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", Ty.path "u16", [], "cmp", [] |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::socket_addr::SocketAddrV4"
-                              "port";
-                            M.get_struct_record_field
-                              (M.read (| other |))
-                              "core::net::socket_addr::SocketAddrV4"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::socket_addr::SocketAddrV4",
                               "port"
+                            |);
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| other |),
+                              "core::net::socket_addr::SocketAddrV4",
+                              "port"
+                            |)
                           ]
                         |)
                       |)));
@@ -866,14 +874,16 @@ Module net.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV4"
-                        "ip";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV4"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV4",
                         "ip"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV4",
+                        "ip"
+                      |)
                     ]
                   |)
                 |),
@@ -881,7 +891,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -896,14 +906,16 @@ Module net.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::net::socket_addr::SocketAddrV4"
-                              "port";
-                            M.get_struct_record_field
-                              (M.read (| other |))
-                              "core::net::socket_addr::SocketAddrV4"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::net::socket_addr::SocketAddrV4",
                               "port"
+                            |);
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| other |),
+                              "core::net::socket_addr::SocketAddrV4",
+                              "port"
+                            |)
                           ]
                         |)
                       |)));
@@ -947,10 +959,11 @@ Module net.
                       [ __H ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV4"
-                        "ip";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV4",
+                        "ip"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -959,10 +972,11 @@ Module net.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.path "u16", [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::net::socket_addr::SocketAddrV4"
-                      "port";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::net::socket_addr::SocketAddrV4",
+                      "port"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -1128,59 +1142,67 @@ Module net.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "ip";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV6"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
                         "ip"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "ip"
+                      |)
                     ]
                   |),
                   ltac:(M.monadic
                     (BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::net::socket_addr::SocketAddrV6"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::net::socket_addr::SocketAddrV6",
                           "port"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::net::socket_addr::SocketAddrV6"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::net::socket_addr::SocketAddrV6",
                           "port"
+                        |)
                       |))))
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
                         "flowinfo"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV6"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV6",
                         "flowinfo"
+                      |)
                     |))))
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::net::socket_addr::SocketAddrV6"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::net::socket_addr::SocketAddrV6",
                       "scope_id"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::net::socket_addr::SocketAddrV6"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::net::socket_addr::SocketAddrV6",
                       "scope_id"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -1216,14 +1238,16 @@ Module net.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "ip";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV6"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
                         "ip"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "ip"
+                      |)
                     ]
                   |)
                 |),
@@ -1235,14 +1259,16 @@ Module net.
                           M.call_closure (|
                             M.get_trait_method (| "core::cmp::Ord", Ty.path "u16", [], "cmp", [] |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::net::socket_addr::SocketAddrV6"
-                                "port";
-                              M.get_struct_record_field
-                                (M.read (| other |))
-                                "core::net::socket_addr::SocketAddrV6"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::net::socket_addr::SocketAddrV6",
                                 "port"
+                              |);
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| other |),
+                                "core::net::socket_addr::SocketAddrV6",
+                                "port"
+                              |)
                             ]
                           |)
                         |),
@@ -1260,14 +1286,16 @@ Module net.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::net::socket_addr::SocketAddrV6"
-                                        "flowinfo";
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "core::net::socket_addr::SocketAddrV6"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::net::socket_addr::SocketAddrV6",
                                         "flowinfo"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "core::net::socket_addr::SocketAddrV6",
+                                        "flowinfo"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -1284,14 +1312,16 @@ Module net.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::net::socket_addr::SocketAddrV6"
-                                              "scope_id";
-                                            M.get_struct_record_field
-                                              (M.read (| other |))
-                                              "core::net::socket_addr::SocketAddrV6"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::net::socket_addr::SocketAddrV6",
                                               "scope_id"
+                                            |);
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| other |),
+                                              "core::net::socket_addr::SocketAddrV6",
+                                              "scope_id"
+                                            |)
                                           ]
                                         |)
                                       |)));
@@ -1347,14 +1377,16 @@ Module net.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "ip";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::net::socket_addr::SocketAddrV6"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
                         "ip"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "ip"
+                      |)
                     ]
                   |)
                 |),
@@ -1362,7 +1394,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1378,14 +1410,16 @@ Module net.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::net::socket_addr::SocketAddrV6"
-                                "port";
-                              M.get_struct_record_field
-                                (M.read (| other |))
-                                "core::net::socket_addr::SocketAddrV6"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::net::socket_addr::SocketAddrV6",
                                 "port"
+                              |);
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| other |),
+                                "core::net::socket_addr::SocketAddrV6",
+                                "port"
+                              |)
                             ]
                           |)
                         |),
@@ -1393,7 +1427,7 @@ Module net.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -1409,14 +1443,16 @@ Module net.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::net::socket_addr::SocketAddrV6"
-                                        "flowinfo";
-                                      M.get_struct_record_field
-                                        (M.read (| other |))
-                                        "core::net::socket_addr::SocketAddrV6"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::net::socket_addr::SocketAddrV6",
                                         "flowinfo"
+                                      |);
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| other |),
+                                        "core::net::socket_addr::SocketAddrV6",
+                                        "flowinfo"
+                                      |)
                                     ]
                                   |)
                                 |),
@@ -1424,7 +1460,7 @@ Module net.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -1439,14 +1475,16 @@ Module net.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::net::socket_addr::SocketAddrV6"
-                                              "scope_id";
-                                            M.get_struct_record_field
-                                              (M.read (| other |))
-                                              "core::net::socket_addr::SocketAddrV6"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::net::socket_addr::SocketAddrV6",
                                               "scope_id"
+                                            |);
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| other |),
+                                              "core::net::socket_addr::SocketAddrV6",
+                                              "scope_id"
+                                            |)
                                           ]
                                         |)
                                       |)));
@@ -1502,10 +1540,11 @@ Module net.
                       [ __H ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "ip";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "ip"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -1515,10 +1554,11 @@ Module net.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Ty.path "u16", [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "port";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "port"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -1528,10 +1568,11 @@ Module net.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::net::socket_addr::SocketAddrV6"
-                        "flowinfo";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::net::socket_addr::SocketAddrV6",
+                        "flowinfo"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -1540,10 +1581,11 @@ Module net.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::net::socket_addr::SocketAddrV6"
-                      "scope_id";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::net::socket_addr::SocketAddrV6",
+                      "scope_id"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -1584,7 +1626,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1607,7 +1649,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1660,7 +1702,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -1685,7 +1727,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -1737,18 +1779,18 @@ Module net.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
                         |) in
                       let a := M.alloc (| γ2_0 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::ip_addr::IpAddr::V4",
                           0
@@ -1766,18 +1808,18 @@ Module net.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
                         |) in
                       let a := M.alloc (| γ2_0 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::net::ip_addr::IpAddr::V6",
                           0
@@ -1795,8 +1837,8 @@ Module net.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let self_ := M.copy (| γ0_0 |) in
                       let new_ip := M.copy (| γ0_1 |) in
                       M.write (|
@@ -1848,7 +1890,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -1867,7 +1909,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -1912,7 +1954,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -1931,7 +1973,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -1972,7 +2014,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -2004,7 +2046,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0
@@ -2052,10 +2094,11 @@ Module net.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::net::socket_addr::SocketAddrV4"
-              "ip"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::net::socket_addr::SocketAddrV4",
+              "ip"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -2075,10 +2118,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV4"
-                    "ip",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV4",
+                    "ip"
+                  |),
                   M.read (| new_ip |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2099,10 +2143,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::net::socket_addr::SocketAddrV4"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::socket_addr::SocketAddrV4",
                 "port"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2123,10 +2168,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV4"
-                    "port",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV4",
+                    "port"
+                  |),
                   M.read (| new_port |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2176,10 +2222,11 @@ Module net.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::net::socket_addr::SocketAddrV6"
-              "ip"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::net::socket_addr::SocketAddrV6",
+              "ip"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -2199,10 +2246,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV6"
-                    "ip",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV6",
+                    "ip"
+                  |),
                   M.read (| new_ip |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2223,10 +2271,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::net::socket_addr::SocketAddrV6"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::socket_addr::SocketAddrV6",
                 "port"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2247,10 +2296,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV6"
-                    "port",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV6",
+                    "port"
+                  |),
                   M.read (| new_port |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2271,10 +2321,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::net::socket_addr::SocketAddrV6"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::socket_addr::SocketAddrV6",
                 "flowinfo"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2295,10 +2346,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV6"
-                    "flowinfo",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV6",
+                    "flowinfo"
+                  |),
                   M.read (| new_flowinfo |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2320,10 +2372,11 @@ Module net.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::net::socket_addr::SocketAddrV6"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::net::socket_addr::SocketAddrV6",
                 "scope_id"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -2344,10 +2397,11 @@ Module net.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::net::socket_addr::SocketAddrV6"
-                    "scope_id",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::net::socket_addr::SocketAddrV6",
+                    "scope_id"
+                  |),
                   M.read (| new_scope_id |)
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -2438,9 +2492,9 @@ Module net.
                     "into",
                     []
                   |),
-                  [ M.read (| M.get_tuple_field pieces 0 |) ]
+                  [ M.read (| M.SubPointer.get_tuple_field (| pieces, 0 |) |) ]
                 |);
-                M.read (| M.get_tuple_field pieces 1 |)
+                M.read (| M.SubPointer.get_tuple_field (| pieces, 1 |) |)
               ]
             |)))
         | _, _ => M.impossible
@@ -2479,7 +2533,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V4",
                           0
@@ -2500,7 +2554,7 @@ Module net.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::net::socket_addr::SocketAddr::V6",
                           0

--- a/CoqOfRust/core/num/bignum.v
+++ b/CoqOfRust/core/num/bignum.v
@@ -479,7 +479,10 @@ Module num.
               let base := M.alloc (| repeat (Value.Integer Integer.U32 0) 40 |) in
               let _ :=
                 M.write (|
-                  M.get_array_field (| base, M.alloc (| Value.Integer Integer.Usize 0 |) |),
+                  M.SubPointer.get_array_field (|
+                    base,
+                    M.alloc (| Value.Integer Integer.Usize 0 |)
+                  |),
                   M.read (| v |)
                 |) in
               M.alloc (|
@@ -530,7 +533,7 @@ Module num.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (| base, sz |),
+                                M.SubPointer.get_array_field (| base, sz |),
                                 M.rust_cast (M.read (| v |))
                               |) in
                             let _ :=
@@ -593,16 +596,21 @@ Module num.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::num::bignum::Big32x40" "base";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::num::bignum::Big32x40",
+                  "base"
+                |);
                 Value.StructRecord
                   "core::ops::range::RangeTo"
                   [
                     ("end_",
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |))
                   ]
               ]
@@ -636,11 +644,12 @@ Module num.
                   (BinOp.Pure.bit_and
                     (BinOp.Panic.shr (|
                       M.read (|
-                        M.get_array_field (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::Big32x40"
-                            "base",
+                        M.SubPointer.get_array_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::Big32x40",
+                            "base"
+                          |),
                           d
                         |)
                       |),
@@ -803,7 +812,7 @@ Module num.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -816,7 +825,11 @@ Module num.
                             M.rust_cast
                               (M.call_closure (|
                                 M.get_associated_function (| Ty.path "u32", "ilog2", [] |),
-                                [ M.read (| M.get_array_field (| M.read (| digits |), msd |) |) ]
+                                [
+                                  M.read (|
+                                    M.SubPointer.get_array_field (| M.read (| digits |), msd |)
+                                  |)
+                                ]
                               |))
                           |),
                           Value.Integer Integer.Usize 1
@@ -864,16 +877,18 @@ Module num.
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |)
                     ]
                   |)
@@ -923,10 +938,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -945,10 +961,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| other |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| other |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -997,13 +1014,13 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let a := M.copy (| γ1_0 |) in
                                         let b := M.copy (| γ1_1 |) in
                                         M.match_operator (|
@@ -1024,8 +1041,10 @@ Module num.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let v := M.copy (| γ0_0 |) in
                                                 let c := M.copy (| γ0_1 |) in
                                                 let _ :=
@@ -1051,11 +1070,12 @@ Module num.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_array_field (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::Big32x40"
-                                "base",
+                            M.SubPointer.get_array_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |),
                               sz
                             |),
                             Value.Integer Integer.U32 1
@@ -1072,10 +1092,11 @@ Module num.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (| sz |)
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -1115,11 +1136,12 @@ Module num.
                     M.get_associated_function (| Ty.path "u32", "carrying_add", [] |),
                     [
                       M.read (|
-                        M.get_array_field (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::Big32x40"
-                            "base",
+                        M.SubPointer.get_array_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::Big32x40",
+                            "base"
+                          |),
                           M.alloc (| Value.Integer Integer.Usize 0 |)
                         |)
                       |);
@@ -1131,17 +1153,18 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let v := M.copy (| γ0_0 |) in
                       let carry := M.copy (| γ0_1 |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::bignum::Big32x40"
-                              "base",
+                          M.SubPointer.get_array_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::bignum::Big32x40",
+                              "base"
+                            |),
                             M.alloc (| Value.Integer Integer.Usize 0 |)
                           |),
                           M.read (| v |)
@@ -1171,11 +1194,12 @@ Module num.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::bignum::Big32x40"
-                                                  "base",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::bignum::Big32x40",
+                                                  "base"
+                                                |),
                                                 i
                                               |)
                                             |);
@@ -1187,17 +1211,18 @@ Module num.
                                       [
                                         fun γ =>
                                           ltac:(M.monadic
-                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                             let v := M.copy (| γ0_0 |) in
                                             let c := M.copy (| γ0_1 |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::bignum::Big32x40"
-                                                    "base",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::bignum::Big32x40",
+                                                    "base"
+                                                  |),
                                                   i
                                                 |),
                                                 M.read (| v |)
@@ -1243,10 +1268,11 @@ Module num.
                                       BinOp.Pure.gt
                                         (M.read (| i |))
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::bignum::Big32x40"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::bignum::Big32x40",
                                             "size"
+                                          |)
                                         |))
                                     |)) in
                                 let _ :=
@@ -1256,10 +1282,11 @@ Module num.
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::Big32x40"
-                                      "size",
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::Big32x40",
+                                      "size"
+                                    |),
                                     M.read (| i |)
                                   |) in
                                 M.alloc (| Value.Tuple [] |)));
@@ -1305,16 +1332,18 @@ Module num.
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |)
                     ]
                   |)
@@ -1364,10 +1393,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -1386,10 +1416,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| other |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| other |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -1438,13 +1469,13 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let a := M.copy (| γ1_0 |) in
                                         let b := M.copy (| γ1_1 |) in
                                         M.match_operator (|
@@ -1465,8 +1496,10 @@ Module num.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let v := M.copy (| γ0_0 |) in
                                                 let c := M.copy (| γ0_1 |) in
                                                 let _ :=
@@ -1503,10 +1536,11 @@ Module num.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (| sz |)
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -1542,7 +1576,11 @@ Module num.
             M.read (|
               let sz :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::num::bignum::Big32x40" "size"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |)
                 |) in
               let carry := M.alloc (| Value.Integer Integer.U32 0 |) in
               let _ :=
@@ -1570,10 +1608,11 @@ Module num.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::Big32x40"
-                                "base";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |);
                               Value.StructRecord
                                 "core::ops::range::RangeTo"
                                 [ ("end_", M.read (| sz |)) ]
@@ -1613,7 +1652,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1637,8 +1676,10 @@ Module num.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let v := M.copy (| γ0_0 |) in
                                                 let c := M.copy (| γ0_1 |) in
                                                 let _ :=
@@ -1668,11 +1709,12 @@ Module num.
                           M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                         let _ :=
                           M.write (|
-                            M.get_array_field (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::Big32x40"
-                                "base",
+                            M.SubPointer.get_array_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |),
                               sz
                             |),
                             M.read (| carry |)
@@ -1689,10 +1731,11 @@ Module num.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (| sz |)
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -1841,10 +1884,11 @@ Module num.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::bignum::Big32x40"
-                                                          "base";
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::bignum::Big32x40",
+                                                          "base"
+                                                        |);
                                                         Value.StructRecord
                                                           "core::ops::range::RangeFrom"
                                                           [
@@ -1933,11 +1977,12 @@ Module num.
                                               (BinOp.Pure.eq
                                                 (BinOp.Panic.shr (|
                                                   M.read (|
-                                                    M.get_array_field (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::num::bignum::Big32x40"
-                                                        "base",
+                                                    M.SubPointer.get_array_field (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::num::bignum::Big32x40",
+                                                        "base"
+                                                      |),
                                                       M.alloc (|
                                                         BinOp.Panic.sub (|
                                                           BinOp.Panic.sub (|
@@ -2012,10 +2057,11 @@ Module num.
                                   ("start", Value.Integer Integer.Usize 0);
                                   ("end_",
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::num::bignum::Big32x40"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::num::bignum::Big32x40",
                                         "size"
+                                      |)
                                     |))
                                 ]
                             ]
@@ -2058,7 +2104,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2066,11 +2112,12 @@ Module num.
                                         let i := M.copy (| γ0_0 |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_array_field (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::num::bignum::Big32x40"
-                                                "base",
+                                            M.SubPointer.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::num::bignum::Big32x40",
+                                                "base"
+                                              |),
                                               M.alloc (|
                                                 BinOp.Panic.add (|
                                                   M.read (| i |),
@@ -2079,11 +2126,12 @@ Module num.
                                               |)
                                             |),
                                             M.read (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::bignum::Big32x40"
-                                                  "base",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::bignum::Big32x40",
+                                                  "base"
+                                                |),
                                                 i
                                               |)
                                             |)
@@ -2148,7 +2196,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2156,11 +2204,12 @@ Module num.
                                         let i := M.copy (| γ0_0 |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_array_field (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::num::bignum::Big32x40"
-                                                "base",
+                                            M.SubPointer.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::num::bignum::Big32x40",
+                                                "base"
+                                              |),
                                               i
                                             |),
                                             Value.Integer Integer.U32 0
@@ -2176,10 +2225,11 @@ Module num.
                 M.alloc (|
                   BinOp.Panic.add (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::bignum::Big32x40"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::bignum::Big32x40",
                         "size"
+                      |)
                     |),
                     M.read (| digits |)
                   |)
@@ -2202,11 +2252,12 @@ Module num.
                           M.alloc (|
                             BinOp.Panic.shr (|
                               M.read (|
-                                M.get_array_field (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::num::bignum::Big32x40"
-                                    "base",
+                                M.SubPointer.get_array_field (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |),
                                   M.alloc (|
                                     BinOp.Panic.sub (|
                                       M.read (| last |),
@@ -2238,11 +2289,12 @@ Module num.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_array_field (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::bignum::Big32x40"
-                                          "base",
+                                      M.SubPointer.get_array_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::bignum::Big32x40",
+                                          "base"
+                                        |),
                                         last
                                       |),
                                       M.read (| overflow |)
@@ -2340,7 +2392,7 @@ Module num.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -2348,21 +2400,23 @@ Module num.
                                                   let i := M.copy (| γ0_0 |) in
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_array_field (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::bignum::Big32x40"
-                                                          "base",
+                                                      M.SubPointer.get_array_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::bignum::Big32x40",
+                                                          "base"
+                                                        |),
                                                         i
                                                       |),
                                                       BinOp.Pure.bit_or
                                                         (BinOp.Panic.shl (|
                                                           M.read (|
-                                                            M.get_array_field (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::num::bignum::Big32x40"
-                                                                "base",
+                                                            M.SubPointer.get_array_field (|
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::num::bignum::Big32x40",
+                                                                "base"
+                                                              |),
                                                               i
                                                             |)
                                                           |),
@@ -2370,11 +2424,12 @@ Module num.
                                                         |))
                                                         (BinOp.Panic.shr (|
                                                           M.read (|
-                                                            M.get_array_field (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::num::bignum::Big32x40"
-                                                                "base",
+                                                            M.SubPointer.get_array_field (|
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::num::bignum::Big32x40",
+                                                                "base"
+                                                              |),
                                                               M.alloc (|
                                                                 BinOp.Panic.sub (|
                                                                   M.read (| i |),
@@ -2398,11 +2453,12 @@ Module num.
                             |)) in
                         let _ :=
                           let β :=
-                            M.get_array_field (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::Big32x40"
-                                "base",
+                            M.SubPointer.get_array_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |),
                               digits
                             |) in
                           M.write (|
@@ -2415,10 +2471,11 @@ Module num.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (| sz |)
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -2476,15 +2533,15 @@ Module num.
                     |))
                 |) in
               M.match_operator (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::num::bignum::SMALL_POW5" |),
                   table_index
                 |),
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let small_power := M.copy (| γ0_0 |) in
                       let small_e := M.copy (| γ0_1 |) in
                       let small_power := M.alloc (| M.rust_cast (M.read (| small_power |)) |) in
@@ -2594,7 +2651,7 @@ Module num.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -2695,10 +2752,11 @@ Module num.
                               (M.alloc (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::Big32x40"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::Big32x40",
                                       "size"
+                                    |)
                                   |))
                                   (M.call_closure (|
                                     M.get_associated_function (|
@@ -2752,18 +2810,20 @@ Module num.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "base",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "base"
+                  |),
                   M.read (| ret |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::Big32x40"
-                    "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (| retsz |)
                 |) in
               M.alloc (| M.read (| self |) |)
@@ -2823,7 +2883,11 @@ Module num.
                 |) in
               let sz :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::num::bignum::Big32x40" "size"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |)
                 |) in
               let borrow := M.alloc (| Value.Integer Integer.U32 0 |) in
               let _ :=
@@ -2870,10 +2934,11 @@ Module num.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::num::bignum::Big32x40"
-                                        "base";
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::num::bignum::Big32x40",
+                                        "base"
+                                      |);
                                       Value.StructRecord
                                         "core::ops::range::RangeTo"
                                         [ ("end_", M.read (| sz |)) ]
@@ -2921,7 +2986,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2947,8 +3012,10 @@ Module num.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let q := M.copy (| γ0_0 |) in
                                                 let r := M.copy (| γ0_1 |) in
                                                 let _ :=
@@ -3075,10 +3142,11 @@ Module num.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| q |))
-                                "core::num::bignum::Big32x40"
-                                "base";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| q |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |);
                               Value.StructTuple "core::ops::range::RangeFull" []
                             ]
                           |)
@@ -3116,7 +3184,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -3158,10 +3226,11 @@ Module num.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| r |))
-                                "core::num::bignum::Big32x40"
-                                "base";
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| r |),
+                                "core::num::bignum::Big32x40",
+                                "base"
+                              |);
                               Value.StructTuple "core::ops::range::RangeFull" []
                             ]
                           |)
@@ -3199,7 +3268,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -3219,14 +3288,26 @@ Module num.
                   |)) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| r |)) "core::num::bignum::Big32x40" "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| r |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   M.read (|
-                    M.get_struct_record_field (M.read (| d |)) "core::num::bignum::Big32x40" "size"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| d |),
+                      "core::num::bignum::Big32x40",
+                      "size"
+                    |)
                   |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (M.read (| q |)) "core::num::bignum::Big32x40" "size",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| q |),
+                    "core::num::bignum::Big32x40",
+                    "size"
+                  |),
                   Value.Integer Integer.Usize 1
                 |) in
               let q_is_zero := M.alloc (| Value.Bool true |) in
@@ -3311,7 +3392,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -3330,11 +3411,12 @@ Module num.
                                           |) in
                                         let _ :=
                                           let β :=
-                                            M.get_array_field (|
-                                              M.get_struct_record_field
-                                                (M.read (| r |))
-                                                "core::num::bignum::Big32x40"
-                                                "base",
+                                            M.SubPointer.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| r |),
+                                                "core::num::bignum::Big32x40",
+                                                "base"
+                                              |),
                                               M.alloc (| Value.Integer Integer.Usize 0 |)
                                             |) in
                                           M.write (|
@@ -3427,10 +3509,11 @@ Module num.
                                                             |) in
                                                           let _ :=
                                                             M.write (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| q |))
-                                                                "core::num::bignum::Big32x40"
-                                                                "size",
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| q |),
+                                                                "core::num::bignum::Big32x40",
+                                                                "size"
+                                                              |),
                                                               BinOp.Panic.add (|
                                                                 M.read (| digit_idx |),
                                                                 Value.Integer Integer.Usize 1
@@ -3449,11 +3532,12 @@ Module num.
                                                   |) in
                                                 let _ :=
                                                   let β :=
-                                                    M.get_array_field (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| q |))
-                                                        "core::num::bignum::Big32x40"
-                                                        "base",
+                                                    M.SubPointer.get_array_field (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| q |),
+                                                        "core::num::bignum::Big32x40",
+                                                        "base"
+                                                      |),
                                                       digit_idx
                                                     |) in
                                                   M.write (|
@@ -3535,19 +3619,21 @@ Module num.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| q |))
-                                                          "core::num::bignum::Big32x40"
-                                                          "base";
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| q |),
+                                                          "core::num::bignum::Big32x40",
+                                                          "base"
+                                                        |);
                                                         Value.StructRecord
                                                           "core::ops::range::RangeFrom"
                                                           [
                                                             ("start",
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| q |))
-                                                                  "core::num::bignum::Big32x40"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| q |),
+                                                                  "core::num::bignum::Big32x40",
                                                                   "size"
+                                                                |)
                                                               |))
                                                           ]
                                                       ]
@@ -3662,19 +3748,21 @@ Module num.
                                                         []
                                                       |),
                                                       [
-                                                        M.get_struct_record_field
-                                                          (M.read (| r |))
-                                                          "core::num::bignum::Big32x40"
-                                                          "base";
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| r |),
+                                                          "core::num::bignum::Big32x40",
+                                                          "base"
+                                                        |);
                                                         Value.StructRecord
                                                           "core::ops::range::RangeFrom"
                                                           [
                                                             ("start",
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| r |))
-                                                                  "core::num::bignum::Big32x40"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| r |),
+                                                                  "core::num::bignum::Big32x40",
                                                                   "size"
+                                                                |)
                                                               |))
                                                           ]
                                                       ]
@@ -3769,10 +3857,11 @@ Module num.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::Big32x40"
-                      "base";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::Big32x40",
+                      "base"
+                    |);
                     Value.StructTuple "core::ops::range::RangeFull" []
                   ]
                 |);
@@ -3785,10 +3874,11 @@ Module num.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::num::bignum::Big32x40"
-                      "base";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::num::bignum::Big32x40",
+                      "base"
+                    |);
                     Value.StructTuple "core::ops::range::RangeFull" []
                   ]
                 |)
@@ -3876,16 +3966,18 @@ Module num.
                     M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::bignum::Big32x40"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::bignum::Big32x40",
                           "size"
+                        |)
                       |)
                     ]
                   |)
@@ -3932,10 +4024,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -3990,10 +4083,11 @@ Module num.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| other |))
-                                    "core::num::bignum::Big32x40"
-                                    "base";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| other |),
+                                    "core::num::bignum::Big32x40",
+                                    "base"
+                                  |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
                                     [ ("end_", M.read (| sz |)) ]
@@ -4062,17 +4156,19 @@ Module num.
               [
                 ("size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::Big32x40"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::Big32x40",
                       "size"
+                    |)
                   |));
                 ("base",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::Big32x40"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::Big32x40",
                       "base"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -4122,10 +4218,11 @@ Module num.
                                   (M.alloc (|
                                     BinOp.Pure.lt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::bignum::Big32x40"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::bignum::Big32x40",
                                           "size"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 1)
                                   |)) in
@@ -4137,10 +4234,11 @@ Module num.
                               M.alloc (| Value.Integer Integer.Usize 1 |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::Big32x40"
-                                "size"))
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::Big32x40",
+                                "size"
+                              |)))
                         ]
                       |)
                     |) in
@@ -4195,11 +4293,12 @@ Module num.
                                                 [ Ty.path "u32" ]
                                               |),
                                               [
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::bignum::Big32x40"
-                                                    "base",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::bignum::Big32x40",
+                                                    "base"
+                                                  |),
                                                   M.alloc (|
                                                     BinOp.Panic.sub (|
                                                       M.read (| sz |),
@@ -4256,7 +4355,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -4292,7 +4391,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -4345,10 +4444,11 @@ Module num.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::bignum::Big32x40"
-                                            "base";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::bignum::Big32x40",
+                                            "base"
+                                          |);
                                           Value.StructRecord
                                             "core::ops::range::RangeTo"
                                             [
@@ -4402,7 +4502,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -4527,7 +4627,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Break",
                                                           0
@@ -4568,7 +4668,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::ops::control_flow::ControlFlow::Continue",
                                                           0
@@ -4626,7 +4726,10 @@ Module num.
                 let base := M.alloc (| repeat (Value.Integer Integer.U8 0) 3 |) in
                 let _ :=
                   M.write (|
-                    M.get_array_field (| base, M.alloc (| Value.Integer Integer.Usize 0 |) |),
+                    M.SubPointer.get_array_field (|
+                      base,
+                      M.alloc (| Value.Integer Integer.Usize 0 |)
+                    |),
                     M.read (| v |)
                   |) in
                 M.alloc (|
@@ -4680,7 +4783,7 @@ Module num.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_array_field (| base, sz |),
+                                  M.SubPointer.get_array_field (| base, sz |),
                                   M.rust_cast (M.read (| v |))
                                 |) in
                               let _ :=
@@ -4748,19 +4851,21 @@ Module num.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::num::bignum::tests::Big8x3"
-                    "base";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::bignum::tests::Big8x3",
+                    "base"
+                  |);
                   Value.StructRecord
                     "core::ops::range::RangeTo"
                     [
                       ("end_",
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |))
                     ]
                 ]
@@ -4796,11 +4901,12 @@ Module num.
                     BinOp.Pure.bit_and
                       (BinOp.Panic.shr (|
                         M.read (|
-                          M.get_array_field (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::bignum::tests::Big8x3"
-                              "base",
+                          M.SubPointer.get_array_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::bignum::tests::Big8x3",
+                              "base"
+                            |),
                             d
                           |)
                         |),
@@ -4965,7 +5071,7 @@ Module num.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -4978,7 +5084,11 @@ Module num.
                               M.rust_cast
                                 (M.call_closure (|
                                   M.get_associated_function (| Ty.path "u8", "ilog2", [] |),
-                                  [ M.read (| M.get_array_field (| M.read (| digits |), msd |) |) ]
+                                  [
+                                    M.read (|
+                                      M.SubPointer.get_array_field (| M.read (| digits |), msd |)
+                                    |)
+                                  ]
                                 |))
                             |),
                             Value.Integer Integer.Usize 1
@@ -5026,16 +5136,18 @@ Module num.
                       M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |)
                       ]
                     |)
@@ -5085,10 +5197,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -5107,10 +5220,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| other |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| other |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -5159,13 +5273,13 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
-                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let a := M.copy (| γ1_0 |) in
                                           let b := M.copy (| γ1_1 |) in
                                           M.match_operator (|
@@ -5186,8 +5300,10 @@ Module num.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let v := M.copy (| γ0_0 |) in
                                                   let c := M.copy (| γ0_1 |) in
                                                   let _ :=
@@ -5213,11 +5329,12 @@ Module num.
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let _ :=
                             M.write (|
-                              M.get_array_field (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base",
+                              M.SubPointer.get_array_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |),
                                 sz
                               |),
                               Value.Integer Integer.U8 1
@@ -5234,10 +5351,11 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (| sz |)
                   |) in
                 M.alloc (| M.read (| self |) |)
@@ -5277,11 +5395,12 @@ Module num.
                       M.get_associated_function (| Ty.path "u8", "carrying_add", [] |),
                       [
                         M.read (|
-                          M.get_array_field (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::bignum::tests::Big8x3"
-                              "base",
+                          M.SubPointer.get_array_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::bignum::tests::Big8x3",
+                              "base"
+                            |),
                             M.alloc (| Value.Integer Integer.Usize 0 |)
                           |)
                         |);
@@ -5293,17 +5412,18 @@ Module num.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let v := M.copy (| γ0_0 |) in
                         let carry := M.copy (| γ0_1 |) in
                         let _ :=
                           M.write (|
-                            M.get_array_field (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::num::bignum::tests::Big8x3"
-                                "base",
+                            M.SubPointer.get_array_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::num::bignum::tests::Big8x3",
+                                "base"
+                              |),
                               M.alloc (| Value.Integer Integer.Usize 0 |)
                             |),
                             M.read (| v |)
@@ -5333,11 +5453,12 @@ Module num.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::bignum::tests::Big8x3"
-                                                    "base",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::bignum::tests::Big8x3",
+                                                    "base"
+                                                  |),
                                                   i
                                                 |)
                                               |);
@@ -5349,17 +5470,19 @@ Module num.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let v := M.copy (| γ0_0 |) in
                                               let c := M.copy (| γ0_1 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_array_field (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::num::bignum::tests::Big8x3"
-                                                      "base",
+                                                  M.SubPointer.get_array_field (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::num::bignum::tests::Big8x3",
+                                                      "base"
+                                                    |),
                                                     i
                                                   |),
                                                   M.read (| v |)
@@ -5405,10 +5528,11 @@ Module num.
                                         BinOp.Pure.gt
                                           (M.read (| i |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::bignum::tests::Big8x3"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::bignum::tests::Big8x3",
                                               "size"
+                                            |)
                                           |))
                                       |)) in
                                   let _ :=
@@ -5418,10 +5542,11 @@ Module num.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::num::bignum::tests::Big8x3"
-                                        "size",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::num::bignum::tests::Big8x3",
+                                        "size"
+                                      |),
                                       M.read (| i |)
                                     |) in
                                   M.alloc (| Value.Tuple [] |)));
@@ -5467,16 +5592,18 @@ Module num.
                       M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |)
                       ]
                     |)
@@ -5526,10 +5653,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -5548,10 +5676,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| other |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| other |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -5600,13 +5729,13 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
-                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let a := M.copy (| γ1_0 |) in
                                           let b := M.copy (| γ1_1 |) in
                                           M.match_operator (|
@@ -5627,8 +5756,10 @@ Module num.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let v := M.copy (| γ0_0 |) in
                                                   let c := M.copy (| γ0_1 |) in
                                                   let _ :=
@@ -5665,10 +5796,11 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (| sz |)
                   |) in
                 M.alloc (| M.read (| self |) |)
@@ -5704,10 +5836,11 @@ Module num.
               M.read (|
                 let sz :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
                       "size"
+                    |)
                   |) in
                 let carry := M.alloc (| Value.Integer Integer.U8 0 |) in
                 let _ :=
@@ -5735,10 +5868,11 @@ Module num.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |);
                                 Value.StructRecord
                                   "core::ops::range::RangeTo"
                                   [ ("end_", M.read (| sz |)) ]
@@ -5778,7 +5912,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -5802,8 +5936,10 @@ Module num.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let v := M.copy (| γ0_0 |) in
                                                   let c := M.copy (| γ0_1 |) in
                                                   let _ :=
@@ -5833,11 +5969,12 @@ Module num.
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let _ :=
                             M.write (|
-                              M.get_array_field (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base",
+                              M.SubPointer.get_array_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |),
                                 sz
                               |),
                               M.read (| carry |)
@@ -5854,10 +5991,11 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (| sz |)
                   |) in
                 M.alloc (| M.read (| self |) |)
@@ -6007,10 +6145,11 @@ Module num.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::num::bignum::tests::Big8x3"
-                                                            "base";
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::num::bignum::tests::Big8x3",
+                                                            "base"
+                                                          |);
                                                           Value.StructRecord
                                                             "core::ops::range::RangeFrom"
                                                             [
@@ -6099,11 +6238,12 @@ Module num.
                                                 (BinOp.Pure.eq
                                                   (BinOp.Panic.shr (|
                                                     M.read (|
-                                                      M.get_array_field (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::bignum::tests::Big8x3"
-                                                          "base",
+                                                      M.SubPointer.get_array_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::bignum::tests::Big8x3",
+                                                          "base"
+                                                        |),
                                                         M.alloc (|
                                                           BinOp.Panic.sub (|
                                                             BinOp.Panic.sub (|
@@ -6178,10 +6318,11 @@ Module num.
                                     ("start", Value.Integer Integer.Usize 0);
                                     ("end_",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::bignum::tests::Big8x3"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::bignum::tests::Big8x3",
                                           "size"
+                                        |)
                                       |))
                                   ]
                               ]
@@ -6224,7 +6365,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -6232,11 +6373,12 @@ Module num.
                                           let i := M.copy (| γ0_0 |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::bignum::tests::Big8x3"
-                                                  "base",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::bignum::tests::Big8x3",
+                                                  "base"
+                                                |),
                                                 M.alloc (|
                                                   BinOp.Panic.add (|
                                                     M.read (| i |),
@@ -6245,11 +6387,12 @@ Module num.
                                                 |)
                                               |),
                                               M.read (|
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::bignum::tests::Big8x3"
-                                                    "base",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::bignum::tests::Big8x3",
+                                                    "base"
+                                                  |),
                                                   i
                                                 |)
                                               |)
@@ -6314,7 +6457,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -6322,11 +6465,12 @@ Module num.
                                           let i := M.copy (| γ0_0 |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::bignum::tests::Big8x3"
-                                                  "base",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::bignum::tests::Big8x3",
+                                                  "base"
+                                                |),
                                                 i
                                               |),
                                               Value.Integer Integer.U8 0
@@ -6342,10 +6486,11 @@ Module num.
                   M.alloc (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::bignum::tests::Big8x3"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::bignum::tests::Big8x3",
                           "size"
+                        |)
                       |),
                       M.read (| digits |)
                     |)
@@ -6368,11 +6513,12 @@ Module num.
                             M.alloc (|
                               BinOp.Panic.shr (|
                                 M.read (|
-                                  M.get_array_field (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base",
+                                  M.SubPointer.get_array_field (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |),
                                     M.alloc (|
                                       BinOp.Panic.sub (|
                                         M.read (| last |),
@@ -6404,11 +6550,12 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::bignum::tests::Big8x3"
-                                            "base",
+                                        M.SubPointer.get_array_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::bignum::tests::Big8x3",
+                                            "base"
+                                          |),
                                           last
                                         |),
                                         M.read (| overflow |)
@@ -6506,7 +6653,7 @@ Module num.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -6514,21 +6661,23 @@ Module num.
                                                     let i := M.copy (| γ0_0 |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_array_field (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::num::bignum::tests::Big8x3"
-                                                            "base",
+                                                        M.SubPointer.get_array_field (|
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::num::bignum::tests::Big8x3",
+                                                            "base"
+                                                          |),
                                                           i
                                                         |),
                                                         BinOp.Pure.bit_or
                                                           (BinOp.Panic.shl (|
                                                             M.read (|
-                                                              M.get_array_field (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::num::bignum::tests::Big8x3"
-                                                                  "base",
+                                                              M.SubPointer.get_array_field (|
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::num::bignum::tests::Big8x3",
+                                                                  "base"
+                                                                |),
                                                                 i
                                                               |)
                                                             |),
@@ -6536,11 +6685,12 @@ Module num.
                                                           |))
                                                           (BinOp.Panic.shr (|
                                                             M.read (|
-                                                              M.get_array_field (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::num::bignum::tests::Big8x3"
-                                                                  "base",
+                                                              M.SubPointer.get_array_field (|
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::num::bignum::tests::Big8x3",
+                                                                  "base"
+                                                                |),
                                                                 M.alloc (|
                                                                   BinOp.Panic.sub (|
                                                                     M.read (| i |),
@@ -6564,11 +6714,12 @@ Module num.
                               |)) in
                           let _ :=
                             let β :=
-                              M.get_array_field (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base",
+                              M.SubPointer.get_array_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |),
                                 digits
                               |) in
                             M.write (|
@@ -6581,10 +6732,11 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (| sz |)
                   |) in
                 M.alloc (| M.read (| self |) |)
@@ -6642,15 +6794,15 @@ Module num.
                       |))
                   |) in
                 M.match_operator (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.get_constant (| "core::num::bignum::SMALL_POW5" |),
                     table_index
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let small_power := M.copy (| γ0_0 |) in
                         let small_e := M.copy (| γ0_1 |) in
                         let small_power := M.alloc (| M.rust_cast (M.read (| small_power |)) |) in
@@ -6762,7 +6914,7 @@ Module num.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -6863,10 +7015,11 @@ Module num.
                                 (M.alloc (|
                                   BinOp.Pure.lt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::num::bignum::tests::Big8x3"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::num::bignum::tests::Big8x3",
                                         "size"
+                                      |)
                                     |))
                                     (M.call_closure (|
                                       M.get_associated_function (|
@@ -6920,18 +7073,20 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "base",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "base"
+                    |),
                     M.read (| ret |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (| retsz |)
                   |) in
                 M.alloc (| M.read (| self |) |)
@@ -6991,10 +7146,11 @@ Module num.
                   |) in
                 let sz :=
                   M.copy (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::bignum::tests::Big8x3"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::bignum::tests::Big8x3",
                       "size"
+                    |)
                   |) in
                 let borrow := M.alloc (| Value.Integer Integer.U8 0 |) in
                 let _ :=
@@ -7041,10 +7197,11 @@ Module num.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::bignum::tests::Big8x3"
-                                          "base";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::bignum::tests::Big8x3",
+                                          "base"
+                                        |);
                                         Value.StructRecord
                                           "core::ops::range::RangeTo"
                                           [ ("end_", M.read (| sz |)) ]
@@ -7092,7 +7249,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7118,8 +7275,10 @@ Module num.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let q := M.copy (| γ0_0 |) in
                                                   let r := M.copy (| γ0_1 |) in
                                                   let _ :=
@@ -7246,10 +7405,11 @@ Module num.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| q |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| q |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |);
                                 Value.StructTuple "core::ops::range::RangeFull" []
                               ]
                             |)
@@ -7287,7 +7447,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7329,10 +7489,11 @@ Module num.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| r |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "base";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| r |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "base"
+                                |);
                                 Value.StructTuple "core::ops::range::RangeFull" []
                               ]
                             |)
@@ -7370,7 +7531,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7390,23 +7551,26 @@ Module num.
                     |)) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| r |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| r |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| d |))
-                        "core::num::bignum::tests::Big8x3"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| d |),
+                        "core::num::bignum::tests::Big8x3",
                         "size"
+                      |)
                     |)
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field
-                      (M.read (| q |))
-                      "core::num::bignum::tests::Big8x3"
-                      "size",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| q |),
+                      "core::num::bignum::tests::Big8x3",
+                      "size"
+                    |),
                     Value.Integer Integer.Usize 1
                   |) in
                 let q_is_zero := M.alloc (| Value.Bool true |) in
@@ -7491,7 +7655,7 @@ Module num.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7510,11 +7674,12 @@ Module num.
                                             |) in
                                           let _ :=
                                             let β :=
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| r |))
-                                                  "core::num::bignum::tests::Big8x3"
-                                                  "base",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| r |),
+                                                  "core::num::bignum::tests::Big8x3",
+                                                  "base"
+                                                |),
                                                 M.alloc (| Value.Integer Integer.Usize 0 |)
                                               |) in
                                             M.write (|
@@ -7615,10 +7780,11 @@ Module num.
                                                               |) in
                                                             let _ :=
                                                               M.write (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| q |))
-                                                                  "core::num::bignum::tests::Big8x3"
-                                                                  "size",
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| q |),
+                                                                  "core::num::bignum::tests::Big8x3",
+                                                                  "size"
+                                                                |),
                                                                 BinOp.Panic.add (|
                                                                   M.read (| digit_idx |),
                                                                   Value.Integer Integer.Usize 1
@@ -7637,11 +7803,12 @@ Module num.
                                                     |) in
                                                   let _ :=
                                                     let β :=
-                                                      M.get_array_field (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| q |))
-                                                          "core::num::bignum::tests::Big8x3"
-                                                          "base",
+                                                      M.SubPointer.get_array_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| q |),
+                                                          "core::num::bignum::tests::Big8x3",
+                                                          "base"
+                                                        |),
                                                         digit_idx
                                                       |) in
                                                     M.write (|
@@ -7725,19 +7892,21 @@ Module num.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_struct_record_field
-                                                            (M.read (| q |))
-                                                            "core::num::bignum::tests::Big8x3"
-                                                            "base";
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| q |),
+                                                            "core::num::bignum::tests::Big8x3",
+                                                            "base"
+                                                          |);
                                                           Value.StructRecord
                                                             "core::ops::range::RangeFrom"
                                                             [
                                                               ("start",
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| q |))
-                                                                    "core::num::bignum::tests::Big8x3"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| q |),
+                                                                    "core::num::bignum::tests::Big8x3",
                                                                     "size"
+                                                                  |)
                                                                 |))
                                                             ]
                                                         ]
@@ -7853,19 +8022,21 @@ Module num.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_struct_record_field
-                                                            (M.read (| r |))
-                                                            "core::num::bignum::tests::Big8x3"
-                                                            "base";
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| r |),
+                                                            "core::num::bignum::tests::Big8x3",
+                                                            "base"
+                                                          |);
                                                           Value.StructRecord
                                                             "core::ops::range::RangeFrom"
                                                             [
                                                               ("start",
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| r |))
-                                                                    "core::num::bignum::tests::Big8x3"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| r |),
+                                                                    "core::num::bignum::tests::Big8x3",
                                                                     "size"
+                                                                  |)
                                                                 |))
                                                             ]
                                                         ]
@@ -7960,10 +8131,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::bignum::tests::Big8x3"
-                        "base";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::bignum::tests::Big8x3",
+                        "base"
+                      |);
                       Value.StructTuple "core::ops::range::RangeFull" []
                     ]
                   |);
@@ -7976,10 +8148,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::num::bignum::tests::Big8x3"
-                        "base";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::bignum::tests::Big8x3",
+                        "base"
+                      |);
                       Value.StructTuple "core::ops::range::RangeFull" []
                     ]
                   |)
@@ -8067,16 +8240,18 @@ Module num.
                       M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::bignum::tests::Big8x3"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::bignum::tests::Big8x3",
                             "size"
+                          |)
                         |)
                       ]
                     |)
@@ -8123,10 +8298,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -8181,10 +8357,11 @@ Module num.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| other |))
-                                      "core::num::bignum::tests::Big8x3"
-                                      "base";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| other |),
+                                      "core::num::bignum::tests::Big8x3",
+                                      "base"
+                                    |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
                                       [ ("end_", M.read (| sz |)) ]
@@ -8253,17 +8430,19 @@ Module num.
                 [
                   ("size",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::bignum::tests::Big8x3"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::bignum::tests::Big8x3",
                         "size"
+                      |)
                     |));
                   ("base",
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::bignum::tests::Big8x3"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::bignum::tests::Big8x3",
                         "base"
+                      |)
                     |))
                 ]))
           | _, _ => M.impossible
@@ -8313,10 +8492,11 @@ Module num.
                                     (M.alloc (|
                                       BinOp.Pure.lt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::bignum::tests::Big8x3"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::bignum::tests::Big8x3",
                                             "size"
+                                          |)
                                         |))
                                         (Value.Integer Integer.Usize 1)
                                     |)) in
@@ -8328,10 +8508,11 @@ Module num.
                                 M.alloc (| Value.Integer Integer.Usize 1 |)));
                             fun γ =>
                               ltac:(M.monadic
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::bignum::tests::Big8x3"
-                                  "size"))
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::bignum::tests::Big8x3",
+                                  "size"
+                                |)))
                           ]
                         |)
                       |) in
@@ -8388,11 +8569,12 @@ Module num.
                                                   [ Ty.path "u8" ]
                                                 |),
                                                 [
-                                                  M.get_array_field (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::num::bignum::tests::Big8x3"
-                                                      "base",
+                                                  M.SubPointer.get_array_field (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::num::bignum::tests::Big8x3",
+                                                      "base"
+                                                    |),
                                                     M.alloc (|
                                                       BinOp.Panic.sub (|
                                                         M.read (| sz |),
@@ -8451,7 +8633,7 @@ Module num.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -8487,7 +8669,7 @@ Module num.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -8540,10 +8722,11 @@ Module num.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::bignum::tests::Big8x3"
-                                              "base";
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::bignum::tests::Big8x3",
+                                              "base"
+                                            |);
                                             Value.StructRecord
                                               "core::ops::range::RangeTo"
                                               [
@@ -8597,7 +8780,7 @@ Module num.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -8726,7 +8909,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Break",
                                                             0
@@ -8768,7 +8951,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                             0

--- a/CoqOfRust/core/num/dec2flt/common.v
+++ b/CoqOfRust/core/num/dec2flt/common.v
@@ -179,8 +179,8 @@ Module num.
                             ltac:(M.monadic
                               (let γ := s in
                               let γ := M.read (| γ |) in
-                              let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                              let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                              let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                              let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                               let c := M.alloc (| γ1_0 |) in
                               let s_next := M.alloc (| γ1_rest |) in
                               let c :=
@@ -335,18 +335,20 @@ Module num.
                   M.read (| Value.String "f" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::common::BiasedFp"
-                      "f");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::common::BiasedFp",
+                      "f"
+                    |));
                   M.read (| Value.String "e" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::common::BiasedFp"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::common::BiasedFp",
                         "e"
+                      |)
                     |))
                 ]
               |)))
@@ -429,30 +431,34 @@ Module num.
               LogicalOp.and (|
                 BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::common::BiasedFp"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::common::BiasedFp",
                       "f"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::num::dec2flt::common::BiasedFp"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::num::dec2flt::common::BiasedFp",
                       "f"
+                    |)
                   |)),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::common::BiasedFp"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::common::BiasedFp",
                         "e"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::num::dec2flt::common::BiasedFp"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::dec2flt::common::BiasedFp",
                         "e"
+                      |)
                     |))))
               |)))
           | _, _ => M.impossible

--- a/CoqOfRust/core/num/dec2flt/decimal.v
+++ b/CoqOfRust/core/num/dec2flt/decimal.v
@@ -39,20 +39,22 @@ Module num.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
                           "num_digits"
+                        |)
                       ]
                     |));
                   ("decimal_point",
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", Ty.path "i32", [], "clone", [] |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
                           "decimal_point"
+                        |)
                       ]
                     |));
                   ("truncated",
@@ -65,10 +67,11 @@ Module num.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
                           "truncated"
+                        |)
                       ]
                     |));
                   ("digits",
@@ -81,10 +84,11 @@ Module num.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
                           "digits"
+                        |)
                       ]
                     |))
                 ]))
@@ -186,10 +190,11 @@ Module num.
                               (M.alloc (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::num::dec2flt::decimal::Decimal"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::num::dec2flt::decimal::Decimal",
                                       "num_digits"
+                                    |)
                                   |))
                                   (M.read (|
                                     M.get_constant (| "core::num::dec2flt::decimal::MAX_DIGITS" |)
@@ -199,15 +204,17 @@ Module num.
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let _ :=
                             M.write (|
-                              M.get_array_field (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::dec2flt::decimal::Decimal"
-                                  "digits",
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::dec2flt::decimal::Decimal"
+                              M.SubPointer.get_array_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::dec2flt::decimal::Decimal",
+                                  "digits"
+                                |),
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::dec2flt::decimal::Decimal",
                                   "num_digits"
+                                |)
                               |),
                               M.read (| digit |)
                             |) in
@@ -217,10 +224,11 @@ Module num.
                   |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::decimal::Decimal"
-                      "num_digits" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::decimal::Decimal",
+                      "num_digits"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -275,10 +283,11 @@ Module num.
                                           UnOp.Pure.not
                                             (BinOp.Pure.le
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::dec2flt::decimal::Decimal"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::dec2flt::decimal::Decimal",
                                                   "num_digits"
+                                                |)
                                               |))
                                               (M.read (|
                                                 M.get_constant (|
@@ -324,27 +333,30 @@ Module num.
                                   LogicalOp.and (|
                                     BinOp.Pure.ne
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "num_digits"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0),
                                     ltac:(M.monadic
                                       (BinOp.Pure.eq
                                         (M.read (|
-                                          M.get_array_field (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::dec2flt::decimal::Decimal"
-                                              "digits",
+                                          M.SubPointer.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::dec2flt::decimal::Decimal",
+                                              "digits"
+                                            |),
                                             M.alloc (|
                                               BinOp.Panic.sub (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::dec2flt::decimal::Decimal"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::dec2flt::decimal::Decimal",
                                                     "num_digits"
+                                                  |)
                                                 |),
                                                 Value.Integer Integer.Usize 1
                                               |)
@@ -358,10 +370,11 @@ Module num.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::dec2flt::decimal::Decimal"
-                                  "num_digits" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::dec2flt::decimal::Decimal",
+                                  "num_digits"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -435,19 +448,21 @@ Module num.
                                     LogicalOp.or (|
                                       BinOp.Pure.eq
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::dec2flt::decimal::Decimal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::dec2flt::decimal::Decimal",
                                             "num_digits"
+                                          |)
                                         |))
                                         (Value.Integer Integer.Usize 0),
                                       ltac:(M.monadic
                                         (BinOp.Pure.lt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::dec2flt::decimal::Decimal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::dec2flt::decimal::Decimal",
                                               "decimal_point"
+                                            |)
                                           |))
                                           (Value.Integer Integer.I32 0)))
                                     |)
@@ -474,10 +489,11 @@ Module num.
                                           (M.alloc (|
                                             BinOp.Pure.gt
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::dec2flt::decimal::Decimal"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::dec2flt::decimal::Decimal",
                                                   "decimal_point"
+                                                |)
                                               |))
                                               (Value.Integer Integer.I32 18)
                                           |)) in
@@ -504,10 +520,11 @@ Module num.
                       M.alloc (|
                         M.rust_cast
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::dec2flt::decimal::Decimal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::dec2flt::decimal::Decimal",
                               "decimal_point"
+                            |)
                           |))
                       |) in
                     let n := M.alloc (| Value.Integer Integer.U64 0 |) in
@@ -564,7 +581,7 @@ Module num.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -590,10 +607,11 @@ Module num.
                                                             BinOp.Pure.lt
                                                               (M.read (| i |))
                                                               (M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::num::dec2flt::decimal::Decimal"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::num::dec2flt::decimal::Decimal",
                                                                   "num_digits"
+                                                                |)
                                                               |))
                                                           |)) in
                                                       let _ :=
@@ -609,11 +627,12 @@ Module num.
                                                             M.read (| β |),
                                                             M.rust_cast
                                                               (M.read (|
-                                                                M.get_array_field (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::num::dec2flt::decimal::Decimal"
-                                                                    "digits",
+                                                                M.SubPointer.get_array_field (|
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::num::dec2flt::decimal::Decimal",
+                                                                    "digits"
+                                                                  |),
                                                                   i
                                                                 |)
                                                               |))
@@ -643,10 +662,11 @@ Module num.
                                     BinOp.Pure.lt
                                       (M.read (| dp |))
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "num_digits"
+                                        |)
                                       |))
                                   |)) in
                               let _ :=
@@ -659,11 +679,12 @@ Module num.
                                   round_up,
                                   BinOp.Pure.ge
                                     (M.read (|
-                                      M.get_array_field (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
-                                          "digits",
+                                      M.SubPointer.get_array_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
+                                          "digits"
+                                        |),
                                         dp
                                       |)
                                     |))
@@ -680,11 +701,12 @@ Module num.
                                             LogicalOp.and (|
                                               BinOp.Pure.eq
                                                 (M.read (|
-                                                  M.get_array_field (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::num::dec2flt::decimal::Decimal"
-                                                      "digits",
+                                                  M.SubPointer.get_array_field (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::num::dec2flt::decimal::Decimal",
+                                                      "digits"
+                                                    |),
                                                     dp
                                                   |)
                                                 |))
@@ -696,10 +718,11 @@ Module num.
                                                     Value.Integer Integer.Usize 1
                                                   |))
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::num::dec2flt::decimal::Decimal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::num::dec2flt::decimal::Decimal",
                                                       "num_digits"
+                                                    |)
                                                   |))))
                                             |)
                                           |)) in
@@ -712,10 +735,11 @@ Module num.
                                         round_up,
                                         LogicalOp.or (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::dec2flt::decimal::Decimal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::dec2flt::decimal::Decimal",
                                               "truncated"
+                                            |)
                                           |),
                                           ltac:(M.monadic
                                             (LogicalOp.and (|
@@ -727,11 +751,12 @@ Module num.
                                                   (BinOp.Pure.bit_and
                                                     (Value.Integer Integer.U8 1)
                                                     (M.read (|
-                                                      M.get_array_field (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::dec2flt::decimal::Decimal"
-                                                          "digits",
+                                                      M.SubPointer.get_array_field (|
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::dec2flt::decimal::Decimal",
+                                                          "digits"
+                                                        |),
                                                         M.alloc (|
                                                           BinOp.Panic.sub (|
                                                             M.read (| dp |),
@@ -841,10 +866,11 @@ Module num.
                                   (M.alloc (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "num_digits"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0)
                                   |)) in
@@ -871,19 +897,21 @@ Module num.
                       |) in
                     let read_index :=
                       M.copy (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
                           "num_digits"
+                        |)
                       |) in
                     let write_index :=
                       M.alloc (|
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::dec2flt::decimal::Decimal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::dec2flt::decimal::Decimal",
                               "num_digits"
+                            |)
                           |),
                           M.read (| num_new_digits |)
                         |)
@@ -936,11 +964,12 @@ Module num.
                                         BinOp.Panic.shl (|
                                           M.rust_cast
                                             (M.read (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::dec2flt::decimal::Decimal"
-                                                  "digits",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::dec2flt::decimal::Decimal",
+                                                  "digits"
+                                                |),
                                                 read_index
                                               |)
                                             |)),
@@ -989,11 +1018,12 @@ Module num.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::dec2flt::decimal::Decimal"
-                                                    "digits",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::dec2flt::decimal::Decimal",
+                                                    "digits"
+                                                  |),
                                                   write_index
                                                 |),
                                                 M.rust_cast (M.read (| remainder |))
@@ -1020,10 +1050,11 @@ Module num.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::dec2flt::decimal::Decimal"
-                                                          "truncated",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::dec2flt::decimal::Decimal",
+                                                          "truncated"
+                                                        |),
                                                         Value.Bool true
                                                       |) in
                                                     M.alloc (| Value.Tuple [] |)));
@@ -1119,11 +1150,12 @@ Module num.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_array_field (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::dec2flt::decimal::Decimal"
-                                                    "digits",
+                                                M.SubPointer.get_array_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::dec2flt::decimal::Decimal",
+                                                    "digits"
+                                                  |),
                                                   write_index
                                                 |),
                                                 M.rust_cast (M.read (| remainder |))
@@ -1150,10 +1182,11 @@ Module num.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::num::dec2flt::decimal::Decimal"
-                                                          "truncated",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::num::dec2flt::decimal::Decimal",
+                                                          "truncated"
+                                                        |),
                                                         Value.Bool true
                                                       |) in
                                                     M.alloc (| Value.Tuple [] |)));
@@ -1183,10 +1216,11 @@ Module num.
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
-                          "num_digits" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
+                          "num_digits"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.add (| M.read (| β |), M.read (| num_new_digits |) |)
@@ -1202,10 +1236,11 @@ Module num.
                                   (M.alloc (|
                                     BinOp.Pure.gt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "num_digits"
+                                        |)
                                       |))
                                       (M.read (|
                                         M.get_constant (|
@@ -1220,10 +1255,11 @@ Module num.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::num::dec2flt::decimal::Decimal"
-                                    "num_digits",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::num::dec2flt::decimal::Decimal",
+                                    "num_digits"
+                                  |),
                                   M.read (|
                                     M.get_constant (| "core::num::dec2flt::decimal::MAX_DIGITS" |)
                                   |)
@@ -1234,10 +1270,11 @@ Module num.
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
-                          "decimal_point" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
+                          "decimal_point"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.add (|
@@ -1356,10 +1393,11 @@ Module num.
                                                 BinOp.Pure.lt
                                                   (M.read (| read_index |))
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::num::dec2flt::decimal::Decimal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::num::dec2flt::decimal::Decimal",
                                                       "num_digits"
+                                                    |)
                                                   |))
                                               |)) in
                                           let _ :=
@@ -1377,11 +1415,12 @@ Module num.
                                                 |),
                                                 M.rust_cast
                                                   (M.read (|
-                                                    M.get_array_field (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::num::dec2flt::decimal::Decimal"
-                                                        "digits",
+                                                    M.SubPointer.get_array_field (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::num::dec2flt::decimal::Decimal",
+                                                        "digits"
+                                                      |),
                                                       read_index
                                                     |)
                                                   |))
@@ -1524,10 +1563,11 @@ Module num.
                       |) in
                     let _ :=
                       let β :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
-                          "decimal_point" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
+                          "decimal_point"
+                        |) in
                       M.write (|
                         β,
                         BinOp.Panic.sub (|
@@ -1549,10 +1589,11 @@ Module num.
                                   (M.alloc (|
                                     BinOp.Pure.lt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "decimal_point"
+                                        |)
                                       |))
                                       (UnOp.Panic.neg (|
                                         M.read (|
@@ -1572,26 +1613,29 @@ Module num.
                                   M.read (|
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
-                                          "num_digits",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
+                                          "num_digits"
+                                        |),
                                         Value.Integer Integer.Usize 0
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
-                                          "decimal_point",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
+                                          "decimal_point"
+                                        |),
                                         Value.Integer Integer.I32 0
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
-                                          "truncated",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
+                                          "truncated"
+                                        |),
                                         Value.Bool false
                                       |) in
                                     M.return_ (| Value.Tuple [] |)
@@ -1622,10 +1666,11 @@ Module num.
                                         BinOp.Pure.lt
                                           (M.read (| read_index |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::num::dec2flt::decimal::Decimal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::num::dec2flt::decimal::Decimal",
                                               "num_digits"
+                                            |)
                                           |))
                                       |)) in
                                   let _ :=
@@ -1648,11 +1693,12 @@ Module num.
                                         |),
                                         M.rust_cast
                                           (M.read (|
-                                            M.get_array_field (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::num::dec2flt::decimal::Decimal"
-                                                "digits",
+                                            M.SubPointer.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::num::dec2flt::decimal::Decimal",
+                                                "digits"
+                                              |),
                                               read_index
                                             |)
                                           |))
@@ -1669,11 +1715,12 @@ Module num.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_array_field (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::num::dec2flt::decimal::Decimal"
-                                          "digits",
+                                      M.SubPointer.get_array_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::num::dec2flt::decimal::Decimal",
+                                          "digits"
+                                        |),
                                         write_index
                                       |),
                                       M.read (| new_digit |)
@@ -1758,11 +1805,12 @@ Module num.
                                             |) in
                                           let _ :=
                                             M.write (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::dec2flt::decimal::Decimal"
-                                                  "digits",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::dec2flt::decimal::Decimal",
+                                                  "digits"
+                                                |),
                                                 write_index
                                               |),
                                               M.read (| new_digit |)
@@ -1798,10 +1846,11 @@ Module num.
                                                     |) in
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::num::dec2flt::decimal::Decimal"
-                                                        "truncated",
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::num::dec2flt::decimal::Decimal",
+                                                        "truncated"
+                                                      |),
                                                       Value.Bool true
                                                     |) in
                                                   M.alloc (| Value.Tuple [] |)));
@@ -1829,10 +1878,11 @@ Module num.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::decimal::Decimal"
-                          "num_digits",
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::decimal::Decimal",
+                          "num_digits"
+                        |),
                         M.read (| write_index |)
                       |) in
                     let _ :=
@@ -1973,13 +2023,13 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let γ1_0 := M.read (| γ1_0 |) in
                             let _ :=
                               M.is_constant_or_break_match (|
@@ -2060,13 +2110,13 @@ Module num.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
-                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                         let γ1_0 := M.read (| γ1_0 |) in
                         let _ :=
                           M.is_constant_or_break_match (|
@@ -2087,10 +2137,11 @@ Module num.
                                       (M.alloc (|
                                         BinOp.Pure.eq
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              d
-                                              "core::num::dec2flt::decimal::Decimal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              d,
+                                              "core::num::dec2flt::decimal::Decimal",
                                               "num_digits"
+                                            |)
                                           |))
                                           (Value.Integer Integer.Usize 0)
                                       |)) in
@@ -2118,13 +2169,15 @@ Module num.
                                                   |)
                                                 |) in
                                               let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
                                                 |) in
-                                              let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                              let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                              let γ1_0 :=
+                                                M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                              let γ1_1 :=
+                                                M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                               let γ1_0 := M.read (| γ1_0 |) in
                                               let _ :=
                                                 M.is_constant_or_break_match (|
@@ -2181,10 +2234,11 @@ Module num.
                                                 (BinOp.Pure.lt
                                                   (BinOp.Panic.add (|
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        d
-                                                        "core::num::dec2flt::decimal::Decimal"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        d,
+                                                        "core::num::dec2flt::decimal::Decimal",
                                                         "num_digits"
+                                                      |)
                                                     |),
                                                     Value.Integer Integer.Usize 8
                                                   |))
@@ -2266,19 +2320,21 @@ Module num.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    d
-                                                    "core::num::dec2flt::decimal::Decimal"
-                                                    "digits";
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    d,
+                                                    "core::num::dec2flt::decimal::Decimal",
+                                                    "digits"
+                                                  |);
                                                   Value.StructRecord
                                                     "core::ops::range::RangeFrom"
                                                     [
                                                       ("start",
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            d
-                                                            "core::num::dec2flt::decimal::Decimal"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            d,
+                                                            "core::num::dec2flt::decimal::Decimal",
                                                             "num_digits"
+                                                          |)
                                                         |))
                                                     ]
                                                 ]
@@ -2292,10 +2348,11 @@ Module num.
                                         |) in
                                       let _ :=
                                         let β :=
-                                          M.get_struct_record_field
-                                            d
-                                            "core::num::dec2flt::decimal::Decimal"
-                                            "num_digits" in
+                                          M.SubPointer.get_struct_record_field (|
+                                            d,
+                                            "core::num::dec2flt::decimal::Decimal",
+                                            "num_digits"
+                                          |) in
                                         M.write (|
                                           β,
                                           BinOp.Panic.add (|
@@ -2384,10 +2441,11 @@ Module num.
                           |) in
                         let _ :=
                           M.write (|
-                            M.get_struct_record_field
-                              d
-                              "core::num::dec2flt::decimal::Decimal"
-                              "decimal_point",
+                            M.SubPointer.get_struct_record_field (|
+                              d,
+                              "core::num::dec2flt::decimal::Decimal",
+                              "decimal_point"
+                            |),
                             BinOp.Panic.sub (|
                               M.rust_cast
                                 (M.call_closure (|
@@ -2424,10 +2482,11 @@ Module num.
                             (M.alloc (|
                               BinOp.Pure.ne
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    d
-                                    "core::num::dec2flt::decimal::Decimal"
+                                  M.SubPointer.get_struct_record_field (|
+                                    d,
+                                    "core::num::dec2flt::decimal::Decimal",
                                     "num_digits"
+                                  |)
                                 |))
                                 (Value.Integer Integer.Usize 0)
                             |)) in
@@ -2556,7 +2615,7 @@ Module num.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -2631,10 +2690,11 @@ Module num.
                             |)) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              d
-                              "core::num::dec2flt::decimal::Decimal"
-                              "decimal_point" in
+                            M.SubPointer.get_struct_record_field (|
+                              d,
+                              "core::num::dec2flt::decimal::Decimal",
+                              "decimal_point"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.add (|
@@ -2644,30 +2704,33 @@ Module num.
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              d
-                              "core::num::dec2flt::decimal::Decimal"
-                              "num_digits" in
+                            M.SubPointer.get_struct_record_field (|
+                              d,
+                              "core::num::dec2flt::decimal::Decimal",
+                              "num_digits"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.sub (| M.read (| β |), M.read (| n_trailing_zeros |) |)
                           |) in
                         let _ :=
                           let β :=
-                            M.get_struct_record_field
-                              d
-                              "core::num::dec2flt::decimal::Decimal"
-                              "decimal_point" in
+                            M.SubPointer.get_struct_record_field (|
+                              d,
+                              "core::num::dec2flt::decimal::Decimal",
+                              "decimal_point"
+                            |) in
                           M.write (|
                             β,
                             BinOp.Panic.add (|
                               M.read (| β |),
                               M.rust_cast
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    d
-                                    "core::num::dec2flt::decimal::Decimal"
+                                  M.SubPointer.get_struct_record_field (|
+                                    d,
+                                    "core::num::dec2flt::decimal::Decimal",
                                     "num_digits"
+                                  |)
                                 |))
                             |)
                           |) in
@@ -2681,10 +2744,11 @@ Module num.
                                     (M.alloc (|
                                       BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            d
-                                            "core::num::dec2flt::decimal::Decimal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            d,
+                                            "core::num::dec2flt::decimal::Decimal",
                                             "num_digits"
+                                          |)
                                         |))
                                         (M.read (|
                                           M.get_constant (|
@@ -2699,18 +2763,20 @@ Module num.
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      d
-                                      "core::num::dec2flt::decimal::Decimal"
-                                      "truncated",
+                                    M.SubPointer.get_struct_record_field (|
+                                      d,
+                                      "core::num::dec2flt::decimal::Decimal",
+                                      "truncated"
+                                    |),
                                     Value.Bool true
                                   |) in
                                 let _ :=
                                   M.write (|
-                                    M.get_struct_record_field
-                                      d
-                                      "core::num::dec2flt::decimal::Decimal"
-                                      "num_digits",
+                                    M.SubPointer.get_struct_record_field (|
+                                      d,
+                                      "core::num::dec2flt::decimal::Decimal",
+                                      "num_digits"
+                                    |),
                                     M.read (|
                                       M.get_constant (| "core::num::dec2flt::decimal::MAX_DIGITS" |)
                                     |)
@@ -2740,13 +2806,13 @@ Module num.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
-                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                         let γ1_0 := M.read (| γ1_0 |) in
                         let ch := M.copy (| γ1_0 |) in
                         let s_next := M.copy (| γ1_1 |) in
@@ -2793,13 +2859,13 @@ Module num.
                                               |)
                                             |) in
                                           let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
-                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let γ1_0 := M.read (| γ1_0 |) in
                                           let ch := M.copy (| γ1_0 |) in
                                           let s_next := M.copy (| γ1_1 |) in
@@ -2916,10 +2982,11 @@ Module num.
                                   |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      d
-                                      "core::num::dec2flt::decimal::Decimal"
-                                      "decimal_point" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      d,
+                                      "core::num::dec2flt::decimal::Decimal",
+                                      "decimal_point"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -2970,10 +3037,11 @@ Module num.
                             [
                               ("start",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    d
-                                    "core::num::dec2flt::decimal::Decimal"
+                                  M.SubPointer.get_struct_record_field (|
+                                    d,
+                                    "core::num::dec2flt::decimal::Decimal",
                                     "num_digits"
+                                  |)
                                 |));
                               ("end_",
                                 M.read (|
@@ -3016,7 +3084,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -3024,11 +3092,12 @@ Module num.
                                         let i := M.copy (| γ0_0 |) in
                                         let _ :=
                                           M.write (|
-                                            M.get_array_field (|
-                                              M.get_struct_record_field
-                                                d
-                                                "core::num::dec2flt::decimal::Decimal"
-                                                "digits",
+                                            M.SubPointer.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                d,
+                                                "core::num::dec2flt::decimal::Decimal",
+                                                "digits"
+                                              |),
                                               i
                                             |),
                                             Value.Integer Integer.U8 0
@@ -3142,7 +3211,7 @@ Module num.
                     |) in
                   let x_a :=
                     M.copy (|
-                      M.get_array_field (|
+                      M.SubPointer.get_array_field (|
                         M.get_constant (|
                           "core::num::dec2flt::decimal::number_of_digits_decimal_left_shift::TABLE"
                         |),
@@ -3151,7 +3220,7 @@ Module num.
                     |) in
                   let x_b :=
                     M.copy (|
-                      M.get_array_field (|
+                      M.SubPointer.get_array_field (|
                         M.get_constant (|
                           "core::num::dec2flt::decimal::number_of_digits_decimal_left_shift::TABLE"
                         |),
@@ -3292,13 +3361,15 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
                                               |) in
-                                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                            let γ1_0 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                            let γ1_1 :=
+                                              M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                             let i := M.copy (| γ1_0 |) in
                                             let γ1_1 := M.read (| γ1_1 |) in
                                             let p5 := M.copy (| γ1_1 |) in
@@ -3313,10 +3384,11 @@ Module num.
                                                           BinOp.Pure.ge
                                                             (M.read (| i |))
                                                             (M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| d |))
-                                                                "core::num::dec2flt::decimal::Decimal"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| d |),
+                                                                "core::num::dec2flt::decimal::Decimal",
                                                                 "num_digits"
+                                                              |)
                                                             |))
                                                         |)) in
                                                     let _ :=
@@ -3348,11 +3420,12 @@ Module num.
                                                                 (M.alloc (|
                                                                   BinOp.Pure.eq
                                                                     (M.read (|
-                                                                      M.get_array_field (|
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| d |))
-                                                                          "core::num::dec2flt::decimal::Decimal"
-                                                                          "digits",
+                                                                      M.SubPointer.get_array_field (|
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| d |),
+                                                                          "core::num::dec2flt::decimal::Decimal",
+                                                                          "digits"
+                                                                        |),
                                                                         i
                                                                       |)
                                                                     |))
@@ -3380,11 +3453,12 @@ Module num.
                                                                         (M.alloc (|
                                                                           BinOp.Pure.lt
                                                                             (M.read (|
-                                                                              M.get_array_field (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (| d |))
-                                                                                  "core::num::dec2flt::decimal::Decimal"
-                                                                                  "digits",
+                                                                              M.SubPointer.get_array_field (|
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| d |),
+                                                                                  "core::num::dec2flt::decimal::Decimal",
+                                                                                  "digits"
+                                                                                |),
                                                                                 i
                                                                               |)
                                                                             |))

--- a/CoqOfRust/core/num/dec2flt/float.v
+++ b/CoqOfRust/core/num/dec2flt/float.v
@@ -192,7 +192,7 @@ Module num.
             ltac:(M.monadic
               (let exponent := M.alloc (| exponent |) in
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::num::dec2flt::float::pow10_fast_path::TABLE" |),
                   M.alloc (|
                     BinOp.Pure.bit_and (M.read (| exponent |)) (Value.Integer Integer.Usize 15)
@@ -548,7 +548,7 @@ Module num.
             ltac:(M.monadic
               (let exponent := M.alloc (| exponent |) in
               M.read (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.get_constant (| "core::num::dec2flt::float::pow10_fast_path::TABLE" |),
                   M.alloc (|
                     BinOp.Pure.bit_and (M.read (| exponent |)) (Value.Integer Integer.Usize 31)

--- a/CoqOfRust/core/num/dec2flt/lemire.v
+++ b/CoqOfRust/core/num/dec2flt/lemire.v
@@ -238,8 +238,8 @@ Module num.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let lo := M.copy (| γ0_0 |) in
                           let hi := M.copy (| γ0_1 |) in
                           let _ :=
@@ -965,15 +965,15 @@ Module num.
                     |))
                 |) in
               M.match_operator (|
-                M.get_array_field (|
+                M.SubPointer.get_array_field (|
                   M.read (| M.get_constant (| "core::num::dec2flt::table::POWER_OF_FIVE_128" |) |),
                   index
                 |),
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let lo5 := M.copy (| γ0_0 |) in
                       let hi5 := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -989,8 +989,8 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let first_lo := M.copy (| γ0_0 |) in
                               let first_hi := M.copy (| γ0_1 |) in
                               let _ :=
@@ -1026,8 +1026,10 @@ Module num.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let second_hi := M.copy (| γ0_1 |) in
                                                 let _ :=
                                                   M.write (|

--- a/CoqOfRust/core/num/dec2flt/mod.v
+++ b/CoqOfRust/core/num/dec2flt/mod.v
@@ -97,10 +97,11 @@ Module num.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::ParseFloatError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::ParseFloatError",
                       "kind"
+                    |)
                   |))
               ]
             |)))
@@ -137,10 +138,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::ParseFloatError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::ParseFloatError",
                         "kind"
+                      |)
                     ]
                   |))
               ]))
@@ -185,14 +187,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::num::dec2flt::ParseFloatError"
-                  "kind";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::num::dec2flt::ParseFloatError"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::num::dec2flt::ParseFloatError",
                   "kind"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::num::dec2flt::ParseFloatError",
+                  "kind"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -451,10 +455,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::num::dec2flt::ParseFloatError"
-                  "kind",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::num::dec2flt::ParseFloatError",
+                  "kind"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -564,7 +569,13 @@ Module num.
           (let x := M.alloc (| x |) in
           M.read (|
             let word :=
-              M.copy (| M.get_struct_record_field x "core::num::dec2flt::common::BiasedFp" "f" |) in
+              M.copy (|
+                M.SubPointer.get_struct_record_field (|
+                  x,
+                  "core::num::dec2flt::common::BiasedFp",
+                  "f"
+                |)
+              |) in
             let _ :=
               let β := word in
               M.write (|
@@ -574,7 +585,11 @@ Module num.
                   (BinOp.Panic.shl (|
                     M.rust_cast
                       (M.read (|
-                        M.get_struct_record_field x "core::num::dec2flt::common::BiasedFp" "e"
+                        M.SubPointer.get_struct_record_field (|
+                          x,
+                          "core::num::dec2flt::common::BiasedFp",
+                          "e"
+                        |)
                       |)),
                     M.read (|
                       M.get_constant (|
@@ -680,7 +695,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -809,7 +824,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -829,7 +844,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -872,7 +887,11 @@ Module num.
                   |) in
                 let _ :=
                   M.write (|
-                    M.get_struct_record_field num "core::num::dec2flt::number::Number" "negative",
+                    M.SubPointer.get_struct_record_field (|
+                      num,
+                      "core::num::dec2flt::number::Number",
+                      "negative"
+                    |),
                     M.read (| negative |)
                   |) in
                 let _ :=
@@ -893,7 +912,7 @@ Module num.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -919,16 +938,18 @@ Module num.
                       M.get_function (| "core::num::dec2flt::lemire::compute_float", [ F ] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            num
-                            "core::num::dec2flt::number::Number"
+                          M.SubPointer.get_struct_record_field (|
+                            num,
+                            "core::num::dec2flt::number::Number",
                             "exponent"
+                          |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            num
-                            "core::num::dec2flt::number::Number"
+                          M.SubPointer.get_struct_record_field (|
+                            num,
+                            "core::num::dec2flt::number::Number",
                             "mantissa"
+                          |)
                         |)
                       ]
                     |)
@@ -945,18 +966,20 @@ Module num.
                                 LogicalOp.and (|
                                   LogicalOp.and (|
                                     M.read (|
-                                      M.get_struct_record_field
-                                        num
-                                        "core::num::dec2flt::number::Number"
+                                      M.SubPointer.get_struct_record_field (|
+                                        num,
+                                        "core::num::dec2flt::number::Number",
                                         "many_digits"
+                                      |)
                                     |),
                                     ltac:(M.monadic
                                       (BinOp.Pure.ge
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            fp
-                                            "core::num::dec2flt::common::BiasedFp"
+                                          M.SubPointer.get_struct_record_field (|
+                                            fp,
+                                            "core::num::dec2flt::common::BiasedFp",
                                             "e"
+                                          |)
                                         |))
                                         (Value.Integer Integer.I32 0)))
                                   |),
@@ -979,17 +1002,19 @@ Module num.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  num
-                                                  "core::num::dec2flt::number::Number"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  num,
+                                                  "core::num::dec2flt::number::Number",
                                                   "exponent"
+                                                |)
                                               |);
                                               BinOp.Panic.add (|
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    num
-                                                    "core::num::dec2flt::number::Number"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    num,
+                                                    "core::num::dec2flt::number::Number",
                                                     "mantissa"
+                                                  |)
                                                 |),
                                                 Value.Integer Integer.U64 1
                                               |)
@@ -1004,10 +1029,11 @@ Module num.
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                fp
-                                "core::num::dec2flt::common::BiasedFp"
-                                "e",
+                              M.SubPointer.get_struct_record_field (|
+                                fp,
+                                "core::num::dec2flt::common::BiasedFp",
+                                "e"
+                              |),
                               Value.Integer Integer.I32 (-1)
                             |) in
                           M.alloc (| Value.Tuple [] |)));
@@ -1025,10 +1051,11 @@ Module num.
                               (M.alloc (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      fp
-                                      "core::num::dec2flt::common::BiasedFp"
+                                    M.SubPointer.get_struct_record_field (|
+                                      fp,
+                                      "core::num::dec2flt::common::BiasedFp",
                                       "e"
+                                    |)
                                   |))
                                   (Value.Integer Integer.I32 0)
                               |)) in
@@ -1064,10 +1091,11 @@ Module num.
                         ltac:(M.monadic
                           (let γ :=
                             M.use
-                              (M.get_struct_record_field
-                                num
-                                "core::num::dec2flt::number::Number"
-                                "negative") in
+                              (M.SubPointer.get_struct_record_field (|
+                                num,
+                                "core::num::dec2flt::number::Number",
+                                "negative"
+                              |)) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let _ :=

--- a/CoqOfRust/core/num/dec2flt/number.v
+++ b/CoqOfRust/core/num/dec2flt/number.v
@@ -115,32 +115,36 @@ Module num.
                   M.read (| Value.String "exponent" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::number::Number"
-                      "exponent");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::number::Number",
+                      "exponent"
+                    |));
                   M.read (| Value.String "mantissa" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::number::Number"
-                      "mantissa");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::number::Number",
+                      "mantissa"
+                    |));
                   M.read (| Value.String "negative" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::dec2flt::number::Number"
-                      "negative");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::dec2flt::number::Number",
+                      "negative"
+                    |));
                   M.read (| Value.String "many_digits" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::number::Number"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::number::Number",
                         "many_digits"
+                      |)
                     |))
                 ]
               |)))
@@ -248,60 +252,68 @@ Module num.
                   LogicalOp.and (|
                     BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::number::Number",
                           "exponent"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::dec2flt::number::Number",
                           "exponent"
+                        |)
                       |)),
                     ltac:(M.monadic
                       (BinOp.Pure.eq
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::dec2flt::number::Number"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::dec2flt::number::Number",
                             "mantissa"
+                          |)
                         |))
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::dec2flt::number::Number"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::dec2flt::number::Number",
                             "mantissa"
+                          |)
                         |))))
                   |),
                   ltac:(M.monadic
                     (BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::number::Number",
                           "negative"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::dec2flt::number::Number",
                           "negative"
+                        |)
                       |))))
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::number::Number"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::number::Number",
                         "many_digits"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::num::dec2flt::number::Number"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::dec2flt::number::Number",
                         "many_digits"
+                      |)
                     |))))
               |)))
           | _, _ => M.impossible
@@ -393,18 +405,20 @@ Module num.
                         |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::number::Number",
                           "exponent"
+                        |)
                       |)),
                     ltac:(M.monadic
                       (BinOp.Pure.le
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::dec2flt::number::Number"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::dec2flt::number::Number",
                             "exponent"
+                          |)
                         |))
                         (M.read (|
                           M.get_constant (|
@@ -415,10 +429,11 @@ Module num.
                   ltac:(M.monadic
                     (BinOp.Pure.le
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::dec2flt::number::Number"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::dec2flt::number::Number",
                           "mantissa"
+                        |)
                       |))
                       (M.read (|
                         M.get_constant (|
@@ -429,10 +444,11 @@ Module num.
                 ltac:(M.monadic
                   (UnOp.Pure.not
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::dec2flt::number::Number"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::dec2flt::number::Number",
                         "many_digits"
+                      |)
                     |))))
               |)))
           | _, _ => M.impossible
@@ -527,10 +543,11 @@ Module num.
                                             (M.alloc (|
                                               BinOp.Pure.le
                                                 (M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::dec2flt::number::Number"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::dec2flt::number::Number",
                                                     "exponent"
+                                                  |)
                                                 |))
                                                 (M.read (|
                                                   M.get_constant (|
@@ -555,10 +572,11 @@ Module num.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::num::dec2flt::number::Number"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::num::dec2flt::number::Number",
                                                     "mantissa"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -573,10 +591,11 @@ Module num.
                                                     (M.alloc (|
                                                       BinOp.Pure.lt
                                                         (M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::num::dec2flt::number::Number"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::num::dec2flt::number::Number",
                                                             "exponent"
+                                                          |)
                                                         |))
                                                         (Value.Integer Integer.I64 0)
                                                     |)) in
@@ -608,10 +627,11 @@ Module num.
                                                           M.rust_cast
                                                             (UnOp.Panic.neg (|
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::num::dec2flt::number::Number"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::num::dec2flt::number::Number",
                                                                   "exponent"
+                                                                |)
                                                               |)
                                                             |))
                                                         ]
@@ -643,10 +663,11 @@ Module num.
                                                         [
                                                           M.rust_cast
                                                             (M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::num::dec2flt::number::Number"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::num::dec2flt::number::Number",
                                                                 "exponent"
+                                                              |)
                                                             |))
                                                         ]
                                                       |)
@@ -661,10 +682,11 @@ Module num.
                                           M.alloc (|
                                             BinOp.Panic.sub (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::num::dec2flt::number::Number"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::num::dec2flt::number::Number",
                                                   "exponent"
+                                                |)
                                               |),
                                               M.read (|
                                                 M.get_constant (|
@@ -696,13 +718,14 @@ Module num.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::num::dec2flt::number::Number"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::num::dec2flt::number::Number",
                                                             "mantissa"
+                                                          |)
                                                         |);
                                                         M.read (|
-                                                          M.get_array_field (|
+                                                          M.SubPointer.get_array_field (|
                                                             M.get_constant (|
                                                               "core::num::dec2flt::number::INT_POW10"
                                                             |),
@@ -720,7 +743,7 @@ Module num.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Break",
                                                         0
@@ -756,7 +779,7 @@ Module num.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                         0
@@ -854,10 +877,11 @@ Module num.
                                     ltac:(M.monadic
                                       (let γ :=
                                         M.use
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::dec2flt::number::Number"
-                                            "negative") in
+                                          (M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::dec2flt::number::Number",
+                                            "negative"
+                                          |)) in
                                       let _ :=
                                         M.is_constant_or_break_match (|
                                           M.read (| γ |),

--- a/CoqOfRust/core/num/dec2flt/parse.v
+++ b/CoqOfRust/core/num/dec2flt/parse.v
@@ -379,8 +379,8 @@ Module num.
                                   ltac:(M.monadic
                                     (let γ := s in
                                     let γ := M.read (| γ |) in
-                                    let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                                    let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                                     let c := M.alloc (| γ1_0 |) in
                                     let s_next := M.alloc (| γ1_rest |) in
                                     let digit :=
@@ -514,13 +514,13 @@ Module num.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
                           |) in
-                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                         let γ1_0 := M.read (| γ1_0 |) in
                         let c := M.copy (| γ1_0 |) in
                         let s_next := M.copy (| γ1_1 |) in
@@ -582,7 +582,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -865,8 +865,13 @@ Module num.
                         [ M.read (| s |); M.read (| mantissa |) ]
                       |)
                     |) in
-                  let _ := M.write (| s, M.read (| M.get_tuple_field tmp 0 |) |) in
-                  let _ := M.write (| mantissa, M.read (| M.get_tuple_field tmp 1 |) |) in
+                  let _ :=
+                    M.write (| s, M.read (| M.SubPointer.get_tuple_field (| tmp, 0 |) |) |) in
+                  let _ :=
+                    M.write (|
+                      mantissa,
+                      M.read (| M.SubPointer.get_tuple_field (| tmp, 1 |) |)
+                    |) in
                   let n_digits :=
                     M.alloc (|
                       M.call_closure (|
@@ -901,13 +906,13 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let γ1_0 := M.read (| γ1_0 |) in
                             let _ :=
                               M.is_constant_or_break_match (|
@@ -927,8 +932,16 @@ Module num.
                                   [ M.read (| s |); M.read (| mantissa |) ]
                                 |)
                               |) in
-                            let _ := M.write (| s, M.read (| M.get_tuple_field tmp 0 |) |) in
-                            let _ := M.write (| mantissa, M.read (| M.get_tuple_field tmp 1 |) |) in
+                            let _ :=
+                              M.write (|
+                                s,
+                                M.read (| M.SubPointer.get_tuple_field (| tmp, 0 |) |)
+                              |) in
+                            let _ :=
+                              M.write (|
+                                mantissa,
+                                M.read (| M.SubPointer.get_tuple_field (| tmp, 1 |) |)
+                              |) in
                             let _ :=
                               M.write (|
                                 n_after_dot,
@@ -1002,13 +1015,13 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let γ1_0 := M.read (| γ1_0 |) in
                             let c := M.copy (| γ1_0 |) in
                             let s_next := M.copy (| γ1_1 |) in
@@ -1067,7 +1080,7 @@ Module num.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Break",
                                                       0
@@ -1110,7 +1123,7 @@ Module num.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::ops::control_flow::ControlFlow::Continue",
                                                       0
@@ -1221,13 +1234,13 @@ Module num.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
-                                let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                 let γ1_0 := M.read (| γ1_0 |) in
                                 let c := M.copy (| γ1_0 |) in
                                 let p_next := M.copy (| γ1_1 |) in
@@ -1490,13 +1503,13 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let float := M.copy (| γ1_0 |) in
                             let rest := M.copy (| γ1_1 |) in
                             M.match_operator (|
@@ -1671,7 +1684,7 @@ Module num.
                                       M.alloc (|
                                         M.rust_cast
                                           (M.read (|
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               M.read (| s |),
                                               M.alloc (| Value.Integer Integer.Usize 0 |)
                                             |)
@@ -1681,7 +1694,7 @@ Module num.
                                       M.alloc (|
                                         M.rust_cast
                                           (M.read (|
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               M.read (| s |),
                                               M.alloc (| Value.Integer Integer.Usize 1 |)
                                             |)
@@ -1691,7 +1704,7 @@ Module num.
                                       M.alloc (|
                                         M.rust_cast
                                           (M.read (|
-                                            M.get_array_field (|
+                                            M.SubPointer.get_array_field (|
                                               M.read (| s |),
                                               M.alloc (| Value.Integer Integer.Usize 2 |)
                                             |)
@@ -1744,8 +1757,8 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),
@@ -1761,8 +1774,8 @@ Module num.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),
@@ -1778,8 +1791,8 @@ Module num.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let _ :=
                                 M.is_constant_or_break_match (|
                                   M.read (| γ0_0 |),

--- a/CoqOfRust/core/num/dec2flt/slow.v
+++ b/CoqOfRust/core/num/dec2flt/slow.v
@@ -136,7 +136,7 @@ Module num.
                                                 M.alloc (|
                                                   M.rust_cast
                                                     (M.read (|
-                                                      M.get_array_field (|
+                                                      M.SubPointer.get_array_field (|
                                                         M.get_constant (|
                                                           "core::num::dec2flt::slow::parse_long_mantissa::POWERS"
                                                         |),
@@ -204,19 +204,21 @@ Module num.
                                   LogicalOp.or (|
                                     BinOp.Pure.eq
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          d
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          d,
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "num_digits"
+                                        |)
                                       |))
                                       (Value.Integer Integer.Usize 0),
                                     ltac:(M.monadic
                                       (BinOp.Pure.lt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            d
-                                            "core::num::dec2flt::decimal::Decimal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            d,
+                                            "core::num::dec2flt::decimal::Decimal",
                                             "decimal_point"
+                                          |)
                                         |))
                                         (Value.Integer Integer.I32 (-324))))
                                   |)
@@ -238,10 +240,11 @@ Module num.
                                         (M.alloc (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                d
-                                                "core::num::dec2flt::decimal::Decimal"
+                                              M.SubPointer.get_struct_record_field (|
+                                                d,
+                                                "core::num::dec2flt::decimal::Decimal",
                                                 "decimal_point"
+                                              |)
                                             |))
                                             (Value.Integer Integer.I32 310)
                                         |)) in
@@ -274,10 +277,11 @@ Module num.
                                     (M.alloc (|
                                       BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            d
-                                            "core::num::dec2flt::decimal::Decimal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            d,
+                                            "core::num::dec2flt::decimal::Decimal",
                                             "decimal_point"
+                                          |)
                                         |))
                                         (Value.Integer Integer.I32 0)
                                     |)) in
@@ -290,10 +294,11 @@ Module num.
                                   M.alloc (|
                                     M.rust_cast
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          d
-                                          "core::num::dec2flt::decimal::Decimal"
+                                        M.SubPointer.get_struct_record_field (|
+                                          d,
+                                          "core::num::dec2flt::decimal::Decimal",
                                           "decimal_point"
+                                        |)
                                       |))
                                   |) in
                                 let shift :=
@@ -333,10 +338,11 @@ Module num.
                                               (M.alloc (|
                                                 BinOp.Pure.lt
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      d
-                                                      "core::num::dec2flt::decimal::Decimal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      d,
+                                                      "core::num::dec2flt::decimal::Decimal",
                                                       "decimal_point"
+                                                    |)
                                                   |))
                                                   (UnOp.Panic.neg (|
                                                     M.read (|
@@ -398,10 +404,11 @@ Module num.
                                     (M.alloc (|
                                       BinOp.Pure.le
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            d
-                                            "core::num::dec2flt::decimal::Decimal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            d,
+                                            "core::num::dec2flt::decimal::Decimal",
                                             "decimal_point"
+                                          |)
                                         |))
                                         (Value.Integer Integer.I32 0)
                                     |)) in
@@ -422,10 +429,11 @@ Module num.
                                                 (M.alloc (|
                                                   BinOp.Pure.eq
                                                     (M.read (|
-                                                      M.get_struct_record_field
-                                                        d
-                                                        "core::num::dec2flt::decimal::Decimal"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        d,
+                                                        "core::num::dec2flt::decimal::Decimal",
                                                         "decimal_point"
+                                                      |)
                                                     |))
                                                     (Value.Integer Integer.I32 0)
                                                 |)) in
@@ -435,11 +443,12 @@ Module num.
                                                 Value.Bool true
                                               |) in
                                             M.match_operator (|
-                                              M.get_array_field (|
-                                                M.get_struct_record_field
-                                                  d
-                                                  "core::num::dec2flt::decimal::Decimal"
-                                                  "digits",
+                                              M.SubPointer.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  d,
+                                                  "core::num::dec2flt::decimal::Decimal",
+                                                  "digits"
+                                                |),
                                                 M.alloc (| Value.Integer Integer.Usize 0 |)
                                               |),
                                               [
@@ -518,10 +527,11 @@ Module num.
                                                       M.rust_cast
                                                         (UnOp.Panic.neg (|
                                                           M.read (|
-                                                            M.get_struct_record_field
-                                                              d
-                                                              "core::num::dec2flt::decimal::Decimal"
+                                                            M.SubPointer.get_struct_record_field (|
+                                                              d,
+                                                              "core::num::dec2flt::decimal::Decimal",
                                                               "decimal_point"
+                                                            |)
                                                           |)
                                                         |))
                                                     ]
@@ -553,10 +563,11 @@ Module num.
                                               (M.alloc (|
                                                 BinOp.Pure.gt
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      d
-                                                      "core::num::dec2flt::decimal::Decimal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      d,
+                                                      "core::num::dec2flt::decimal::Decimal",
                                                       "decimal_point"
+                                                    |)
                                                   |))
                                                   (M.read (|
                                                     M.get_constant (|

--- a/CoqOfRust/core/num/diy_float.v
+++ b/CoqOfRust/core/num/diy_float.v
@@ -76,12 +76,20 @@ Module num.
                 M.read (| Value.String "f" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "f");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::diy_float::Fp",
+                    "f"
+                  |));
                 M.read (| Value.String "e" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "e"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::diy_float::Fp",
+                      "e"
+                    |)
                   |))
               ]
             |)))
@@ -127,7 +135,11 @@ Module num.
                 M.alloc (|
                   BinOp.Panic.shr (|
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "f"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::diy_float::Fp",
+                        "f"
+                      |)
                     |),
                     Value.Integer Integer.I32 32
                   |)
@@ -136,7 +148,11 @@ Module num.
                 M.alloc (|
                   BinOp.Pure.bit_and
                     (M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "f"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::diy_float::Fp",
+                        "f"
+                      |)
                     |))
                     (M.read (| M.get_constant (| "core::num::diy_float::mul::MASK" |) |))
                 |) in
@@ -144,7 +160,11 @@ Module num.
                 M.alloc (|
                   BinOp.Panic.shr (|
                     M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "core::num::diy_float::Fp" "f"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::diy_float::Fp",
+                        "f"
+                      |)
                     |),
                     Value.Integer Integer.I32 32
                   |)
@@ -153,7 +173,11 @@ Module num.
                 M.alloc (|
                   BinOp.Pure.bit_and
                     (M.read (|
-                      M.get_struct_record_field (M.read (| other |)) "core::num::diy_float::Fp" "f"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::diy_float::Fp",
+                        "f"
+                      |)
                     |))
                     (M.read (| M.get_constant (| "core::num::diy_float::mul::MASK" |) |))
                 |) in
@@ -196,13 +220,18 @@ Module num.
                   BinOp.Panic.add (|
                     BinOp.Panic.add (|
                       M.read (|
-                        M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "e"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::diy_float::Fp",
+                          "e"
+                        |)
                       |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::diy_float::Fp"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::diy_float::Fp",
                           "e"
+                        |)
                       |)
                     |),
                     Value.Integer Integer.I16 64
@@ -259,11 +288,19 @@ Module num.
             M.read (|
               let f :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "f"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::diy_float::Fp",
+                    "f"
+                  |)
                 |) in
               let e :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "e"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::num::diy_float::Fp",
+                    "e"
+                  |)
                 |) in
               let _ :=
                 M.match_operator (|
@@ -568,7 +605,11 @@ Module num.
                 M.alloc (|
                   BinOp.Panic.sub (|
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "e"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::diy_float::Fp",
+                        "e"
+                      |)
                     |),
                     M.read (| e |)
                   |)
@@ -608,24 +649,29 @@ Module num.
                           BinOp.Panic.shr (|
                             BinOp.Panic.shl (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::diy_float::Fp"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::diy_float::Fp",
                                   "f"
+                                |)
                               |),
                               M.read (| edelta |)
                             |),
                             M.read (| edelta |)
                           |)
                         |);
-                        M.get_struct_record_field (M.read (| self |)) "core::num::diy_float::Fp" "f"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::diy_float::Fp",
+                          "f"
+                        |)
                       ]
                   |),
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let left_val := M.copy (| γ0_0 |) in
                         let right_val := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -682,10 +728,11 @@ Module num.
                     ("f",
                       BinOp.Panic.shl (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::diy_float::Fp"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::diy_float::Fp",
                             "f"
+                          |)
                         |),
                         M.read (| edelta |)
                       |));

--- a/CoqOfRust/core/num/error.v
+++ b/CoqOfRust/core/num/error.v
@@ -32,10 +32,11 @@ Module num.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::num::error::TryFromIntError"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::num::error::TryFromIntError",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -117,8 +118,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::error::TryFromIntError" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::error::TryFromIntError" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::error::TryFromIntError",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::error::TryFromIntError",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -320,10 +329,11 @@ Module num.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::error::ParseIntError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::error::ParseIntError",
                       "kind"
+                    |)
                   |))
               ]
             |)))
@@ -360,10 +370,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::error::ParseIntError"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::error::ParseIntError",
                         "kind"
+                      |)
                     ]
                   |))
               ]))
@@ -408,14 +419,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::num::error::ParseIntError"
-                  "kind";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::num::error::ParseIntError"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::num::error::ParseIntError",
                   "kind"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::num::error::ParseIntError",
+                  "kind"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -710,7 +723,11 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field (M.read (| self |)) "core::num::error::ParseIntError" "kind"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::num::error::ParseIntError",
+              "kind"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -780,10 +797,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::num::error::ParseIntError"
-                  "kind",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::num::error::ParseIntError",
+                  "kind"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic

--- a/CoqOfRust/core/num/f32.v
+++ b/CoqOfRust/core/num/f32.v
@@ -500,8 +500,8 @@ Module f32.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -515,8 +515,8 @@ Module f32.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Zero" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -570,8 +570,8 @@ Module f32.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -585,8 +585,8 @@ Module f32.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Infinite" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -595,8 +595,8 @@ Module f32.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Nan" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -610,8 +610,8 @@ Module f32.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Zero" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -1342,8 +1342,8 @@ Module f32.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     let abs_a :=

--- a/CoqOfRust/core/num/f64.v
+++ b/CoqOfRust/core/num/f64.v
@@ -478,8 +478,8 @@ Module f64.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -493,8 +493,8 @@ Module f64.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Infinite" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -508,8 +508,8 @@ Module f64.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Zero" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -563,8 +563,8 @@ Module f64.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -578,8 +578,8 @@ Module f64.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Infinite" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -588,8 +588,8 @@ Module f64.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Nan" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_0 |),
@@ -603,8 +603,8 @@ Module f64.
                     M.alloc (| Value.StructTuple "core::num::FpCategory::Zero" [] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _ :=
                       M.is_constant_or_break_match (|
                         M.read (| γ0_1 |),
@@ -1377,8 +1377,8 @@ Module f64.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     let abs_a :=

--- a/CoqOfRust/core/num/flt2dec/decoder.v
+++ b/CoqOfRust/core/num/flt2dec/decoder.v
@@ -91,39 +91,44 @@ Module num.
                   M.read (| Value.String "mant" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::flt2dec::decoder::Decoded"
-                      "mant");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::flt2dec::decoder::Decoded",
+                      "mant"
+                    |));
                   M.read (| Value.String "minus" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::flt2dec::decoder::Decoded"
-                      "minus");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::flt2dec::decoder::Decoded",
+                      "minus"
+                    |));
                   M.read (| Value.String "plus" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::flt2dec::decoder::Decoded"
-                      "plus");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::flt2dec::decoder::Decoded",
+                      "plus"
+                    |));
                   M.read (| Value.String "exp" |);
                   (* Unsize *)
                   M.pointer_coercion
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::num::flt2dec::decoder::Decoded"
-                      "exp");
+                    (M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::num::flt2dec::decoder::Decoded",
+                      "exp"
+                    |));
                   M.read (| Value.String "inclusive" |);
                   (* Unsize *)
                   M.pointer_coercion
                     (M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::flt2dec::decoder::Decoded"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::flt2dec::decoder::Decoded",
                         "inclusive"
+                      |)
                     |))
                 ]
               |)))
@@ -165,75 +170,85 @@ Module num.
                     LogicalOp.and (|
                       BinOp.Pure.eq
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "mant"
+                          |)
                         |))
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "mant"
+                          |)
                         |)),
                       ltac:(M.monadic
                         (BinOp.Pure.eq
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::flt2dec::decoder::Decoded"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::flt2dec::decoder::Decoded",
                               "minus"
+                            |)
                           |))
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| other |))
-                              "core::num::flt2dec::decoder::Decoded"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| other |),
+                              "core::num::flt2dec::decoder::Decoded",
                               "minus"
+                            |)
                           |))))
                     |),
                     ltac:(M.monadic
                       (BinOp.Pure.eq
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "plus"
+                          |)
                         |))
                         (M.read (|
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "plus"
+                          |)
                         |))))
                   |),
                   ltac:(M.monadic
                     (BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::flt2dec::decoder::Decoded"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::flt2dec::decoder::Decoded",
                           "exp"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::num::flt2dec::decoder::Decoded"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::num::flt2dec::decoder::Decoded",
                           "exp"
+                        |)
                       |))))
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::flt2dec::decoder::Decoded"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::flt2dec::decoder::Decoded",
                         "inclusive"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::num::flt2dec::decoder::Decoded"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::num::flt2dec::decoder::Decoded",
                         "inclusive"
+                      |)
                     |))))
               |)))
           | _, _ => M.impossible
@@ -423,7 +438,7 @@ Module num.
                       ltac:(M.monadic
                         (let γ := M.read (| γ |) in
                         let γ1_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::num::flt2dec::decoder::FullDecoded::Finite",
                             0
@@ -509,11 +524,11 @@ Module num.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let γ0_0 := M.read (| γ0_0 |) in
                                 let γ2_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_0,
                                     "core::num::flt2dec::decoder::FullDecoded::Finite",
                                     0
@@ -521,7 +536,7 @@ Module num.
                                 let __self_0 := M.alloc (| γ2_0 |) in
                                 let γ0_1 := M.read (| γ0_1 |) in
                                 let γ2_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ0_1,
                                     "core::num::flt2dec::decoder::FullDecoded::Finite",
                                     0
@@ -705,9 +720,9 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
-                      let γ0_2 := M.get_tuple_field γ 2 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                      let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                       let mant := M.copy (| γ0_0 |) in
                       let exp := M.copy (| γ0_1 |) in
                       let sign := M.copy (| γ0_2 |) in
@@ -807,7 +822,9 @@ Module num.
                                               (M.alloc (|
                                                 BinOp.Pure.eq
                                                   (M.read (| mant |))
-                                                  (M.read (| M.get_tuple_field minnorm 0 |))
+                                                  (M.read (|
+                                                    M.SubPointer.get_tuple_field (| minnorm, 0 |)
+                                                  |))
                                               |)) in
                                           let _ :=
                                             M.is_constant_or_break_match (|

--- a/CoqOfRust/core/num/flt2dec/mod.v
+++ b/CoqOfRust/core/num/flt2dec/mod.v
@@ -89,14 +89,14 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
                     let i := M.copy (| γ0_0 |) in
                     let _ :=
-                      let β := M.get_array_field (| M.read (| d |), i |) in
+                      let β := M.SubPointer.get_array_field (| M.read (| d |), i |) in
                       M.write (|
                         β,
                         BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.U8 1 |)
@@ -166,7 +166,7 @@ Module num.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -174,7 +174,10 @@ Module num.
                                               let j := M.copy (| γ0_0 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_array_field (| M.read (| d |), j |),
+                                                  M.SubPointer.get_array_field (|
+                                                    M.read (| d |),
+                                                    j
+                                                  |),
                                                   M.read (| UnsupportedLiteral |)
                                                 |) in
                                               M.alloc (| Value.Tuple [] |)))
@@ -203,7 +206,7 @@ Module num.
                     let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                     let _ :=
                       M.write (|
-                        M.get_array_field (|
+                        M.SubPointer.get_array_field (|
                           M.read (| d |),
                           M.alloc (| Value.Integer Integer.Usize 0 |)
                         |),
@@ -270,7 +273,7 @@ Module num.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -278,7 +281,10 @@ Module num.
                                               let j := M.copy (| γ0_0 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_array_field (| M.read (| d |), j |),
+                                                  M.SubPointer.get_array_field (|
+                                                    M.read (| d |),
+                                                    j
+                                                  |),
                                                   M.read (| UnsupportedLiteral |)
                                                 |) in
                                               M.alloc (| Value.Tuple [] |)))
@@ -429,7 +435,7 @@ Module num.
                             UnOp.Pure.not
                               (BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     M.read (| buf |),
                                     M.alloc (| Value.Integer Integer.Usize 0 |)
                                   |)
@@ -504,7 +510,7 @@ Module num.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_array_field (|
+                        M.SubPointer.get_array_field (|
                           M.read (| parts |),
                           M.alloc (| Value.Integer Integer.Usize 0 |)
                         |),
@@ -525,7 +531,7 @@ Module num.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_array_field (|
+                        M.SubPointer.get_array_field (|
                           M.read (| parts |),
                           M.alloc (| Value.Integer Integer.Usize 1 |)
                         |),
@@ -546,7 +552,7 @@ Module num.
                       |) in
                     let _ :=
                       M.write (|
-                        M.get_array_field (|
+                        M.SubPointer.get_array_field (|
                           M.read (| parts |),
                           M.alloc (| Value.Integer Integer.Usize 2 |)
                         |),
@@ -600,7 +606,7 @@ Module num.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 3 |)
                                 |),
@@ -740,7 +746,7 @@ Module num.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -781,7 +787,7 @@ Module num.
                               |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 1 |)
                                 |),
@@ -805,7 +811,7 @@ Module num.
                               |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 2 |)
                                 |),
@@ -873,7 +879,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 3 |)
                                         |),
@@ -991,7 +997,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -1012,7 +1018,7 @@ Module num.
                               |) in
                             let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 1 |)
                                 |),
@@ -1062,7 +1068,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 2 |)
                                         |),
@@ -1086,7 +1092,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 3 |)
                                         |),
@@ -1287,7 +1293,7 @@ Module num.
                             UnOp.Pure.not
                               (BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     M.read (| buf |),
                                     M.alloc (| Value.Integer Integer.Usize 0 |)
                                   |)
@@ -1348,7 +1354,7 @@ Module num.
             let n := M.alloc (| Value.Integer Integer.Usize 0 |) in
             let _ :=
               M.write (|
-                M.get_array_field (| M.read (| parts |), n |),
+                M.SubPointer.get_array_field (| M.read (| parts |), n |),
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply
@@ -1415,7 +1421,7 @@ Module num.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (| M.read (| parts |), n |),
+                          M.SubPointer.get_array_field (| M.read (| parts |), n |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
@@ -1434,7 +1440,7 @@ Module num.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (| parts |),
                             M.alloc (|
                               BinOp.Panic.add (| M.read (| n |), Value.Integer Integer.Usize 1 |)
@@ -1507,7 +1513,7 @@ Module num.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_array_field (| M.read (| parts |), n |),
+                                  M.SubPointer.get_array_field (| M.read (| parts |), n |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
@@ -1569,7 +1575,7 @@ Module num.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (| M.read (| parts |), n |),
+                          M.SubPointer.get_array_field (| M.read (| parts |), n |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
@@ -1613,7 +1619,7 @@ Module num.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (| parts |),
                             M.alloc (|
                               BinOp.Panic.add (| M.read (| n |), Value.Integer Integer.Usize 1 |)
@@ -1639,7 +1645,7 @@ Module num.
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_array_field (| M.read (| parts |), n |),
+                          M.SubPointer.get_array_field (| M.read (| parts |), n |),
                           M.call_closure (|
                             M.get_associated_function (|
                               Ty.apply
@@ -1683,7 +1689,7 @@ Module num.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (| parts |),
                             M.alloc (|
                               BinOp.Panic.add (| M.read (| n |), Value.Integer Integer.Usize 1 |)
@@ -1964,13 +1970,13 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     Value.String ""));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),
                       [
@@ -1985,8 +1991,8 @@ Module num.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),
                       [
@@ -2165,8 +2171,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let negative := M.copy (| γ0_0 |) in
                     let full_decoded := M.copy (| γ0_1 |) in
                     let sign :=
@@ -2183,7 +2189,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -2253,7 +2259,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -2340,7 +2346,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -2364,7 +2370,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 1 |)
                                         |),
@@ -2432,7 +2438,7 @@ Module num.
                                   ltac:(M.monadic
                                     (let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -2504,7 +2510,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::num::flt2dec::decoder::FullDecoded::Finite",
                                 0
@@ -2547,8 +2553,8 @@ Module num.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let buf := M.copy (| γ0_0 |) in
                                     let exp := M.copy (| γ0_1 |) in
                                     M.alloc (|
@@ -2741,8 +2747,8 @@ Module num.
                           (M.alloc (|
                             UnOp.Pure.not
                               (BinOp.Pure.le
-                                (M.read (| M.get_tuple_field dec_bounds 0 |))
-                                (M.read (| M.get_tuple_field dec_bounds 1 |)))
+                                (M.read (| M.SubPointer.get_tuple_field (| dec_bounds, 0 |) |))
+                                (M.read (| M.SubPointer.get_tuple_field (| dec_bounds, 1 |) |)))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
@@ -2770,8 +2776,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let negative := M.copy (| γ0_0 |) in
                     let full_decoded := M.copy (| γ0_1 |) in
                     let sign :=
@@ -2788,7 +2794,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -2858,7 +2864,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -2928,7 +2934,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -2943,13 +2949,21 @@ Module num.
                                               (M.alloc (|
                                                 LogicalOp.and (|
                                                   BinOp.Pure.le
-                                                    (M.read (| M.get_tuple_field dec_bounds 0 |))
+                                                    (M.read (|
+                                                      M.SubPointer.get_tuple_field (|
+                                                        dec_bounds,
+                                                        0
+                                                      |)
+                                                    |))
                                                     (Value.Integer Integer.I16 0),
                                                   ltac:(M.monadic
                                                     (BinOp.Pure.lt
                                                       (Value.Integer Integer.I16 0)
                                                       (M.read (|
-                                                        M.get_tuple_field dec_bounds 1
+                                                        M.SubPointer.get_tuple_field (|
+                                                          dec_bounds,
+                                                          1
+                                                        |)
                                                       |))))
                                                 |)
                                               |)) in
@@ -3075,7 +3089,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::num::flt2dec::decoder::FullDecoded::Finite",
                                 0
@@ -3118,8 +3132,8 @@ Module num.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let buf := M.copy (| γ0_0 |) in
                                     let exp := M.copy (| γ0_1 |) in
                                     let vis_exp :=
@@ -3143,7 +3157,10 @@ Module num.
                                                         BinOp.Pure.le
                                                           (M.rust_cast
                                                             (M.read (|
-                                                              M.get_tuple_field dec_bounds 0
+                                                              M.SubPointer.get_tuple_field (|
+                                                                dec_bounds,
+                                                                0
+                                                              |)
                                                             |)))
                                                           (M.read (| vis_exp |)),
                                                         ltac:(M.monadic
@@ -3151,7 +3168,10 @@ Module num.
                                                             (M.read (| vis_exp |))
                                                             (M.rust_cast
                                                               (M.read (|
-                                                                M.get_tuple_field dec_bounds 1
+                                                                M.SubPointer.get_tuple_field (|
+                                                                  dec_bounds,
+                                                                  1
+                                                                |)
                                                               |)))))
                                                       |)
                                                     |)) in
@@ -3397,8 +3417,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let negative := M.copy (| γ0_0 |) in
                     let full_decoded := M.copy (| γ0_1 |) in
                     let sign :=
@@ -3415,7 +3435,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -3485,7 +3505,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -3572,7 +3592,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -3596,7 +3616,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 1 |)
                                         |),
@@ -3622,7 +3642,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 2 |)
                                         |),
@@ -3718,7 +3738,7 @@ Module num.
                                   ltac:(M.monadic
                                     (let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -3815,7 +3835,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::num::flt2dec::decoder::FullDecoded::Finite",
                                 0
@@ -3830,10 +3850,11 @@ Module num.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| decoded |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| decoded |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "exp"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -3998,8 +4019,8 @@ Module num.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let buf := M.copy (| γ0_0 |) in
                                     let exp := M.copy (| γ0_1 |) in
                                     M.alloc (|
@@ -4178,8 +4199,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let negative := M.copy (| γ0_0 |) in
                     let full_decoded := M.copy (| γ0_1 |) in
                     let sign :=
@@ -4196,7 +4217,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -4266,7 +4287,7 @@ Module num.
                           ltac:(M.monadic
                             (let _ :=
                               M.write (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| parts |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |),
@@ -4353,7 +4374,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -4377,7 +4398,7 @@ Module num.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 1 |)
                                         |),
@@ -4445,7 +4466,7 @@ Module num.
                                   ltac:(M.monadic
                                     (let _ :=
                                       M.write (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| parts |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
                                         |),
@@ -4517,7 +4538,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::num::flt2dec::decoder::FullDecoded::Finite",
                                 0
@@ -4532,10 +4553,11 @@ Module num.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| decoded |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| decoded |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "exp"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -4684,8 +4706,8 @@ Module num.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let buf := M.copy (| γ0_0 |) in
                                     let exp := M.copy (| γ0_1 |) in
                                     M.match_operator (|
@@ -4744,8 +4766,15 @@ Module num.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_tuple_field γ 0 in
-                                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    0
+                                                                  |) in
+                                                                let γ0_1 :=
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    γ,
+                                                                    1
+                                                                  |) in
                                                                 let left_val := M.copy (| γ0_0 |) in
                                                                 let right_val :=
                                                                   M.copy (| γ0_1 |) in
@@ -4847,7 +4876,7 @@ Module num.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_array_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (| parts |),
                                                           M.alloc (|
                                                             Value.Integer Integer.Usize 0
@@ -4875,7 +4904,7 @@ Module num.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_array_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (| parts |),
                                                           M.alloc (|
                                                             Value.Integer Integer.Usize 1
@@ -4957,7 +4986,7 @@ Module num.
                                                   ltac:(M.monadic
                                                     (let _ :=
                                                       M.write (|
-                                                        M.get_array_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (| parts |),
                                                           M.alloc (|
                                                             Value.Integer Integer.Usize 0

--- a/CoqOfRust/core/num/flt2dec/strategy/dragon.v
+++ b/CoqOfRust/core/num/flt2dec/strategy/dragon.v
@@ -258,7 +258,7 @@ Module num.
                                 [
                                   M.read (| x |);
                                   M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       M.read (|
                                         M.get_constant (|
                                           "core::num::flt2dec::strategy::dragon::POW10"
@@ -306,7 +306,7 @@ Module num.
                                 [
                                   M.read (| x |);
                                   M.read (|
-                                    M.get_array_field (|
+                                    M.SubPointer.get_array_field (|
                                       M.read (|
                                         M.get_constant (|
                                           "core::num::flt2dec::strategy::dragon::POW10"
@@ -599,7 +599,7 @@ Module num.
                                     [
                                       M.read (| x |);
                                       M.read (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (|
                                             M.get_constant (|
                                               "core::num::flt2dec::strategy::dragon::POW10"
@@ -645,7 +645,7 @@ Module num.
                       [
                         M.read (| x |);
                         M.read (|
-                          M.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (|
                               M.get_constant (| "core::num::flt2dec::strategy::dragon::TWOPOW10" |)
                             |),
@@ -1110,10 +1110,11 @@ Module num.
                                 UnOp.Pure.not
                                   (BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "mant"
+                                      |)
                                     |))
                                     (Value.Integer Integer.U64 0))
                               |)) in
@@ -1142,10 +1143,11 @@ Module num.
                                 UnOp.Pure.not
                                   (BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "minus"
+                                      |)
                                     |))
                                     (Value.Integer Integer.U64 0))
                               |)) in
@@ -1174,10 +1176,11 @@ Module num.
                                 UnOp.Pure.not
                                   (BinOp.Pure.gt
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "plus"
+                                      |)
                                     |))
                                     (Value.Integer Integer.U64 0))
                               |)) in
@@ -1220,16 +1223,18 @@ Module num.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "mant"
+                                              |)
                                             |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "plus"
+                                              |)
                                             |)
                                           ]
                                         |)
@@ -1281,16 +1286,18 @@ Module num.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "mant"
+                                              |)
                                             |);
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "minus"
+                                              |)
                                             |)
                                           ]
                                         |)
@@ -1371,10 +1378,11 @@ Module num.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| d |))
-                                  "core::num::flt2dec::decoder::Decoded"
-                                  "inclusive") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| d |),
+                                  "core::num::flt2dec::decoder::Decoded",
+                                  "inclusive"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (| Value.StructTuple "core::cmp::Ordering::Greater" [] |)));
@@ -1394,23 +1402,26 @@ Module num.
                       [
                         BinOp.Panic.add (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| d |))
-                              "core::num::flt2dec::decoder::Decoded"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| d |),
+                              "core::num::flt2dec::decoder::Decoded",
                               "mant"
+                            |)
                           |),
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| d |))
-                              "core::num::flt2dec::decoder::Decoded"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| d |),
+                              "core::num::flt2dec::decoder::Decoded",
                               "plus"
+                            |)
                           |)
                         |);
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| d |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| d |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "exp"
+                          |)
                         |)
                       ]
                     |)
@@ -1425,10 +1436,11 @@ Module num.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| d |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| d |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "mant"
+                          |)
                         |)
                       ]
                     |)
@@ -1443,10 +1455,11 @@ Module num.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| d |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| d |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "minus"
+                          |)
                         |)
                       ]
                     |)
@@ -1461,10 +1474,11 @@ Module num.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| d |))
-                            "core::num::flt2dec::decoder::Decoded"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| d |),
+                            "core::num::flt2dec::decoder::Decoded",
                             "plus"
+                          |)
                         |)
                       ]
                     |)
@@ -1491,10 +1505,11 @@ Module num.
                               (M.alloc (|
                                 BinOp.Pure.lt
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| d |))
-                                      "core::num::flt2dec::decoder::Decoded"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| d |),
+                                      "core::num::flt2dec::decoder::Decoded",
                                       "exp"
+                                    |)
                                   |))
                                   (Value.Integer Integer.I16 0)
                               |)) in
@@ -1513,10 +1528,11 @@ Module num.
                                   M.rust_cast
                                     (UnOp.Panic.neg (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |)
                                     |))
                                 ]
@@ -1537,10 +1553,11 @@ Module num.
                                   mant;
                                   M.rust_cast
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "exp"
+                                      |)
                                     |))
                                 ]
                               |)
@@ -1557,10 +1574,11 @@ Module num.
                                   minus;
                                   M.rust_cast
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "exp"
+                                      |)
                                     |))
                                 ]
                               |)
@@ -1577,10 +1595,11 @@ Module num.
                                   plus;
                                   M.rust_cast
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| d |))
-                                        "core::num::flt2dec::decoder::Decoded"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| d |),
+                                        "core::num::flt2dec::decoder::Decoded",
                                         "exp"
+                                      |)
                                     |))
                                 ]
                               |)
@@ -1843,8 +1862,8 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let d := M.copy (| γ0_0 |) in
                               let _ :=
                                 M.match_operator (|
@@ -1902,7 +1921,7 @@ Module num.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_array_field (| M.read (| buf |), i |),
+                                  M.SubPointer.get_array_field (| M.read (| buf |), i |),
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply
@@ -2161,7 +2180,7 @@ Module num.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -2169,7 +2188,7 @@ Module num.
                                   let c := M.copy (| γ0_0 |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_array_field (| M.read (| buf |), i |),
+                                      M.SubPointer.get_array_field (| M.read (| buf |), i |),
                                       M.call_closure (|
                                         M.get_associated_function (|
                                           Ty.apply
@@ -2401,10 +2420,11 @@ Module num.
                                     UnOp.Pure.not
                                       (BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "mant"
+                                          |)
                                         |))
                                         (Value.Integer Integer.U64 0))
                                   |)) in
@@ -2436,10 +2456,11 @@ Module num.
                                     UnOp.Pure.not
                                       (BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "minus"
+                                          |)
                                         |))
                                         (Value.Integer Integer.U64 0))
                                   |)) in
@@ -2471,10 +2492,11 @@ Module num.
                                     UnOp.Pure.not
                                       (BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "plus"
+                                          |)
                                         |))
                                         (Value.Integer Integer.U64 0))
                                   |)) in
@@ -2522,16 +2544,18 @@ Module num.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| d |))
-                                                    "core::num::flt2dec::decoder::Decoded"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| d |),
+                                                    "core::num::flt2dec::decoder::Decoded",
                                                     "mant"
+                                                  |)
                                                 |);
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| d |))
-                                                    "core::num::flt2dec::decoder::Decoded"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| d |),
+                                                    "core::num::flt2dec::decoder::Decoded",
                                                     "plus"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -2588,16 +2612,18 @@ Module num.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| d |))
-                                                    "core::num::flt2dec::decoder::Decoded"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| d |),
+                                                    "core::num::flt2dec::decoder::Decoded",
                                                     "mant"
+                                                  |)
                                                 |);
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| d |))
-                                                    "core::num::flt2dec::decoder::Decoded"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| d |),
+                                                    "core::num::flt2dec::decoder::Decoded",
                                                     "minus"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -2635,16 +2661,18 @@ Module num.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| d |))
-                                "core::num::flt2dec::decoder::Decoded"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| d |),
+                                "core::num::flt2dec::decoder::Decoded",
                                 "mant"
+                              |)
                             |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| d |))
-                                "core::num::flt2dec::decoder::Decoded"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| d |),
+                                "core::num::flt2dec::decoder::Decoded",
                                 "exp"
+                              |)
                             |)
                           ]
                         |)
@@ -2659,10 +2687,11 @@ Module num.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| d |))
-                                "core::num::flt2dec::decoder::Decoded"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| d |),
+                                "core::num::flt2dec::decoder::Decoded",
                                 "mant"
+                              |)
                             |)
                           ]
                         |)
@@ -2689,10 +2718,11 @@ Module num.
                                   (M.alloc (|
                                     BinOp.Pure.lt
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |))
                                       (Value.Integer Integer.I16 0)
                                   |)) in
@@ -2714,10 +2744,11 @@ Module num.
                                       M.rust_cast
                                         (UnOp.Panic.neg (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "exp"
+                                            |)
                                           |)
                                         |))
                                     ]
@@ -2738,10 +2769,11 @@ Module num.
                                       mant;
                                       M.rust_cast
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "exp"
+                                          |)
                                         |))
                                     ]
                                   |)
@@ -3115,7 +3147,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -3273,7 +3305,7 @@ Module num.
                                                                                               ltac:(M.monadic
                                                                                                 (let
                                                                                                       γ0_0 :=
-                                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                                     γ,
                                                                                                     "core::option::Option::Some",
                                                                                                     0
@@ -3757,7 +3789,7 @@ Module num.
                                                         |) in
                                                       let _ :=
                                                         M.write (|
-                                                          M.get_array_field (|
+                                                          M.SubPointer.get_array_field (|
                                                             M.read (| buf |),
                                                             i
                                                           |),
@@ -3884,7 +3916,7 @@ Module num.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_array_field (|
+                                                      M.SubPointer.get_array_field (|
                                                         M.read (| buf |),
                                                         M.alloc (|
                                                           BinOp.Panic.sub (|
@@ -3957,7 +3989,7 @@ Module num.
                                           |)
                                         |) in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -4011,7 +4043,10 @@ Module num.
                                                 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_array_field (| M.read (| buf |), len |),
+                                                  M.SubPointer.get_array_field (|
+                                                    M.read (| buf |),
+                                                    len
+                                                  |),
                                                   M.call_closure (|
                                                     M.get_associated_function (|
                                                       Ty.apply

--- a/CoqOfRust/core/num/flt2dec/strategy/grisu.v
+++ b/CoqOfRust/core/num/flt2dec/strategy/grisu.v
@@ -593,7 +593,7 @@ Module num.
                     |)
                   |) in
                 M.match_operator (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.read (|
                       M.get_constant (| "core::num::flt2dec::strategy::grisu::CACHED_POW10" |)
                     |),
@@ -602,9 +602,9 @@ Module num.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
-                        let γ0_2 := M.get_tuple_field γ 2 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                        let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                         let f := M.copy (| γ0_0 |) in
                         let e := M.copy (| γ0_1 |) in
                         let k := M.copy (| γ0_2 |) in
@@ -1430,10 +1430,11 @@ Module num.
                                       UnOp.Pure.not
                                         (BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "mant"
+                                            |)
                                           |))
                                           (Value.Integer Integer.U64 0))
                                     |)) in
@@ -1465,10 +1466,11 @@ Module num.
                                       UnOp.Pure.not
                                         (BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "minus"
+                                            |)
                                           |))
                                           (Value.Integer Integer.U64 0))
                                     |)) in
@@ -1500,10 +1502,11 @@ Module num.
                                       UnOp.Pure.not
                                         (BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "plus"
+                                            |)
                                           |))
                                           (Value.Integer Integer.U64 0))
                                     |)) in
@@ -1551,16 +1554,18 @@ Module num.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| d |))
-                                                      "core::num::flt2dec::decoder::Decoded"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| d |),
+                                                      "core::num::flt2dec::decoder::Decoded",
                                                       "mant"
+                                                    |)
                                                   |);
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| d |))
-                                                      "core::num::flt2dec::decoder::Decoded"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| d |),
+                                                      "core::num::flt2dec::decoder::Decoded",
                                                       "plus"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -1617,16 +1622,18 @@ Module num.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| d |))
-                                                      "core::num::flt2dec::decoder::Decoded"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| d |),
+                                                      "core::num::flt2dec::decoder::Decoded",
                                                       "mant"
+                                                    |)
                                                   |);
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| d |))
-                                                      "core::num::flt2dec::decoder::Decoded"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| d |),
+                                                      "core::num::flt2dec::decoder::Decoded",
                                                       "minus"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -1720,16 +1727,18 @@ Module num.
                                         (BinOp.Pure.lt
                                           (BinOp.Panic.add (|
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "mant"
+                                              |)
                                             |),
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| d |))
-                                                "core::num::flt2dec::decoder::Decoded"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| d |),
+                                                "core::num::flt2dec::decoder::Decoded",
                                                 "plus"
+                                              |)
                                             |)
                                           |))
                                           (BinOp.Panic.shl (|
@@ -1774,24 +1783,27 @@ Module num.
                                     ("f",
                                       BinOp.Panic.add (|
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "mant"
+                                          |)
                                         |),
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "plus"
+                                          |)
                                         |)
                                       |));
                                     ("e",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |))
                                   ]
                               |)
@@ -1814,29 +1826,36 @@ Module num.
                                     ("f",
                                       BinOp.Panic.sub (|
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "mant"
+                                          |)
                                         |),
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| d |))
-                                            "core::num::flt2dec::decoder::Decoded"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| d |),
+                                            "core::num::flt2dec::decoder::Decoded",
                                             "minus"
+                                          |)
                                         |)
                                       |));
                                     ("e",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |))
                                   ]
                               |);
                               M.read (|
-                                M.get_struct_record_field plus "core::num::diy_float::Fp" "e"
+                                M.SubPointer.get_struct_record_field (|
+                                  plus,
+                                  "core::num::diy_float::Fp",
+                                  "e"
+                                |)
                               |)
                             ]
                           |)
@@ -1856,22 +1875,28 @@ Module num.
                                   [
                                     ("f",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "mant"
+                                        |)
                                       |));
                                     ("e",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |))
                                   ]
                               |);
                               M.read (|
-                                M.get_struct_record_field plus "core::num::diy_float::Fp" "e"
+                                M.SubPointer.get_struct_record_field (|
+                                  plus,
+                                  "core::num::diy_float::Fp",
+                                  "e"
+                                |)
                               |)
                             ]
                           |)
@@ -1892,7 +1917,11 @@ Module num.
                                     |)
                                   |),
                                   M.read (|
-                                    M.get_struct_record_field plus "core::num::diy_float::Fp" "e"
+                                    M.SubPointer.get_struct_record_field (|
+                                      plus,
+                                      "core::num::diy_float::Fp",
+                                      "e"
+                                    |)
                                   |)
                                 |),
                                 Value.Integer Integer.I16 64
@@ -1905,7 +1934,11 @@ Module num.
                                     |)
                                   |),
                                   M.read (|
-                                    M.get_struct_record_field plus "core::num::diy_float::Fp" "e"
+                                    M.SubPointer.get_struct_record_field (|
+                                      plus,
+                                      "core::num::diy_float::Fp",
+                                      "e"
+                                    |)
                                   |)
                                 |),
                                 Value.Integer Integer.I16 64
@@ -1916,8 +1949,8 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let minusk := M.copy (| γ0_0 |) in
                               let cached := M.copy (| γ0_1 |) in
                               let plus :=
@@ -1970,21 +2003,25 @@ Module num.
                                             M.alloc (|
                                               Value.Tuple
                                                 [
-                                                  M.get_struct_record_field
-                                                    plus
-                                                    "core::num::diy_float::Fp"
-                                                    "e";
-                                                  M.get_struct_record_field
-                                                    minus
-                                                    "core::num::diy_float::Fp"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    plus,
+                                                    "core::num::diy_float::Fp",
                                                     "e"
+                                                  |);
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    minus,
+                                                    "core::num::diy_float::Fp",
+                                                    "e"
+                                                  |)
                                                 ]
                                             |),
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let left_val := M.copy (| γ0_0 |) in
                                                   let right_val := M.copy (| γ0_1 |) in
                                                   M.match_operator (|
@@ -2066,21 +2103,25 @@ Module num.
                                             M.alloc (|
                                               Value.Tuple
                                                 [
-                                                  M.get_struct_record_field
-                                                    plus
-                                                    "core::num::diy_float::Fp"
-                                                    "e";
-                                                  M.get_struct_record_field
-                                                    v
-                                                    "core::num::diy_float::Fp"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    plus,
+                                                    "core::num::diy_float::Fp",
                                                     "e"
+                                                  |);
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    v,
+                                                    "core::num::diy_float::Fp",
+                                                    "e"
+                                                  |)
                                                 ]
                                             |),
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let left_val := M.copy (| γ0_0 |) in
                                                   let right_val := M.copy (| γ0_1 |) in
                                                   M.match_operator (|
@@ -2149,7 +2190,11 @@ Module num.
                                 M.alloc (|
                                   BinOp.Panic.add (|
                                     M.read (|
-                                      M.get_struct_record_field plus "core::num::diy_float::Fp" "f"
+                                      M.SubPointer.get_struct_record_field (|
+                                        plus,
+                                        "core::num::diy_float::Fp",
+                                        "f"
+                                      |)
                                     |),
                                     Value.Integer Integer.U64 1
                                   |)
@@ -2158,7 +2203,11 @@ Module num.
                                 M.alloc (|
                                   BinOp.Panic.sub (|
                                     M.read (|
-                                      M.get_struct_record_field minus "core::num::diy_float::Fp" "f"
+                                      M.SubPointer.get_struct_record_field (|
+                                        minus,
+                                        "core::num::diy_float::Fp",
+                                        "f"
+                                      |)
                                     |),
                                     Value.Integer Integer.U64 1
                                   |)
@@ -2168,10 +2217,11 @@ Module num.
                                   M.rust_cast
                                     (UnOp.Panic.neg (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          plus
-                                          "core::num::diy_float::Fp"
+                                        M.SubPointer.get_struct_record_field (|
+                                          plus,
+                                          "core::num::diy_float::Fp",
                                           "e"
+                                        |)
                                       |)
                                     |))
                                 |) in
@@ -2205,8 +2255,8 @@ Module num.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let max_kappa := M.copy (| γ0_0 |) in
                                       let max_ten_kappa := M.copy (| γ0_1 |) in
                                       let i := M.alloc (| Value.Integer Integer.Usize 0 |) in
@@ -2320,7 +2370,10 @@ Module num.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_array_field (| M.read (| buf |), i |),
+                                                M.SubPointer.get_array_field (|
+                                                  M.read (| buf |),
+                                                  i
+                                                |),
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
@@ -2441,10 +2494,11 @@ Module num.
                                                                   BinOp.Panic.sub (|
                                                                     M.read (| plus1 |),
                                                                     M.read (|
-                                                                      M.get_struct_record_field
-                                                                        v
-                                                                        "core::num::diy_float::Fp"
+                                                                      M.SubPointer.get_struct_record_field (|
+                                                                        v,
+                                                                        "core::num::diy_float::Fp",
                                                                         "f"
+                                                                      |)
                                                                     |)
                                                                   |);
                                                                   M.read (| ten_kappa |);
@@ -2513,13 +2567,15 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    0 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    0
+                                                                                  |) in
                                                                                 let γ0_1 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    1 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    1
+                                                                                  |) in
                                                                                 let left_val :=
                                                                                   M.copy (|
                                                                                     γ0_0
@@ -2760,7 +2816,10 @@ Module num.
                                                     |) in
                                                   let _ :=
                                                     M.write (|
-                                                      M.get_array_field (| M.read (| buf |), i |),
+                                                      M.SubPointer.get_array_field (|
+                                                        M.read (| buf |),
+                                                        i
+                                                      |),
                                                       M.call_closure (|
                                                         M.get_associated_function (|
                                                           Ty.apply
@@ -2877,10 +2936,11 @@ Module num.
                                                                           BinOp.Panic.sub (|
                                                                             M.read (| plus1 |),
                                                                             M.read (|
-                                                                              M.get_struct_record_field
-                                                                                v
-                                                                                "core::num::diy_float::Fp"
+                                                                              M.SubPointer.get_struct_record_field (|
+                                                                                v,
+                                                                                "core::num::diy_float::Fp",
                                                                                 "f"
+                                                                              |)
                                                                             |)
                                                                           |),
                                                                           M.read (| ulp |)
@@ -3380,7 +3440,7 @@ Module num.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -3717,10 +3777,11 @@ Module num.
                                       UnOp.Pure.not
                                         (BinOp.Pure.gt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "mant"
+                                            |)
                                           |))
                                           (Value.Integer Integer.U64 0))
                                     |)) in
@@ -3752,10 +3813,11 @@ Module num.
                                       UnOp.Pure.not
                                         (BinOp.Pure.lt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| d |))
-                                              "core::num::flt2dec::decoder::Decoded"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| d |),
+                                              "core::num::flt2dec::decoder::Decoded",
                                               "mant"
+                                            |)
                                           |))
                                           (BinOp.Panic.shl (|
                                             Value.Integer Integer.U64 1,
@@ -3843,17 +3905,19 @@ Module num.
                                   [
                                     ("f",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "mant"
+                                        |)
                                       |));
                                     ("e",
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| d |))
-                                          "core::num::flt2dec::decoder::Decoded"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| d |),
+                                          "core::num::flt2dec::decoder::Decoded",
                                           "exp"
+                                        |)
                                       |))
                                   ]
                               |)
@@ -3876,7 +3940,11 @@ Module num.
                                     |)
                                   |),
                                   M.read (|
-                                    M.get_struct_record_field v "core::num::diy_float::Fp" "e"
+                                    M.SubPointer.get_struct_record_field (|
+                                      v,
+                                      "core::num::diy_float::Fp",
+                                      "e"
+                                    |)
                                   |)
                                 |),
                                 Value.Integer Integer.I16 64
@@ -3889,7 +3957,11 @@ Module num.
                                     |)
                                   |),
                                   M.read (|
-                                    M.get_struct_record_field v "core::num::diy_float::Fp" "e"
+                                    M.SubPointer.get_struct_record_field (|
+                                      v,
+                                      "core::num::diy_float::Fp",
+                                      "e"
+                                    |)
                                   |)
                                 |),
                                 Value.Integer Integer.I16 64
@@ -3900,8 +3972,8 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let minusk := M.copy (| γ0_0 |) in
                               let cached := M.copy (| γ0_1 |) in
                               let v :=
@@ -3920,7 +3992,11 @@ Module num.
                                   M.rust_cast
                                     (UnOp.Panic.neg (|
                                       M.read (|
-                                        M.get_struct_record_field v "core::num::diy_float::Fp" "e"
+                                        M.SubPointer.get_struct_record_field (|
+                                          v,
+                                          "core::num::diy_float::Fp",
+                                          "e"
+                                        |)
                                       |)
                                     |))
                                 |) in
@@ -3929,7 +4005,11 @@ Module num.
                                   M.rust_cast
                                     (BinOp.Panic.shr (|
                                       M.read (|
-                                        M.get_struct_record_field v "core::num::diy_float::Fp" "f"
+                                        M.SubPointer.get_struct_record_field (|
+                                          v,
+                                          "core::num::diy_float::Fp",
+                                          "f"
+                                        |)
                                       |),
                                       M.read (| e |)
                                     |))
@@ -3938,7 +4018,11 @@ Module num.
                                 M.alloc (|
                                   BinOp.Pure.bit_and
                                     (M.read (|
-                                      M.get_struct_record_field v "core::num::diy_float::Fp" "f"
+                                      M.SubPointer.get_struct_record_field (|
+                                        v,
+                                        "core::num::diy_float::Fp",
+                                        "f"
+                                      |)
                                     |))
                                     (BinOp.Panic.sub (|
                                       BinOp.Panic.shl (|
@@ -3987,7 +4071,7 @@ Module num.
                                                       (BinOp.Pure.lt
                                                         (M.read (| vint |))
                                                         (M.read (|
-                                                          M.get_array_field (|
+                                                          M.SubPointer.get_array_field (|
                                                             M.get_constant (|
                                                               "core::num::flt2dec::strategy::grisu::format_exact_opt::POW10_UP_TO_9"
                                                             |),
@@ -4033,8 +4117,8 @@ Module num.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let max_kappa := M.copy (| γ0_0 |) in
                                       let max_ten_kappa := M.copy (| γ0_1 |) in
                                       let i := M.alloc (| Value.Integer Integer.Usize 0 |) in
@@ -4083,10 +4167,11 @@ Module num.
                                                               M.read (| limit |);
                                                               BinOp.Panic.div (|
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    v
-                                                                    "core::num::diy_float::Fp"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    v,
+                                                                    "core::num::diy_float::Fp",
                                                                     "f"
+                                                                  |)
                                                                 |),
                                                                 Value.Integer Integer.U64 10
                                                               |);
@@ -4314,7 +4399,10 @@ Module num.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_array_field (| M.read (| buf |), i |),
+                                                M.SubPointer.get_array_field (|
+                                                  M.read (| buf |),
+                                                  i
+                                                |),
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply
@@ -4457,13 +4545,15 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    0 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    0
+                                                                                  |) in
                                                                                 let γ0_1 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    1 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    1
+                                                                                  |) in
                                                                                 let left_val :=
                                                                                   M.copy (|
                                                                                     γ0_0
@@ -4596,13 +4686,15 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    0 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    0
+                                                                                  |) in
                                                                                 let γ0_1 :=
-                                                                                  M.get_tuple_field
-                                                                                    γ
-                                                                                    1 in
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    γ,
+                                                                                    1
+                                                                                  |) in
                                                                                 let left_val :=
                                                                                   M.copy (|
                                                                                     γ0_0
@@ -4865,7 +4957,10 @@ Module num.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_array_field (| M.read (| buf |), i |),
+                                                        M.SubPointer.get_array_field (|
+                                                          M.read (| buf |),
+                                                          i
+                                                        |),
                                                         M.call_closure (|
                                                           M.get_associated_function (|
                                                             Ty.apply
@@ -5419,7 +5514,7 @@ Module num.
                                                     |)
                                                   |) in
                                                 let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -5473,7 +5568,7 @@ Module num.
                                                           |) in
                                                         let _ :=
                                                           M.write (|
-                                                            M.get_array_field (|
+                                                            M.SubPointer.get_array_field (|
                                                               M.read (| buf |),
                                                               len
                                                             |),
@@ -5610,7 +5705,7 @@ Module num.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0

--- a/CoqOfRust/core/num/fmt.v
+++ b/CoqOfRust/core/num/fmt.v
@@ -133,11 +133,11 @@ Module num.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::num::fmt::Part::Zero",
                                   0
@@ -145,7 +145,7 @@ Module num.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::num::fmt::Part::Zero",
                                   0
@@ -158,11 +158,11 @@ Module num.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::num::fmt::Part::Num",
                                   0
@@ -170,7 +170,7 @@ Module num.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::num::fmt::Part::Num",
                                   0
@@ -183,11 +183,11 @@ Module num.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::num::fmt::Part::Copy",
                                   0
@@ -195,7 +195,7 @@ Module num.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::num::fmt::Part::Copy",
                                   0
@@ -316,7 +316,7 @@ Module num.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Zero",
                           0
@@ -340,7 +340,7 @@ Module num.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Num",
                           0
@@ -364,7 +364,7 @@ Module num.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Copy",
                           0
@@ -434,7 +434,7 @@ Module num.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Zero",
                           0
@@ -444,7 +444,7 @@ Module num.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Num",
                           0
@@ -539,7 +539,7 @@ Module num.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::num::fmt::Part::Copy",
                           0
@@ -630,7 +630,7 @@ Module num.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::num::fmt::Part::Zero",
                                     0
@@ -705,7 +705,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -726,7 +726,7 @@ Module num.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::num::fmt::Part::Num",
                                     0
@@ -831,7 +831,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -868,7 +868,7 @@ Module num.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::num::fmt::Part::Copy",
                                     0
@@ -970,10 +970,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::fmt::Formatted"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::fmt::Formatted",
                         "sign"
+                      |)
                     ]
                   |));
                 ("parts",
@@ -988,10 +989,11 @@ Module num.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::num::fmt::Formatted"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::num::fmt::Formatted",
                         "parts"
+                      |)
                     ]
                   |))
               ]))
@@ -1030,10 +1032,11 @@ Module num.
                     M.get_associated_function (| Ty.path "str", "len", [] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::num::fmt::Formatted"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::num::fmt::Formatted",
                           "sign"
+                        |)
                       |)
                     ]
                   |)
@@ -1054,10 +1057,11 @@ Module num.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::fmt::Formatted"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::fmt::Formatted",
                               "parts"
+                            |)
                           |)
                         ]
                       |)
@@ -1093,7 +1097,7 @@ Module num.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -1175,10 +1179,11 @@ Module num.
                                       M.get_associated_function (| Ty.path "str", "len", [] |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::fmt::Formatted"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::fmt::Formatted",
                                             "sign"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -1223,10 +1228,11 @@ Module num.
                                       M.get_associated_function (| Ty.path "str", "len", [] |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::num::fmt::Formatted"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::num::fmt::Formatted",
                                             "sign"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -1237,10 +1243,11 @@ Module num.
                             M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::fmt::Formatted"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::fmt::Formatted",
                                   "sign"
+                                |)
                               |)
                             ]
                           |)
@@ -1253,10 +1260,11 @@ Module num.
                         M.get_associated_function (| Ty.path "str", "len", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::num::fmt::Formatted"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::num::fmt::Formatted",
                               "sign"
+                            |)
                           |)
                         ]
                       |)
@@ -1277,10 +1285,11 @@ Module num.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::num::fmt::Formatted"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::num::fmt::Formatted",
                                   "parts"
+                                |)
                               |)
                             ]
                           |)
@@ -1316,7 +1325,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -1377,7 +1386,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Break",
                                                             0
@@ -1415,7 +1424,7 @@ Module num.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                             0

--- a/CoqOfRust/core/num/mod.v
+++ b/CoqOfRust/core/num/mod.v
@@ -373,8 +373,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -454,8 +454,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -513,8 +513,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -594,8 +594,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -653,8 +653,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1001,8 +1001,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1081,8 +1081,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1199,8 +1199,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1459,7 +1459,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -1512,7 +1512,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -1664,7 +1664,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1730,7 +1730,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1842,7 +1842,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1903,16 +1903,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -1953,7 +1953,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2099,14 +2099,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -2125,14 +2126,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -2152,14 +2154,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -2178,14 +2181,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -2520,8 +2524,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -2561,8 +2565,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -2575,8 +2579,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -2618,8 +2622,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -2663,8 +2667,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -2704,8 +2708,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -2718,8 +2722,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -2762,8 +2766,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -2807,8 +2811,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -3299,14 +3303,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -3330,14 +3337,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -3365,7 +3376,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -3547,7 +3558,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -4037,7 +4048,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -4250,7 +4261,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -4306,7 +4317,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -4362,7 +4373,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -5391,8 +5402,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -5472,8 +5483,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -5531,8 +5542,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -5612,8 +5623,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -5671,8 +5682,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -6019,8 +6030,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -6099,8 +6110,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -6217,8 +6228,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -6477,7 +6488,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -6530,7 +6541,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -6682,7 +6693,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6748,7 +6759,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6860,7 +6871,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6923,16 +6934,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -6973,7 +6984,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -7119,14 +7130,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -7145,14 +7157,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -7172,14 +7185,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -7198,14 +7212,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -7540,8 +7555,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -7581,8 +7596,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -7595,8 +7610,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -7638,8 +7653,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -7683,8 +7698,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -7724,8 +7739,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -7738,8 +7753,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -7782,8 +7797,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -7827,8 +7842,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -8319,14 +8334,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -8350,14 +8368,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -8385,7 +8407,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -8567,7 +8589,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9059,7 +9081,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -9274,7 +9296,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9330,7 +9352,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9386,7 +9408,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -10415,8 +10437,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -10496,8 +10518,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -10555,8 +10577,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -10636,8 +10658,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -10695,8 +10717,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -11043,8 +11065,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -11123,8 +11145,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -11241,8 +11263,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -11501,7 +11523,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -11554,7 +11576,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -11706,7 +11728,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -11772,7 +11794,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -11884,7 +11906,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -11947,16 +11969,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -11997,7 +12019,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -12143,14 +12165,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -12169,14 +12192,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -12196,14 +12220,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -12222,14 +12247,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -12564,8 +12590,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -12605,8 +12631,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -12619,8 +12645,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -12662,8 +12688,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -12707,8 +12733,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -12748,8 +12774,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -12762,8 +12788,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -12806,8 +12832,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -12851,8 +12877,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -13343,14 +13369,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -13374,14 +13403,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -13409,7 +13442,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -13591,7 +13624,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -14083,7 +14116,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -14298,7 +14331,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -14354,7 +14387,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -14410,7 +14443,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -15439,8 +15472,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -15520,8 +15553,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -15579,8 +15612,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -15660,8 +15693,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -15719,8 +15752,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -16067,8 +16100,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -16147,8 +16180,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -16265,8 +16298,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -16525,7 +16558,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -16578,7 +16611,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -16730,7 +16763,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -16796,7 +16829,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -16908,7 +16941,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -16971,16 +17004,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -17021,7 +17054,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -17167,14 +17200,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -17193,14 +17227,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -17220,14 +17255,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -17246,14 +17282,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -17588,8 +17625,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -17629,8 +17666,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -17643,8 +17680,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -17686,8 +17723,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -17731,8 +17768,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -17772,8 +17809,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -17786,8 +17823,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -17830,8 +17867,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -17875,8 +17912,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -18367,14 +18404,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -18398,14 +18438,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -18433,7 +18477,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -18615,7 +18659,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -19107,7 +19151,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -19322,7 +19366,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -19378,7 +19422,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -19434,7 +19478,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -20463,8 +20507,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -20544,8 +20588,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -20603,8 +20647,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -20684,8 +20728,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -20743,8 +20787,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -21091,8 +21135,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -21171,8 +21215,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -21289,8 +21333,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -21549,7 +21593,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -21602,7 +21646,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -21754,7 +21798,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -21820,7 +21864,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -21932,7 +21976,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -21997,16 +22041,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -22047,7 +22091,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -22193,14 +22237,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -22219,14 +22264,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -22246,14 +22292,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -22272,14 +22319,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -22614,8 +22662,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -22655,8 +22703,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -22669,8 +22717,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -22712,8 +22760,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -22757,8 +22805,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -22798,8 +22846,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -22812,8 +22860,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -22856,8 +22904,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -22901,8 +22949,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -23393,14 +23441,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -23424,14 +23475,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -23459,7 +23514,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -23641,7 +23696,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -24133,7 +24188,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -24348,7 +24403,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -24404,7 +24459,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -24460,7 +24515,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -25489,8 +25544,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -25570,8 +25625,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -25629,8 +25684,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -25710,8 +25765,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -25769,8 +25824,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -26117,8 +26172,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -26197,8 +26252,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -26315,8 +26370,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -26575,7 +26630,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -26628,7 +26683,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -26780,7 +26835,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -26846,7 +26901,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -26958,7 +27013,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -27023,16 +27078,16 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool false |) in
                     result));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let _result := M.copy (| γ0_0 |) in
                     let _ :=
                       M.is_constant_or_break_match (| M.read (| γ0_1 |), Value.Bool true |) in
@@ -27073,7 +27128,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -27219,14 +27274,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "overflowing_div", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -27245,14 +27301,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "overflowing_div_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -27272,14 +27329,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "overflowing_rem", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -27298,14 +27356,15 @@ Module num.
           (let self := M.alloc (| self |) in
           let rhs := M.alloc (| rhs |) in
           M.read (|
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "overflowing_rem_euclid", [] |),
                   [ M.read (| self |); M.read (| rhs |) ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -27640,8 +27699,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -27681,8 +27740,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -27695,8 +27754,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -27738,8 +27797,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -27783,8 +27842,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -27824,8 +27883,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -27838,8 +27897,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -27882,8 +27941,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -27927,8 +27986,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -28423,14 +28482,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -28454,14 +28516,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -28489,7 +28555,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -28671,7 +28737,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -29169,7 +29235,7 @@ Module num.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -29386,7 +29452,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -29442,7 +29508,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -29498,7 +29564,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -30544,8 +30610,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -30625,8 +30691,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -30684,8 +30750,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -30765,8 +30831,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -31114,7 +31180,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -31170,7 +31236,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -31226,7 +31292,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -31453,7 +31519,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -31516,7 +31582,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -31569,8 +31635,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -31627,8 +31693,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -31745,8 +31811,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -31959,7 +32025,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -32012,7 +32078,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -32116,8 +32182,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -32210,7 +32276,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -32275,7 +32341,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -32706,8 +32772,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -32747,8 +32813,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -32761,8 +32827,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -32808,8 +32874,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -32853,8 +32919,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -32894,8 +32960,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -32908,8 +32974,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -33038,8 +33104,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -33324,14 +33390,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -33355,14 +33424,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -33390,7 +33463,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -33924,7 +33997,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -35454,8 +35527,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -35535,8 +35608,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -35594,8 +35667,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -35675,8 +35748,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -36024,7 +36097,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -36080,7 +36153,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -36136,7 +36209,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -36363,7 +36436,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -36426,7 +36499,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -36479,8 +36552,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -36537,8 +36610,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -36655,8 +36728,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -36869,7 +36942,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -36922,7 +36995,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -37026,8 +37099,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -37121,7 +37194,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -37186,7 +37259,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -37617,8 +37690,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -37658,8 +37731,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -37672,8 +37745,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -37719,8 +37792,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -37764,8 +37837,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -37805,8 +37878,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -37819,8 +37892,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -37949,8 +38022,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -38235,14 +38308,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -38266,14 +38342,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -38301,7 +38381,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -38835,7 +38915,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -39745,8 +39825,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -39826,8 +39906,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -39885,8 +39965,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -39966,8 +40046,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -40315,7 +40395,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -40371,7 +40451,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -40427,7 +40507,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -40654,7 +40734,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -40717,7 +40797,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -40770,8 +40850,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -40828,8 +40908,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -40945,8 +41025,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -41158,7 +41238,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -41211,7 +41291,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -41315,8 +41395,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -41410,7 +41490,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -41475,7 +41555,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -41906,8 +41986,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -41947,8 +42027,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -41961,8 +42041,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -42008,8 +42088,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -42053,8 +42133,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -42094,8 +42174,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -42108,8 +42188,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -42238,8 +42318,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -42524,14 +42604,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -42555,14 +42638,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -42590,7 +42677,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -43124,7 +43211,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -43997,8 +44084,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -44078,8 +44165,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -44137,8 +44224,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -44218,8 +44305,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -44567,7 +44654,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -44623,7 +44710,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -44679,7 +44766,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -44906,7 +44993,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -44969,7 +45056,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -45022,8 +45109,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -45080,8 +45167,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -45198,8 +45285,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -45412,7 +45499,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -45465,7 +45552,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -45569,8 +45656,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -45664,7 +45751,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -45729,7 +45816,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -46160,8 +46247,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -46201,8 +46288,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -46215,8 +46302,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -46262,8 +46349,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -46307,8 +46394,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -46348,8 +46435,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -46362,8 +46449,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -46492,8 +46579,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -46778,14 +46865,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -46809,14 +46899,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -46844,7 +46938,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -47378,7 +47472,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -48251,8 +48345,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -48332,8 +48426,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -48391,8 +48485,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -48472,8 +48566,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -48821,7 +48915,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -48877,7 +48971,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -48933,7 +49027,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -49160,7 +49254,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -49223,7 +49317,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -49276,8 +49370,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -49334,8 +49428,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -49452,8 +49546,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -49666,7 +49760,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -49719,7 +49813,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -49823,8 +49917,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -49920,7 +50014,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -49985,7 +50079,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -50416,8 +50510,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -50457,8 +50551,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -50471,8 +50565,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -50518,8 +50612,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -50563,8 +50657,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -50604,8 +50698,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -50618,8 +50712,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -50748,8 +50842,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| M.use a |); M.read (| b |) ] |)))
@@ -51034,14 +51128,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -51065,14 +51162,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -51100,7 +51201,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -51634,7 +51735,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -52420,8 +52521,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -52501,8 +52602,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -52560,8 +52661,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -52641,8 +52742,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -52990,7 +53091,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -53046,7 +53147,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -53102,7 +53203,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -53333,7 +53434,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -53396,7 +53497,7 @@ Module num.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -53449,8 +53550,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -53507,8 +53608,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -53625,8 +53726,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -53839,7 +53940,7 @@ Module num.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -53892,7 +53993,7 @@ Module num.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -53996,8 +54097,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflow := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -54093,7 +54194,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -54158,7 +54259,7 @@ Module num.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -54589,8 +54690,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -54630,8 +54731,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -54644,8 +54745,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -54691,8 +54792,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let res := M.copy (| γ0_0 |) in
                     let overflowed := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -54736,8 +54837,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -54777,8 +54878,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -54791,8 +54892,8 @@ Module num.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let c := M.copy (| γ0_0 |) in
                             let d := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -54921,8 +55022,8 @@ Module num.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.rust_cast (M.read (| a |)); M.read (| b |) ] |)))
@@ -55207,14 +55308,17 @@ Module num.
                                             |)
                                           |) in
                                         let _ :=
-                                          M.write (| acc, M.read (| M.get_tuple_field r 0 |) |) in
+                                          M.write (|
+                                            acc,
+                                            M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                          |) in
                                         let _ :=
                                           let β := overflown in
                                           M.write (|
                                             β,
                                             BinOp.Pure.bit_or
                                               (M.read (| β |))
-                                              (M.read (| M.get_tuple_field r 1 |))
+                                              (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                           |) in
                                         M.alloc (| Value.Tuple [] |)));
                                     fun γ => ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
@@ -55238,14 +55342,18 @@ Module num.
                                     [ M.read (| base |); M.read (| base |) ]
                                   |)
                                 |) in
-                              let _ := M.write (| base, M.read (| M.get_tuple_field r 0 |) |) in
+                              let _ :=
+                                M.write (|
+                                  base,
+                                  M.read (| M.SubPointer.get_tuple_field (| r, 0 |) |)
+                                |) in
                               let _ :=
                                 let β := overflown in
                                 M.write (|
                                   β,
                                   BinOp.Pure.bit_or
                                     (M.read (| β |))
-                                    (M.read (| M.get_tuple_field r 1 |))
+                                    (M.read (| M.SubPointer.get_tuple_field (| r, 1 |) |))
                                 |) in
                               M.alloc (| Value.Tuple [] |)));
                           fun γ =>
@@ -55273,7 +55381,7 @@ Module num.
                     |)
                   |) in
                 let _ :=
-                  let β := M.get_tuple_field r 1 in
+                  let β := M.SubPointer.get_tuple_field (| r, 1 |) in
                   M.write (| β, BinOp.Pure.bit_or (M.read (| β |)) (M.read (| overflown |)) |) in
                 r
               |)))
@@ -55807,7 +55915,7 @@ Module num.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -58329,7 +58437,7 @@ Module num.
                 |) in
               M.match_operator (|
                 M.match_operator (|
-                  M.get_array_field (|
+                  M.SubPointer.get_array_field (|
                     M.read (| src |),
                     M.alloc (| Value.Integer Integer.Usize 0 |)
                   |),
@@ -58495,8 +58603,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let is_positive := M.copy (| γ0_0 |) in
                       let digits := M.copy (| γ0_1 |) in
                       let result :=
@@ -58598,7 +58706,7 @@ Module num.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0
@@ -58699,7 +58807,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -58748,7 +58856,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -58845,7 +58953,7 @@ Module num.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0
@@ -58946,7 +59054,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -58995,7 +59103,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -59107,7 +59215,7 @@ Module num.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0
@@ -59196,7 +59304,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -59245,7 +59353,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -59338,7 +59446,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Break",
                                                                                     0
@@ -59389,7 +59497,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                                                     0
@@ -59497,7 +59605,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Break",
                                                                                     0
@@ -59548,7 +59656,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                                                     0
@@ -59622,7 +59730,7 @@ Module num.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0
@@ -59711,7 +59819,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -59760,7 +59868,7 @@ Module num.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -59853,7 +59961,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Break",
                                                                                     0
@@ -59904,7 +60012,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                                                     0
@@ -60012,7 +60120,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Break",
                                                                                     0
@@ -60063,7 +60171,7 @@ Module num.
                                                                             fun γ =>
                                                                               ltac:(M.monadic
                                                                                 (let γ0_0 :=
-                                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                                     γ,
                                                                                     "core::ops::control_flow::ControlFlow::Continue",
                                                                                     0

--- a/CoqOfRust/core/num/nonzero.v
+++ b/CoqOfRust/core/num/nonzero.v
@@ -108,10 +108,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -137,8 +145,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "u8", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU8" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -171,8 +187,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU8" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -199,7 +223,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u8", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU8" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU8",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -362,7 +390,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU8" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU8", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -383,7 +413,12 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u8" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU8" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU8",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -409,7 +444,12 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u8" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU8" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU8",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -464,7 +504,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -626,7 +666,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -699,7 +739,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::u8", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU8" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU8", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -808,7 +852,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -988,7 +1032,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1179,7 +1223,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroU8" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroU8", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -1785,10 +1831,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -1814,8 +1868,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "u16", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU16" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1848,8 +1910,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU16" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1876,7 +1946,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u16", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU16" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU16",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -2039,7 +2113,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU16" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU16", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -2060,7 +2136,12 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u16" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU16" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU16",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -2086,7 +2167,12 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u16" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU16" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU16",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -2141,7 +2227,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2303,7 +2389,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2376,7 +2462,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::u16", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU16" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::nonzero::NonZeroU16",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2485,7 +2579,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2665,7 +2759,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2856,7 +2950,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroU16" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroU16", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -3462,10 +3558,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -3491,8 +3595,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "u32", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU32" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3525,8 +3637,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU32" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -3553,7 +3673,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU32" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU32",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -3716,7 +3840,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU32" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU32", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -3739,7 +3865,12 @@ Module num.
                     M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u32" ] |),
                     [
                       M.read (|
-                        M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU32" 0)
+                        M.use
+                          (M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::num::nonzero::NonZeroU32",
+                            0
+                          |))
                       |)
                     ]
                   |)
@@ -3769,7 +3900,12 @@ Module num.
                     M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u32" ] |),
                     [
                       M.read (|
-                        M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU32" 0)
+                        M.use
+                          (M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::num::nonzero::NonZeroU32",
+                            0
+                          |))
                       |)
                     ]
                   |)
@@ -3826,7 +3962,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -3988,7 +4124,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -4061,7 +4197,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::u32", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU32" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::nonzero::NonZeroU32",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4170,7 +4314,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -4350,7 +4494,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -4541,7 +4685,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroU32" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroU32", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -5147,10 +5293,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -5176,8 +5330,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "u64", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU64" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5210,8 +5372,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU64" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5238,7 +5408,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u64", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU64" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU64",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -5401,7 +5575,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU64" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU64", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -5422,7 +5598,12 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u64" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU64" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU64",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -5448,7 +5629,12 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u64" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU64" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU64",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -5503,7 +5689,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -5665,7 +5851,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -5738,7 +5924,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::u64", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU64" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::nonzero::NonZeroU64",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5847,7 +6041,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -6027,7 +6221,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -6218,7 +6412,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroU64" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroU64", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -6824,10 +7020,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -6853,8 +7057,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "u128", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU128" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6887,8 +7099,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU128" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroU128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6915,7 +7135,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u128", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroU128" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroU128",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -7078,7 +7302,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU128" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroU128", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -7099,7 +7325,12 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u128" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU128" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU128",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -7125,7 +7356,12 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u128" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroU128" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroU128",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -7180,7 +7416,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7342,7 +7578,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7415,7 +7651,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::u128", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroU128" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::nonzero::NonZeroU128",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7524,7 +7768,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7704,7 +7948,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -7895,7 +8139,13 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroU128" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (|
+                nonzero,
+                "core::num::nonzero::NonZeroU128",
+                0
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -8501,10 +8751,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroUsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroUsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -8530,8 +8788,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "usize", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroUsize" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroUsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -8564,8 +8830,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroUsize" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroUsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -8592,7 +8866,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "usize", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroUsize" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroUsize",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -8756,7 +9034,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroUsize" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroUsize", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -8777,7 +9057,12 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "usize" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroUsize" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroUsize",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -8803,7 +9088,12 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "usize" ] |),
                 [
                   M.read (|
-                    M.use (M.get_struct_tuple_field self "core::num::nonzero::NonZeroUsize" 0)
+                    M.use
+                      (M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroUsize",
+                        0
+                      |))
                   |)
                 ]
               |))))
@@ -8858,7 +9148,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -9020,7 +9310,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -9093,7 +9383,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::num::int_log10::usize", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroUsize" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::nonzero::NonZeroUsize",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -9202,7 +9500,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -9382,7 +9680,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -9573,7 +9871,13 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroUsize" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (|
+                nonzero,
+                "core::num::nonzero::NonZeroUsize",
+                0
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -10179,10 +10483,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -10208,8 +10520,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "i8", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI8" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -10242,8 +10562,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI8" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI8" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -10270,7 +10598,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "i8", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI8" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI8",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -10433,7 +10765,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI8" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroI8", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -10454,7 +10788,13 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u8" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI8" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI8",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -10479,7 +10819,13 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u8" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI8" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI8",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -10563,7 +10909,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -10629,8 +10975,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -10869,7 +11215,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -10938,8 +11284,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -10999,7 +11345,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -11118,7 +11464,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -11298,7 +11644,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -11454,7 +11800,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroI8" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroI8", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -12060,10 +12408,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -12089,8 +12445,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "i16", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI16" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12123,8 +12487,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI16" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI16" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12151,7 +12523,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "i16", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI16" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI16",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -12314,7 +12690,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI16" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroI16", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -12335,7 +12713,13 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u16" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI16" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI16",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -12360,7 +12744,13 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u16" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI16" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI16",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -12444,7 +12834,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -12510,8 +12900,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -12750,7 +13140,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -12819,8 +13209,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -12880,7 +13270,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -12999,7 +13389,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -13179,7 +13569,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -13335,7 +13725,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroI16" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroI16", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -13941,10 +14333,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -13970,8 +14370,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "i32", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI32" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -14004,8 +14412,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI32" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI32" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -14032,7 +14448,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "i32", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI32" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI32",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -14195,7 +14615,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI32" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroI32", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -14219,7 +14641,11 @@ Module num.
                     [
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_tuple_field self "core::num::nonzero::NonZeroI32" 0
+                          M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::num::nonzero::NonZeroI32",
+                            0
+                          |)
                         |))
                     ]
                   |)
@@ -14250,7 +14676,11 @@ Module num.
                     [
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_tuple_field self "core::num::nonzero::NonZeroI32" 0
+                          M.SubPointer.get_struct_tuple_field (|
+                            self,
+                            "core::num::nonzero::NonZeroI32",
+                            0
+                          |)
                         |))
                     ]
                   |)
@@ -14337,7 +14767,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -14403,8 +14833,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -14643,7 +15073,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -14712,8 +15142,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -14773,7 +15203,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -14892,7 +15322,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -15072,7 +15502,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -15228,7 +15658,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroI32" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroI32", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -15834,10 +16266,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -15863,8 +16303,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "i64", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI64" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -15897,8 +16345,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI64" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI64" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -15925,7 +16381,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "i64", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI64" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI64",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -16088,7 +16548,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI64" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroI64", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -16109,7 +16571,13 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u64" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI64" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI64",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -16134,7 +16602,13 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u64" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI64" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI64",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -16218,7 +16692,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -16284,8 +16758,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -16524,7 +16998,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -16593,8 +17067,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -16654,7 +17128,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -16773,7 +17247,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -16953,7 +17427,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -17109,7 +17583,9 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroI64" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| nonzero, "core::num::nonzero::NonZeroI64", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -17715,10 +18191,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -17744,8 +18228,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "i128", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI128" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -17778,8 +18270,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI128" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroI128" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -17806,7 +18306,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "i128", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroI128" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroI128",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -17969,7 +18473,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI128" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroI128", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -17990,7 +18496,13 @@ Module num.
                 M.get_function (| "core::intrinsics::ctlz_nonzero", [ Ty.path "u128" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI128" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI128",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -18015,7 +18527,13 @@ Module num.
                 M.get_function (| "core::intrinsics::cttz_nonzero", [ Ty.path "u128" ] |),
                 [
                   M.rust_cast
-                    (M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroI128" 0 |))
+                    (M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroI128",
+                        0
+                      |)
+                    |))
                 ]
               |))))
         | _, _ => M.impossible
@@ -18099,7 +18617,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -18165,8 +18683,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -18405,7 +18923,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -18474,8 +18992,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -18535,7 +19053,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -18654,7 +19172,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -18834,7 +19352,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -18990,7 +19508,13 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroI128" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (|
+                nonzero,
+                "core::num::nonzero::NonZeroI128",
+                0
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -19596,10 +20120,18 @@ Module num.
             let other := M.alloc (| other |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroIsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |)
               |))
               (M.read (|
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroIsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -19625,8 +20157,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", Ty.path "isize", [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroIsize" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroIsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -19659,8 +20199,16 @@ Module num.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroIsize" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::nonzero::NonZeroIsize" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -19687,7 +20235,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "isize", [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::nonzero::NonZeroIsize" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::nonzero::NonZeroIsize",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -19851,7 +20403,9 @@ Module num.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_tuple_field self "core::num::nonzero::NonZeroIsize" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (| self, "core::num::nonzero::NonZeroIsize", 0 |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -19873,7 +20427,11 @@ Module num.
                 [
                   M.rust_cast
                     (M.read (|
-                      M.get_struct_tuple_field self "core::num::nonzero::NonZeroIsize" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroIsize",
+                        0
+                      |)
                     |))
                 ]
               |))))
@@ -19900,7 +20458,11 @@ Module num.
                 [
                   M.rust_cast
                     (M.read (|
-                      M.get_struct_tuple_field self "core::num::nonzero::NonZeroIsize" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::nonzero::NonZeroIsize",
+                        0
+                      |)
                     |))
                 ]
               |))))
@@ -19985,7 +20547,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -20051,8 +20613,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let nz := M.copy (| γ0_0 |) in
                       let flag := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -20295,7 +20857,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -20364,8 +20926,8 @@ Module num.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let result := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -20425,7 +20987,7 @@ Module num.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -20544,7 +21106,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -20724,7 +21286,7 @@ Module num.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -20880,7 +21442,13 @@ Module num.
         | [], [ nonzero ] =>
           ltac:(M.monadic
             (let nonzero := M.alloc (| nonzero |) in
-            M.read (| M.get_struct_tuple_field nonzero "core::num::nonzero::NonZeroIsize" 0 |)))
+            M.read (|
+              M.SubPointer.get_struct_tuple_field (|
+                nonzero,
+                "core::num::nonzero::NonZeroIsize",
+                0
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -21446,7 +22014,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -21485,7 +22053,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -21580,7 +22148,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -21619,7 +22187,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -21714,7 +22282,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -21753,7 +22321,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -21848,7 +22416,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -21887,7 +22455,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -21982,7 +22550,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22021,7 +22589,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22116,7 +22684,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22155,7 +22723,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22250,7 +22818,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22289,7 +22857,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22384,7 +22952,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22423,7 +22991,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22518,7 +23086,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22557,7 +23125,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22652,7 +23220,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22691,7 +23259,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22786,7 +23354,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22825,7 +23393,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -22920,7 +23488,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -22959,7 +23527,7 @@ Module num.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0

--- a/CoqOfRust/core/num/saturating.v
+++ b/CoqOfRust/core/num/saturating.v
@@ -38,8 +38,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::saturating::Saturating" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::saturating::Saturating",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -112,8 +120,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "partial_cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::saturating::Saturating" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::saturating::Saturating",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -143,8 +159,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::saturating::Saturating" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::saturating::Saturating",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -176,10 +200,11 @@ Module num.
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::num::saturating::Saturating"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::num::saturating::Saturating",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -253,7 +278,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", T, [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -288,7 +317,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Debug", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -323,7 +356,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Display", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -358,7 +395,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Binary", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -393,7 +434,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Octal", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -428,7 +473,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::LowerHex", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -463,7 +512,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::UpperHex", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::saturating::Saturating" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::saturating::Saturating",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -505,10 +558,18 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -642,10 +703,18 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -779,10 +848,18 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -916,10 +993,18 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -1059,10 +1144,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -1192,7 +1285,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -1229,9 +1328,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -1360,9 +1469,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -1491,9 +1610,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -1625,10 +1754,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -1760,10 +1897,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -1895,10 +2040,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -2030,10 +2183,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -2171,10 +2332,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -2302,7 +2471,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -2339,9 +2514,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -2468,9 +2653,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -2597,9 +2792,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -2729,10 +2934,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -2864,10 +3077,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -2999,10 +3220,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -3134,10 +3363,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -3275,10 +3512,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -3406,7 +3651,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -3443,9 +3694,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -3572,9 +3833,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -3701,9 +3972,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -3833,10 +4114,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -3968,10 +4257,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -4103,10 +4400,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -4238,10 +4543,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -4379,10 +4692,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -4510,7 +4831,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -4547,9 +4874,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -4676,9 +5013,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -4805,9 +5152,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -4937,10 +5294,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -5072,10 +5437,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -5207,10 +5580,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -5342,10 +5723,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -5483,10 +5872,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -5614,7 +6011,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -5651,9 +6054,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -5780,9 +6193,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -5909,9 +6332,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -6041,10 +6474,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -6176,10 +6617,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -6311,10 +6760,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -6446,10 +6903,18 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -6587,10 +7052,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -6718,7 +7191,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -6755,9 +7234,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -6884,9 +7373,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -7013,9 +7512,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -7145,10 +7654,18 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -7282,10 +7799,18 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -7419,10 +7944,18 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -7556,10 +8089,18 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -7699,10 +8240,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -7832,7 +8381,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -7869,9 +8424,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -8000,9 +8565,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -8131,9 +8706,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -8265,10 +8850,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -8400,10 +8993,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -8535,10 +9136,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -8670,10 +9279,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -8811,10 +9428,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -8942,7 +9567,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -8979,9 +9610,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -9108,9 +9749,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -9237,9 +9888,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -9369,10 +10030,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -9504,10 +10173,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -9639,10 +10316,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -9774,10 +10459,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -9915,10 +10608,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -10046,7 +10747,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -10083,9 +10790,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -10212,9 +10929,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -10341,9 +11068,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -10473,10 +11210,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -10608,10 +11353,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -10743,10 +11496,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -10878,10 +11639,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -11019,10 +11788,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -11150,7 +11927,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -11187,9 +11970,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -11316,9 +12109,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -11445,9 +12248,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -11577,10 +12390,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -11712,10 +12533,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -11847,10 +12676,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -11982,10 +12819,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -12123,10 +12968,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -12254,7 +13107,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -12291,9 +13150,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -12420,9 +13289,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -12549,9 +13428,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -12681,10 +13570,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "saturating_add", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -12816,10 +13713,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "saturating_sub", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -12951,10 +13856,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "saturating_mul", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -13086,10 +13999,18 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "saturating_div", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -13227,10 +14148,18 @@ Module num.
                   |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (|
-                      M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |)
                   ]
                 |)
@@ -13358,7 +14287,13 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -13395,9 +14330,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -13524,9 +14469,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -13653,9 +14608,19 @@ Module num.
               "core::num::saturating::Saturating"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |))
                   (M.read (|
-                    M.get_struct_tuple_field other "core::num::saturating::Saturating" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::saturating::Saturating",
+                      0
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -13808,7 +14773,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -13827,7 +14800,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -13846,7 +14827,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -13872,7 +14861,11 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -13901,7 +14894,11 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -13928,7 +14925,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13952,7 +14956,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13977,7 +14988,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14000,7 +15019,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14023,7 +15050,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14047,7 +15081,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14074,7 +15115,11 @@ Module num.
                   M.get_associated_function (| Ty.path "usize", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -14096,7 +15141,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14116,7 +15169,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14174,7 +15235,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14193,7 +15262,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14212,7 +15289,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14238,7 +15323,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -14267,7 +15356,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -14294,7 +15387,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14318,7 +15418,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14343,7 +15450,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14366,7 +15481,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14389,7 +15512,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14413,7 +15543,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14440,7 +15577,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u8", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -14462,7 +15603,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14482,7 +15631,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14540,7 +15697,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14559,7 +15724,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14578,7 +15751,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14604,7 +15785,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -14633,7 +15818,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -14660,7 +15849,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14684,7 +15880,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14709,7 +15912,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14732,7 +15943,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -14755,7 +15974,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14779,7 +16005,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14806,7 +16039,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u16", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -14828,7 +16065,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14848,7 +16093,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14906,7 +16159,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14925,7 +16186,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14944,7 +16213,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -14970,7 +16247,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -14999,7 +16280,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -15026,7 +16311,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15050,7 +16342,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15075,7 +16374,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15098,7 +16405,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15121,7 +16436,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15145,7 +16467,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15172,7 +16501,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u32", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -15194,7 +16527,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15214,7 +16555,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15272,7 +16621,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15291,7 +16648,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15310,7 +16675,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15336,7 +16709,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -15365,7 +16742,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -15392,7 +16773,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15416,7 +16804,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15441,7 +16836,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15464,7 +16867,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15487,7 +16898,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15511,7 +16929,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15538,7 +16963,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u64", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -15560,7 +16989,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15580,7 +17017,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15638,7 +17083,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15657,7 +17110,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15676,7 +17137,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15702,7 +17171,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -15731,7 +17204,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -15758,7 +17235,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15782,7 +17266,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15807,7 +17298,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15830,7 +17329,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -15853,7 +17360,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15877,7 +17391,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15904,7 +17425,11 @@ Module num.
                   M.get_associated_function (| Ty.path "u128", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -15926,7 +17451,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -15946,7 +17479,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16004,7 +17545,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16023,7 +17572,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16042,7 +17599,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16068,7 +17633,11 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16097,7 +17666,11 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16124,7 +17697,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16148,7 +17728,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16173,7 +17760,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16196,7 +17791,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16219,7 +17822,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16243,7 +17853,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16270,7 +17887,11 @@ Module num.
                   M.get_associated_function (| Ty.path "isize", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -16292,7 +17913,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16315,7 +17944,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16339,7 +17975,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16360,7 +18003,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16379,7 +18030,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16436,7 +18095,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16455,7 +18122,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16474,7 +18149,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16500,7 +18183,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16529,7 +18216,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16556,7 +18247,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16580,7 +18278,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16605,7 +18310,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16628,7 +18341,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16651,7 +18372,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16675,7 +18403,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16702,7 +18437,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i8", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -16724,7 +18463,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16747,7 +18494,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16771,7 +18525,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -16792,7 +18553,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16811,7 +18580,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16868,7 +18645,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16887,7 +18672,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16906,7 +18699,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16932,7 +18733,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16961,7 +18766,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -16988,7 +18797,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17012,7 +18828,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17037,7 +18860,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17060,7 +18891,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17083,7 +18922,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17107,7 +18953,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17134,7 +18987,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i16", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -17156,7 +19013,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17179,7 +19044,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17203,7 +19075,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17224,7 +19103,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17243,7 +19130,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17300,7 +19195,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17319,7 +19222,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17338,7 +19249,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17364,7 +19283,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -17393,7 +19316,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -17420,7 +19347,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17444,7 +19378,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17469,7 +19410,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17492,7 +19441,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17515,7 +19472,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17539,7 +19503,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17566,7 +19537,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i32", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -17588,7 +19563,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17611,7 +19594,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17635,7 +19625,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17656,7 +19653,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17675,7 +19680,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17732,7 +19745,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17751,7 +19772,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17770,7 +19799,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17796,7 +19833,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -17825,7 +19866,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -17852,7 +19897,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17876,7 +19928,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17901,7 +19960,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17924,7 +19991,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17947,7 +20022,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17971,7 +20053,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -17998,7 +20087,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i64", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -18020,7 +20113,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18043,7 +20144,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18067,7 +20175,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18088,7 +20203,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18107,7 +20230,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18164,7 +20295,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18183,7 +20322,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18202,7 +20349,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18228,7 +20383,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "rotate_left", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -18257,7 +20416,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "rotate_right", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| n |)
                   ]
@@ -18284,7 +20447,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18308,7 +20478,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18333,7 +20510,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18356,7 +20541,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::saturating::Saturating" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18379,7 +20572,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18403,7 +20603,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18430,7 +20637,11 @@ Module num.
                   M.get_associated_function (| Ty.path "i128", "saturating_pow", [] |),
                   [
                     M.read (|
-                      M.get_struct_tuple_field self "core::num::saturating::Saturating" 0
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
                     |);
                     M.read (| exp |)
                   ]
@@ -18452,7 +20663,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18475,7 +20694,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "saturating_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18499,7 +20725,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18520,7 +20753,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18539,7 +20780,15 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::num::saturating::Saturating",
+                    0
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18571,7 +20820,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18611,7 +20867,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18651,7 +20914,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18691,7 +20961,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18731,7 +21008,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -18771,7 +21055,14 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "saturating_neg", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::saturating::Saturating" 0 |)
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::saturating::Saturating",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))

--- a/CoqOfRust/core/num/wrapping.v
+++ b/CoqOfRust/core/num/wrapping.v
@@ -36,8 +36,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::wrapping::Wrapping" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -107,8 +115,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "partial_cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::wrapping::Wrapping" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -137,8 +153,16 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::num::wrapping::Wrapping" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -168,7 +192,13 @@ Module num.
               [
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -238,7 +268,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", T, [], "hash", [ __H ] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -272,7 +306,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Debug", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -306,7 +344,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Display", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -340,7 +382,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Binary", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -374,7 +420,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::Octal", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -408,7 +458,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::LowerHex", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -442,7 +496,11 @@ Module num.
             M.call_closure (|
               M.get_trait_method (| "core::fmt::UpperHex", T, [], "fmt", [] |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::num::wrapping::Wrapping" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::num::wrapping::Wrapping",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -482,7 +540,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -569,7 +633,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -657,7 +727,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -748,7 +824,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -839,7 +921,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -930,7 +1018,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1021,7 +1115,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1112,7 +1212,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1203,7 +1309,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1294,7 +1406,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1385,7 +1503,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1476,7 +1600,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1566,7 +1696,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1653,7 +1789,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1741,7 +1883,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1832,7 +1980,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -1923,7 +2077,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2014,7 +2174,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2105,7 +2271,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2196,7 +2368,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2287,7 +2465,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2378,7 +2562,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2469,7 +2659,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_shl", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2560,7 +2756,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_shr", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.rust_cast
                       (BinOp.Pure.bit_and
                         (M.read (| other |))
@@ -2651,8 +2853,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -2782,8 +2996,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -2913,8 +3139,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -3044,8 +3282,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -3175,8 +3425,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -3303,7 +3565,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -3340,8 +3608,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -3467,8 +3747,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -3594,8 +3886,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -3765,8 +4069,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -3893,8 +4209,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -4021,8 +4349,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -4149,8 +4489,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -4277,8 +4629,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -4402,7 +4766,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -4438,8 +4808,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -4562,8 +4944,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -4686,8 +5080,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -4855,8 +5261,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -4986,8 +5404,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -5117,8 +5547,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -5248,8 +5690,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -5379,8 +5833,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -5507,7 +5973,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -5544,8 +6016,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -5671,8 +6155,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -5798,8 +6294,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -5970,8 +6478,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -6101,8 +6621,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -6232,8 +6764,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -6363,8 +6907,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -6494,8 +7050,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -6622,7 +7190,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -6659,8 +7233,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -6786,8 +7372,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -6913,8 +7511,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -7085,8 +7695,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -7216,8 +7838,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -7347,8 +7981,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -7478,8 +8124,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -7609,8 +8267,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -7737,7 +8407,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -7774,8 +8450,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -7901,8 +8589,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -8028,8 +8728,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -8200,8 +8912,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -8331,8 +9055,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -8462,8 +9198,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -8593,8 +9341,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -8724,8 +9484,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -8852,7 +9624,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -8889,8 +9667,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -9016,8 +9806,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -9143,8 +9945,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -9315,8 +10129,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -9446,8 +10272,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -9577,8 +10415,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -9708,8 +10558,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -9839,8 +10701,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -9967,7 +10841,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -10004,8 +10884,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -10131,8 +11023,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -10258,8 +11162,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -10429,8 +11345,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -10557,8 +11485,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -10685,8 +11625,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -10813,8 +11765,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -10941,8 +11905,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -11066,7 +12042,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -11102,8 +12084,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -11226,8 +12220,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -11350,8 +12356,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -11519,8 +12537,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -11650,8 +12680,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -11781,8 +12823,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -11912,8 +12966,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -12043,8 +13109,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -12171,7 +13249,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -12208,8 +13292,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -12335,8 +13431,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -12462,8 +13570,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -12634,8 +13754,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -12765,8 +13897,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -12896,8 +14040,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13027,8 +14183,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13158,8 +14326,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13286,7 +14466,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -13323,8 +14509,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -13450,8 +14648,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -13577,8 +14787,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -13749,8 +14971,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -13880,8 +15114,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14011,8 +15257,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14142,8 +15400,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14273,8 +15543,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14401,7 +15683,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -14438,8 +15726,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -14565,8 +15865,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -14692,8 +16004,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -14864,8 +16188,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_add", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -14995,8 +16331,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_sub", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15126,8 +16474,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_mul", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15257,8 +16617,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_div", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15388,8 +16760,20 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_rem", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
-                    M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |)
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        other,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
                   ]
                 |)
               ]))
@@ -15516,7 +16900,13 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 UnOp.Pure.not
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -15553,8 +16943,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_xor
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -15680,8 +17082,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_or
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -15807,8 +17221,20 @@ Module num.
               "core::num::wrapping::Wrapping"
               [
                 BinOp.Pure.bit_and
-                  (M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |))
-                  (M.read (| M.get_struct_tuple_field other "core::num::wrapping::Wrapping" 0 |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
+                  (M.read (|
+                    M.SubPointer.get_struct_tuple_field (|
+                      other,
+                      "core::num::wrapping::Wrapping",
+                      0
+                    |)
+                  |))
               ]))
         | _, _ => M.impossible
         end.
@@ -16003,7 +17429,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16022,7 +17452,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16041,7 +17475,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16066,7 +17504,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16093,7 +17537,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16119,7 +17569,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16142,7 +17600,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16166,7 +17632,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16189,7 +17663,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16212,7 +17694,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16235,7 +17725,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16260,7 +17758,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -16281,7 +17785,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16301,7 +17809,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "usize", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16324,7 +17836,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "usize", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16382,7 +17902,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16401,7 +17925,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16420,7 +17948,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16445,7 +17977,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16472,7 +18010,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16498,7 +18042,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16521,7 +18073,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16545,7 +18105,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16568,7 +18136,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16591,7 +18167,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16614,7 +18198,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16639,7 +18231,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -16660,7 +18258,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16680,7 +18282,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u8", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16703,7 +18309,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u8", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16762,7 +18376,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16781,7 +18399,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16800,7 +18422,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -16825,7 +18451,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16852,7 +18484,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -16878,7 +18516,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16901,7 +18547,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16925,7 +18579,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16948,7 +18610,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16971,7 +18641,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -16994,7 +18672,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17019,7 +18705,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -17040,7 +18732,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17060,7 +18756,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u16", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17083,7 +18783,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u16", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17142,7 +18850,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17161,7 +18873,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17180,7 +18896,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17205,7 +18925,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -17232,7 +18958,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -17258,7 +18990,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17281,7 +19021,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17305,7 +19053,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17328,7 +19084,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17351,7 +19115,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17374,7 +19146,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17399,7 +19179,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -17420,7 +19206,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17440,7 +19230,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u32", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17463,7 +19257,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u32", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17522,7 +19324,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17541,7 +19347,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17560,7 +19370,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17585,7 +19399,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -17612,7 +19432,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -17638,7 +19464,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17661,7 +19495,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17685,7 +19527,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17708,7 +19558,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17731,7 +19589,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17754,7 +19620,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17779,7 +19653,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -17800,7 +19680,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17820,7 +19704,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u64", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17843,7 +19731,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u64", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -17902,7 +19798,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17921,7 +19821,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17940,7 +19844,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -17965,7 +19873,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -17992,7 +19906,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -18018,7 +19938,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18041,7 +19969,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18065,7 +20001,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18088,7 +20032,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18111,7 +20063,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18134,7 +20094,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18159,7 +20127,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -18180,7 +20154,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18200,7 +20178,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "u128", "is_power_of_two", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18223,7 +20205,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "u128", "wrapping_next_power_of_two", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18282,7 +20272,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18301,7 +20295,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18320,7 +20318,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18345,7 +20347,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -18372,7 +20380,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -18398,7 +20412,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18421,7 +20443,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18445,7 +20475,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18468,7 +20506,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18491,7 +20537,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18514,7 +20568,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18539,7 +20601,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -18560,7 +20628,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18583,7 +20655,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18606,7 +20686,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "isize", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18626,7 +20714,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18645,7 +20737,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "isize", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18701,7 +20797,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18720,7 +20820,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18739,7 +20843,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -18764,7 +20872,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -18791,7 +20905,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -18817,7 +20937,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18840,7 +20968,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18864,7 +21000,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18887,7 +21031,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18910,7 +21062,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18933,7 +21093,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -18958,7 +21126,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -18979,7 +21153,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19002,7 +21180,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19025,7 +21211,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i8", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19045,7 +21239,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19064,7 +21262,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i8", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19121,7 +21323,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19140,7 +21346,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19159,7 +21369,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19184,7 +21398,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -19211,7 +21431,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -19237,7 +21463,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19260,7 +21494,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19284,7 +21526,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19307,7 +21557,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19330,7 +21588,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19353,7 +21619,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19378,7 +21652,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -19399,7 +21679,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19422,7 +21706,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19445,7 +21737,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i16", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19465,7 +21765,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19484,7 +21788,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i16", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19541,7 +21849,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19560,7 +21872,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19579,7 +21895,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19604,7 +21924,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -19631,7 +21957,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -19657,7 +21989,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19680,7 +22020,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19704,7 +22052,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19727,7 +22083,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19750,7 +22114,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19773,7 +22145,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19798,7 +22178,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -19819,7 +22205,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19842,7 +22232,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19865,7 +22263,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i32", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -19885,7 +22291,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19904,7 +22314,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i32", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19961,7 +22375,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19980,7 +22398,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -19999,7 +22421,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20024,7 +22450,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -20051,7 +22483,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -20077,7 +22515,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20100,7 +22546,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20124,7 +22578,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20147,7 +22609,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20170,7 +22640,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20193,7 +22671,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20218,7 +22704,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -20239,7 +22731,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20262,7 +22758,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20285,7 +22789,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i64", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20305,7 +22817,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20324,7 +22840,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i64", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20381,7 +22901,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "count_ones", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20400,7 +22924,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "count_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20419,7 +22947,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "trailing_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20444,7 +22976,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "rotate_left", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -20471,7 +23009,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "rotate_right", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| n |)
                   ]
                 |)
@@ -20497,7 +23041,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "swap_bytes", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20520,7 +23072,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "reverse_bits", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20544,7 +23104,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "from_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20567,7 +23135,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "from_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field x "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        x,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20590,7 +23166,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "to_be", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20613,7 +23197,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "to_le", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20638,7 +23230,13 @@ Module num.
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_pow", [] |),
                   [
-                    M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |);
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |);
                     M.read (| exp |)
                   ]
                 |)
@@ -20659,7 +23257,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "leading_zeros", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20682,7 +23284,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "wrapping_abs", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20705,7 +23315,15 @@ Module num.
               [
                 M.call_closure (|
                   M.get_associated_function (| Ty.path "i128", "signum", [] |),
-                  [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        self,
+                        "core::num::wrapping::Wrapping",
+                        0
+                      |)
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -20725,7 +23343,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "is_positive", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -20744,7 +23366,11 @@ Module num.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "i128", "is_negative", [] |),
-              [ M.read (| M.get_struct_tuple_field self "core::num::wrapping::Wrapping" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::num::wrapping::Wrapping", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.

--- a/CoqOfRust/core/ops/control_flow.v
+++ b/CoqOfRust/core/ops/control_flow.v
@@ -43,7 +43,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -67,7 +67,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -121,7 +121,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -141,7 +141,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -241,11 +241,11 @@ Module ops.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -253,7 +253,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -273,11 +273,11 @@ Module ops.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -285,7 +285,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -425,7 +425,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -441,7 +441,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -519,7 +519,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -533,7 +533,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -593,7 +593,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -660,7 +660,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -695,7 +695,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -736,7 +736,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -780,7 +780,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -794,7 +794,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -847,7 +847,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -894,7 +894,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -919,7 +919,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -971,7 +971,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -985,7 +985,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0
@@ -1038,7 +1038,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Continue",
                           0
@@ -1059,7 +1059,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::control_flow::ControlFlow::Break",
                           0

--- a/CoqOfRust/core/ops/coroutine.v
+++ b/CoqOfRust/core/ops/coroutine.v
@@ -42,7 +42,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Yielded",
                           0
@@ -62,7 +62,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Complete",
                           0
@@ -162,11 +162,11 @@ Module ops.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::coroutine::CoroutineState::Yielded",
                                   0
@@ -174,7 +174,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::coroutine::CoroutineState::Yielded",
                                   0
@@ -194,11 +194,11 @@ Module ops.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::coroutine::CoroutineState::Complete",
                                   0
@@ -206,7 +206,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::coroutine::CoroutineState::Complete",
                                   0
@@ -290,11 +290,11 @@ Module ops.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::ops::coroutine::CoroutineState::Yielded",
                           0
@@ -302,7 +302,7 @@ Module ops.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::ops::coroutine::CoroutineState::Yielded",
                           0
@@ -322,11 +322,11 @@ Module ops.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::ops::coroutine::CoroutineState::Complete",
                           0
@@ -334,7 +334,7 @@ Module ops.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::ops::coroutine::CoroutineState::Complete",
                           0
@@ -480,11 +480,11 @@ Module ops.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::coroutine::CoroutineState::Yielded",
                                   0
@@ -492,7 +492,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::coroutine::CoroutineState::Yielded",
                                   0
@@ -506,11 +506,11 @@ Module ops.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::coroutine::CoroutineState::Complete",
                                   0
@@ -518,7 +518,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::coroutine::CoroutineState::Complete",
                                   0
@@ -581,7 +581,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Yielded",
                           0
@@ -605,7 +605,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Complete",
                           0
@@ -683,7 +683,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Yielded",
                           0
@@ -699,7 +699,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::coroutine::CoroutineState::Complete",
                           0

--- a/CoqOfRust/core/ops/index_range.v
+++ b/CoqOfRust/core/ops/index_range.v
@@ -26,20 +26,22 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::index_range::IndexRange"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::index_range::IndexRange",
                         "start"
+                      |)
                     ]
                   |));
                 ("end_",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::index_range::IndexRange"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::index_range::IndexRange",
                         "end"
+                      |)
                     ]
                   |))
               ]))
@@ -76,18 +78,20 @@ Module ops.
                 M.read (| Value.String "start" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
-                    "start");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
+                    "start"
+                  |));
                 M.read (| Value.String "end" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ops::index_range::IndexRange"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::index_range::IndexRange",
                       "end"
+                    |)
                   |))
               ]
             |)))
@@ -126,30 +130,34 @@ Module ops.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
                     "start"
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::ops::index_range::IndexRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::ops::index_range::IndexRange",
                     "start"
+                  |)
                 |)),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ops::index_range::IndexRange"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::index_range::IndexRange",
                       "end"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::ops::index_range::IndexRange"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::ops::index_range::IndexRange",
                       "end"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -325,10 +333,11 @@ Module ops.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::ops::index_range::IndexRange"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::ops::index_range::IndexRange",
                 "start"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -346,10 +355,11 @@ Module ops.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::ops::index_range::IndexRange"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::ops::index_range::IndexRange",
                 "end"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -371,16 +381,18 @@ Module ops.
               M.get_function (| "core::intrinsics::unchecked_sub", [ Ty.path "usize" ] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
                     "end"
+                  |)
                 |);
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
                     "start"
+                  |)
                 |)
               ]
             |)))
@@ -426,16 +438,18 @@ Module ops.
                                         UnOp.Pure.not
                                           (BinOp.Pure.lt
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::index_range::IndexRange"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::index_range::IndexRange",
                                                 "start"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::index_range::IndexRange"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::index_range::IndexRange",
                                                 "end"
+                                              |)
                                             |)))
                                       |)) in
                                   let _ :=
@@ -464,17 +478,19 @@ Module ops.
                 |) in
               let value :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
                     "start"
+                  |)
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
-                    "start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
+                    "start"
+                  |),
                   M.call_closure (|
                     M.get_function (| "core::intrinsics::unchecked_add", [ Ty.path "usize" ] |),
                     [ M.read (| value |); Value.Integer Integer.Usize 1 ]
@@ -525,16 +541,18 @@ Module ops.
                                         UnOp.Pure.not
                                           (BinOp.Pure.lt
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::index_range::IndexRange"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::index_range::IndexRange",
                                                 "start"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::ops::index_range::IndexRange"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::ops::index_range::IndexRange",
                                                 "end"
+                                              |)
                                             |)))
                                       |)) in
                                   let _ :=
@@ -567,10 +585,11 @@ Module ops.
                     M.get_function (| "core::intrinsics::unchecked_sub", [ Ty.path "usize" ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::ops::index_range::IndexRange"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::ops::index_range::IndexRange",
                           "end"
+                        |)
                       |);
                       Value.Integer Integer.Usize 1
                     ]
@@ -578,10 +597,11 @@ Module ops.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
-                    "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
+                    "end"
+                  |),
                   M.read (| value |)
                 |) in
               value
@@ -648,10 +668,11 @@ Module ops.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::ops::index_range::IndexRange"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::ops::index_range::IndexRange",
                                     "start"
+                                  |)
                                 |);
                                 M.read (| n |)
                               ]
@@ -659,10 +680,11 @@ Module ops.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::index_range::IndexRange"
-                            "end"))
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::index_range::IndexRange",
+                            "end"
+                          |)))
                     ]
                   |)
                 |) in
@@ -673,20 +695,22 @@ Module ops.
                     [
                       ("start",
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::index_range::IndexRange"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::index_range::IndexRange",
                             "start"
+                          |)
                         |));
                       ("end_", M.read (| mid |))
                     ]
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
-                    "start",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
+                    "start"
+                  |),
                   M.read (| mid |)
                 |) in
               prefix
@@ -752,10 +776,11 @@ Module ops.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::ops::index_range::IndexRange"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::ops::index_range::IndexRange",
                                     "end"
+                                  |)
                                 |);
                                 M.read (| n |)
                               ]
@@ -763,10 +788,11 @@ Module ops.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::index_range::IndexRange"
-                            "start"))
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::index_range::IndexRange",
+                            "start"
+                          |)))
                     ]
                   |)
                 |) in
@@ -778,19 +804,21 @@ Module ops.
                       ("start", M.read (| mid |));
                       ("end_",
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::index_range::IndexRange"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::index_range::IndexRange",
                             "end"
+                          |)
                         |))
                     ]
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::index_range::IndexRange"
-                    "end",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::index_range::IndexRange",
+                    "end"
+                  |),
                   M.read (| mid |)
                 |) in
               suffix

--- a/CoqOfRust/core/ops/range.v
+++ b/CoqOfRust/core/ops/range.v
@@ -211,16 +211,22 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::Range"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
                         "start"
+                      |)
                     ]
                   |));
                 ("end_",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
-                    [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end"
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "end"
+                      |)
                     ]
                   |))
               ]))
@@ -298,16 +304,32 @@ Module ops.
               M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start";
-                  M.get_struct_record_field (M.read (| other |)) "core::ops::range::Range" "start"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "start"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::ops::range::Range",
+                    "start"
+                  |)
                 ]
               |),
               ltac:(M.monadic
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end";
-                    M.get_struct_record_field (M.read (| other |)) "core::ops::range::Range" "end"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::Range",
+                      "end"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::ops::range::Range",
+                      "end"
+                    |)
                   ]
                 |)))
             |)))
@@ -382,10 +404,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::Range"
-                        "start";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::Range",
+                        "start"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -394,7 +417,11 @@ Module ops.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::Range",
+                      "end"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -450,10 +477,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "start";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "start"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -464,7 +492,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -500,7 +528,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -552,7 +580,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -588,7 +616,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -614,10 +642,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::Range"
-                                  "end";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::Range",
+                                  "end"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -628,7 +657,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -664,7 +693,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -739,8 +768,16 @@ Module ops.
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialOrd", Idx, [ Idx ], "lt", [] |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start";
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "start"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "end"
+                  |)
                 ]
               |))))
         | _, _ => M.impossible
@@ -776,10 +813,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeFrom"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeFrom",
                         "start"
+                      |)
                     ]
                   |))
               ]))
@@ -823,8 +861,16 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeFrom" "start";
-                M.get_struct_record_field (M.read (| other |)) "core::ops::range::RangeFrom" "start"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeFrom",
+                  "start"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::ops::range::RangeFrom",
+                  "start"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -898,7 +944,11 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeFrom" "start";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeFrom",
+                  "start"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -952,10 +1002,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeFrom"
-                                  "start";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeFrom",
+                                  "start"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -966,7 +1017,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1002,7 +1053,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1054,7 +1105,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1090,7 +1141,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1188,10 +1239,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeTo"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeTo",
                         "end"
+                      |)
                     ]
                   |))
               ]))
@@ -1233,8 +1285,16 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeTo" "end";
-                M.get_struct_record_field (M.read (| other |)) "core::ops::range::RangeTo" "end"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeTo",
+                  "end"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::ops::range::RangeTo",
+                  "end"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1305,7 +1365,11 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeTo" "end";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeTo",
+                  "end"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -1384,7 +1448,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1420,7 +1484,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1446,10 +1510,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeTo"
-                                  "end";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeTo",
+                                  "end"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -1460,7 +1525,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1496,7 +1561,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1582,30 +1647,33 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
                         "start"
+                      |)
                     ]
                   |));
                 ("end_",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
                         "end"
+                      |)
                     ]
                   |));
                 ("exhausted",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
                         "exhausted"
+                      |)
                     ]
                   |))
               ]))
@@ -1651,44 +1719,50 @@ Module ops.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ops::range::RangeInclusive"
-                      "start";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::ops::range::RangeInclusive"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::RangeInclusive",
                       "start"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::ops::range::RangeInclusive",
+                      "start"
+                    |)
                   ]
                 |),
                 ltac:(M.monadic
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "end";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::ops::range::RangeInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
                         "end"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::ops::range::RangeInclusive",
+                        "end"
+                      |)
                     ]
                   |)))
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ops::range::RangeInclusive"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::RangeInclusive",
                       "exhausted"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::ops::range::RangeInclusive"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::ops::range::RangeInclusive",
                       "exhausted"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -1772,10 +1846,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "start";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "start"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -1785,10 +1860,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "end";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "end"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -1797,10 +1873,11 @@ Module ops.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.path "bool", [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::ops::range::RangeInclusive"
-                      "exhausted";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::ops::range::RangeInclusive",
+                      "exhausted"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -1859,10 +1936,11 @@ Module ops.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::ops::range::RangeInclusive"
-              "start"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::ops::range::RangeInclusive",
+              "start"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -1881,7 +1959,11 @@ Module ops.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeInclusive" "end"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::ops::range::RangeInclusive",
+              "end"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -1903,9 +1985,19 @@ Module ops.
             Value.Tuple
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ops::range::RangeInclusive" "start"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ops::range::RangeInclusive",
+                    "start"
+                  |)
                 |);
-                M.read (| M.get_struct_record_field self "core::ops::range::RangeInclusive" "end" |)
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ops::range::RangeInclusive",
+                    "end"
+                  |)
+                |)
               ]))
         | _, _ => M.impossible
         end.
@@ -1959,24 +2051,27 @@ Module ops.
             (let self := M.alloc (| self |) in
             LogicalOp.or (|
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ops::range::RangeInclusive"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeInclusive",
                   "exhausted"
+                |)
               |),
               ltac:(M.monadic
                 (UnOp.Pure.not
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialOrd", Idx, [ Idx ], "le", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
-                        "start";
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
+                        "start"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeInclusive",
                         "end"
+                      |)
                     ]
                   |))))
             |)))
@@ -2012,7 +2107,11 @@ Module ops.
                 M.alloc (|
                   BinOp.Panic.add (|
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeInclusive",
+                        "end"
+                      |)
                     |),
                     Value.Integer Integer.Usize 1
                   |)
@@ -2026,19 +2125,21 @@ Module ops.
                         ltac:(M.monadic
                           (let γ :=
                             M.use
-                              (M.get_struct_record_field
-                                self
-                                "core::ops::range::RangeInclusive"
-                                "exhausted") in
+                              (M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::ops::range::RangeInclusive",
+                                "exhausted"
+                              |)) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           exclusive_end));
                       fun γ =>
                         ltac:(M.monadic
-                          (M.get_struct_record_field
-                            self
-                            "core::ops::range::RangeInclusive"
-                            "start"))
+                          (M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::ops::range::RangeInclusive",
+                            "start"
+                          |)))
                     ]
                   |)
                 |) in
@@ -2097,10 +2198,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeInclusive"
-                                  "start";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeInclusive",
+                                  "start"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -2111,7 +2213,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2147,7 +2249,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2201,7 +2303,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2237,7 +2339,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2263,10 +2365,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeInclusive"
-                                  "end";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeInclusive",
+                                  "end"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -2277,7 +2380,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2313,7 +2416,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2330,10 +2433,11 @@ Module ops.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeInclusive"
-                                  "exhausted") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeInclusive",
+                                  "exhausted"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
@@ -2382,7 +2486,7 @@ Module ops.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -2418,7 +2522,7 @@ Module ops.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -2485,10 +2589,11 @@ Module ops.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Idx, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ops::range::RangeToInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ops::range::RangeToInclusive",
                         "end"
+                      |)
                     ]
                   |))
               ]))
@@ -2532,14 +2637,16 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", Idx, [ Idx ], "eq", [] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ops::range::RangeToInclusive"
-                  "end";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "core::ops::range::RangeToInclusive"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeToInclusive",
                   "end"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::ops::range::RangeToInclusive",
+                  "end"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -2613,10 +2720,11 @@ Module ops.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Idx, [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ops::range::RangeToInclusive"
-                  "end";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeToInclusive",
+                  "end"
+                |);
                 M.read (| state |)
               ]
             |)))
@@ -2698,7 +2806,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2734,7 +2842,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2760,10 +2868,11 @@ Module ops.
                             M.call_closure (|
                               M.get_trait_method (| "core::fmt::Debug", Idx, [], "fmt", [] |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::ops::range::RangeToInclusive"
-                                  "end";
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::ops::range::RangeToInclusive",
+                                  "end"
+                                |);
                                 M.read (| fmt |)
                               ]
                             |)
@@ -2774,7 +2883,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -2810,7 +2919,7 @@ Module ops.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -2915,7 +3024,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -2935,7 +3044,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3001,7 +3110,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3025,7 +3134,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3115,7 +3224,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3131,7 +3240,7 @@ Module ops.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3213,11 +3322,11 @@ Module ops.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::range::Bound::Included",
                                   0
@@ -3225,7 +3334,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::range::Bound::Included",
                                   0
@@ -3245,11 +3354,11 @@ Module ops.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::ops::range::Bound::Excluded",
                                   0
@@ -3257,7 +3366,7 @@ Module ops.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::ops::range::Bound::Excluded",
                                   0
@@ -3360,7 +3469,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3372,7 +3481,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3416,7 +3525,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3428,7 +3537,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3476,7 +3585,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3501,7 +3610,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3563,7 +3672,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Included",
                           0
@@ -3582,7 +3691,7 @@ Module ops.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -3636,7 +3745,7 @@ Module ops.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Included",
                             0
@@ -3657,7 +3766,7 @@ Module ops.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Excluded",
                             0
@@ -3698,7 +3807,7 @@ Module ops.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::range::Bound::Included",
                               0
@@ -3719,7 +3828,7 @@ Module ops.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::range::Bound::Excluded",
                               0
@@ -3812,7 +3921,12 @@ Module ops.
             (let self := M.alloc (| self |) in
             Value.StructTuple
               "core::ops::range::Bound::Included"
-              [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeFrom" "start"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeFrom",
+                  "start"
+                |)
               ]))
         | _, _ => M.impossible
         end.
@@ -3876,7 +3990,13 @@ Module ops.
             (let self := M.alloc (| self |) in
             Value.StructTuple
               "core::ops::range::Bound::Excluded"
-              [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeTo" "end" ]))
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeTo",
+                  "end"
+                |)
+              ]))
         | _, _ => M.impossible
         end.
       
@@ -3909,7 +4029,13 @@ Module ops.
             (let self := M.alloc (| self |) in
             Value.StructTuple
               "core::ops::range::Bound::Included"
-              [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start" ]))
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::Range",
+                  "start"
+                |)
+              ]))
         | _, _ => M.impossible
         end.
       
@@ -3926,7 +4052,13 @@ Module ops.
             (let self := M.alloc (| self |) in
             Value.StructTuple
               "core::ops::range::Bound::Excluded"
-              [ M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end" ]))
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::Range",
+                  "end"
+                |)
+              ]))
         | _, _ => M.impossible
         end.
       
@@ -3961,10 +4093,11 @@ Module ops.
             Value.StructTuple
               "core::ops::range::Bound::Included"
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ops::range::RangeInclusive"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeInclusive",
                   "start"
+                |)
               ]))
         | _, _ => M.impossible
         end.
@@ -3994,19 +4127,21 @@ Module ops.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::ops::range::RangeInclusive"
-                            "exhausted") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::ops::range::RangeInclusive",
+                            "exhausted"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         Value.StructTuple
                           "core::ops::range::Bound::Excluded"
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::ops::range::RangeInclusive"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::ops::range::RangeInclusive",
                               "end"
+                            |)
                           ]
                       |)));
                   fun γ =>
@@ -4015,10 +4150,11 @@ Module ops.
                         Value.StructTuple
                           "core::ops::range::Bound::Included"
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::ops::range::RangeInclusive"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::ops::range::RangeInclusive",
                               "end"
+                            |)
                           ]
                       |)))
                 ]
@@ -4073,10 +4209,11 @@ Module ops.
             Value.StructTuple
               "core::ops::range::Bound::Included"
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::ops::range::RangeToInclusive"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ops::range::RangeToInclusive",
                   "end"
+                |)
               ]))
         | _, _ => M.impossible
         end.
@@ -4123,10 +4260,10 @@ Module ops.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::ops::range::Bound::Included",
                           0
@@ -4137,10 +4274,10 @@ Module ops.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -4151,8 +4288,8 @@ Module ops.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (| Value.StructTuple "core::ops::range::Bound::Unbounded" [] |)))
                 ]
               |)
@@ -4181,10 +4318,10 @@ Module ops.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::ops::range::Bound::Included",
                           0
@@ -4195,10 +4332,10 @@ Module ops.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::ops::range::Bound::Excluded",
                           0
@@ -4209,8 +4346,8 @@ Module ops.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (| Value.StructTuple "core::ops::range::Bound::Unbounded" [] |)))
                 ]
               |)
@@ -4250,7 +4387,7 @@ Module ops.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_tuple_field (M.read (| self |)) 0 |)))
+            M.read (| M.SubPointer.get_tuple_field (| M.read (| self |), 0 |) |)))
         | _, _ => M.impossible
         end.
       
@@ -4265,7 +4402,7 @@ Module ops.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_tuple_field (M.read (| self |)) 1 |)))
+            M.read (| M.SubPointer.get_tuple_field (| M.read (| self |), 1 |) |)))
         | _, _ => M.impossible
         end.
       
@@ -4301,10 +4438,11 @@ Module ops.
               "core::ops::range::Bound::Included"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::range::RangeFrom"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeFrom",
                     "start"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4372,7 +4510,11 @@ Module ops.
               "core::ops::range::Bound::Excluded"
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::RangeTo" "end"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeTo",
+                    "end"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4410,7 +4552,11 @@ Module ops.
               "core::ops::range::Bound::Included"
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "start"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "start"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4431,7 +4577,11 @@ Module ops.
               "core::ops::range::Bound::Excluded"
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::ops::range::Range" "end"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::Range",
+                    "end"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4469,10 +4619,11 @@ Module ops.
               "core::ops::range::Bound::Included"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::range::RangeInclusive"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeInclusive",
                     "start"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4493,10 +4644,11 @@ Module ops.
               "core::ops::range::Bound::Included"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::range::RangeInclusive"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeInclusive",
                     "end"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -4549,10 +4701,11 @@ Module ops.
               "core::ops::range::Bound::Included"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ops::range::RangeToInclusive"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ops::range::RangeToInclusive",
                     "end"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible

--- a/CoqOfRust/core/ops/try_trait.v
+++ b/CoqOfRust/core/ops/try_trait.v
@@ -190,7 +190,11 @@ Module ops.
               "core::ops::control_flow::ControlFlow::Continue"
               [
                 M.read (|
-                  M.get_struct_tuple_field self "core::ops::try_trait::NeverShortCircuit" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::ops::try_trait::NeverShortCircuit",
+                    0
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -301,7 +305,11 @@ Module ops.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::ops::try_trait::Yeet" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::ops::try_trait::Yeet",
+                      0
+                    |)
                   |))
               ]
             |)))

--- a/CoqOfRust/core/option.v
+++ b/CoqOfRust/core/option.v
@@ -71,11 +71,11 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
@@ -83,7 +83,7 @@ Module option.
                     let __self_0 := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -218,11 +218,11 @@ Module option.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_0,
                                 "core::option::Option::Some",
                                 0
@@ -230,7 +230,7 @@ Module option.
                             let __self_0 := M.alloc (| γ2_0 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_1,
                                 "core::option::Option::Some",
                                 0
@@ -298,7 +298,7 @@ Module option.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -369,7 +369,7 @@ Module option.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -418,7 +418,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -458,7 +458,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -534,7 +534,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -576,7 +576,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -644,7 +644,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -725,7 +725,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -955,7 +955,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1003,7 +1003,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1053,7 +1053,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1096,7 +1096,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1151,7 +1151,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1247,7 +1247,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1299,7 +1299,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1356,7 +1356,7 @@ Module option.
                     ltac:(M.monadic
                       (let γ := self in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1414,7 +1414,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1470,7 +1470,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1534,7 +1534,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1581,7 +1581,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1649,7 +1649,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1710,7 +1710,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1838,7 +1838,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1879,7 +1879,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1940,7 +1940,7 @@ Module option.
                         ltac:(M.monadic
                           (let γ := self in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -2020,7 +2020,7 @@ Module option.
                   ltac:(M.monadic
                     (let x := M.copy (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2061,7 +2061,7 @@ Module option.
                   ltac:(M.monadic
                     (let x := M.copy (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2113,11 +2113,11 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
@@ -2125,11 +2125,11 @@ Module option.
                     a));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let b := M.copy (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -2511,17 +2511,17 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
                       |) in
                     let a := M.copy (| γ1_0 |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -2567,17 +2567,17 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
                       |) in
                     let a := M.copy (| γ1_0 |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -2637,13 +2637,13 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
-                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                    let γ1_1 := M.get_tuple_field γ0_0 1 in
+                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                     let a := M.copy (| γ1_0 |) in
                     let b := M.copy (| γ1_1 |) in
                     M.alloc (|
@@ -2703,7 +2703,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2749,7 +2749,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2806,7 +2806,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2852,7 +2852,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2909,13 +2909,13 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Ok",
                         0
@@ -2929,13 +2929,13 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
                       |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Err",
                         0
@@ -3004,7 +3004,7 @@ Module option.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -3051,11 +3051,11 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
@@ -3063,7 +3063,7 @@ Module option.
                     let to := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -3077,8 +3077,8 @@ Module option.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let to := M.copy (| γ0_0 |) in
                     let from := M.copy (| γ0_1 |) in
                     M.write (|
@@ -3439,11 +3439,11 @@ Module option.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
@@ -3451,7 +3451,7 @@ Module option.
                     let l := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::option::Option::Some",
                         0
@@ -3465,8 +3465,8 @@ Module option.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     M.alloc (| Value.Bool true |)));
@@ -4760,7 +4760,13 @@ Module option.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::option::Item" "opt" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::option::Item",
+                      "opt"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -4799,7 +4805,11 @@ Module option.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::option::Item" "opt"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::option::Item",
+                    "opt"
+                  |)
                 |))
             ]
           |)))
@@ -4838,7 +4848,13 @@ Module option.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::Item" "opt" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Item",
+                "opt"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4859,12 +4875,16 @@ Module option.
           (let self := M.alloc (| self |) in
           M.read (|
             M.match_operator (|
-              M.get_struct_record_field (M.read (| self |)) "core::option::Item" "opt",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Item",
+                "opt"
+              |),
               [
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -4929,7 +4949,13 @@ Module option.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::Item" "opt" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Item",
+                "opt"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5011,7 +5037,11 @@ Module option.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::option::Iter" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::option::Iter",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -5052,7 +5082,13 @@ Module option.
               "next",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::Iter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Iter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5076,7 +5112,13 @@ Module option.
               "size_hint",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::Iter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Iter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5117,7 +5159,13 @@ Module option.
               "next_back",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::Iter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::Iter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5193,7 +5241,13 @@ Module option.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::option::Iter" "inner" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::option::Iter",
+                      "inner"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -5240,7 +5294,11 @@ Module option.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::option::IterMut" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::option::IterMut",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -5281,7 +5339,13 @@ Module option.
               "next",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IterMut" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IterMut",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5305,7 +5369,13 @@ Module option.
               "size_hint",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IterMut" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IterMut",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5346,7 +5416,13 @@ Module option.
               "next_back",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IterMut" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IterMut",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5425,7 +5501,13 @@ Module option.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::option::IntoIter" "inner" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::option::IntoIter",
+                      "inner"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -5464,7 +5546,11 @@ Module option.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::option::IntoIter" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::option::IntoIter",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -5505,7 +5591,13 @@ Module option.
               "next",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IntoIter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IntoIter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5529,7 +5621,13 @@ Module option.
               "size_hint",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IntoIter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IntoIter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5570,7 +5668,13 @@ Module option.
               "next_back",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::option::IntoIter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::option::IntoIter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -5765,7 +5869,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -5861,11 +5965,7 @@ Module option.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::ops::try_trait::Yeet",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::ops::try_trait::Yeet", 0 |) in
                   Value.StructTuple "core::option::Option::None" []))
             ]
           |)))
@@ -5923,7 +6023,7 @@ Module option.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0

--- a/CoqOfRust/core/panic/location.v
+++ b/CoqOfRust/core/panic/location.v
@@ -81,25 +81,28 @@ Module panic.
                 M.read (| Value.String "file" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::location::Location"
-                    "file");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::location::Location",
+                    "file"
+                  |));
                 M.read (| Value.String "line" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::location::Location"
-                    "line");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::location::Location",
+                    "line"
+                  |));
                 M.read (| Value.String "col" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::panic::location::Location"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::panic::location::Location",
                       "col"
+                    |)
                   |))
               ]
             |)))
@@ -181,10 +184,11 @@ Module panic.
                       [ __H ]
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::panic::location::Location"
-                        "file";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::panic::location::Location",
+                        "file"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -194,10 +198,11 @@ Module panic.
                   M.call_closure (|
                     M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::panic::location::Location"
-                        "line";
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::panic::location::Location",
+                        "line"
+                      |);
                       M.read (| state |)
                     ]
                   |)
@@ -206,10 +211,11 @@ Module panic.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::panic::location::Location"
-                      "col";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::panic::location::Location",
+                      "col"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -248,14 +254,16 @@ Module panic.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::panic::location::Location"
-                        "file";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::panic::location::Location"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::panic::location::Location",
                         "file"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::panic::location::Location",
+                        "file"
+                      |)
                     ]
                   |)
                 |),
@@ -267,14 +275,16 @@ Module panic.
                           M.call_closure (|
                             M.get_trait_method (| "core::cmp::Ord", Ty.path "u32", [], "cmp", [] |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::panic::location::Location"
-                                "line";
-                              M.get_struct_record_field
-                                (M.read (| other |))
-                                "core::panic::location::Location"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::panic::location::Location",
                                 "line"
+                              |);
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| other |),
+                                "core::panic::location::Location",
+                                "line"
+                              |)
                             ]
                           |)
                         |),
@@ -291,14 +301,16 @@ Module panic.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::panic::location::Location"
-                                      "col";
-                                    M.get_struct_record_field
-                                      (M.read (| other |))
-                                      "core::panic::location::Location"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::panic::location::Location",
                                       "col"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| other |),
+                                      "core::panic::location::Location",
+                                      "col"
+                                    |)
                                   ]
                                 |)
                               |)));
@@ -358,44 +370,50 @@ Module panic.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::panic::location::Location"
-                      "file";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::panic::location::Location"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::panic::location::Location",
                       "file"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::panic::location::Location",
+                      "file"
+                    |)
                   ]
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::panic::location::Location"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::panic::location::Location",
                         "line"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::panic::location::Location"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::panic::location::Location",
                         "line"
+                      |)
                     |))))
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::panic::location::Location"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::panic::location::Location",
                       "col"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::panic::location::Location"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::panic::location::Location",
                       "col"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -431,14 +449,16 @@ Module panic.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::panic::location::Location"
-                        "file";
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::panic::location::Location"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::panic::location::Location",
                         "file"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::panic::location::Location",
+                        "file"
+                      |)
                     ]
                   |)
                 |),
@@ -446,7 +466,7 @@ Module panic.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -462,14 +482,16 @@ Module panic.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::panic::location::Location"
-                                "line";
-                              M.get_struct_record_field
-                                (M.read (| other |))
-                                "core::panic::location::Location"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::panic::location::Location",
                                 "line"
+                              |);
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| other |),
+                                "core::panic::location::Location",
+                                "line"
+                              |)
                             ]
                           |)
                         |),
@@ -477,7 +499,7 @@ Module panic.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -492,14 +514,16 @@ Module panic.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::panic::location::Location"
-                                      "col";
-                                    M.get_struct_record_field
-                                      (M.read (| other |))
-                                      "core::panic::location::Location"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::panic::location::Location",
                                       "col"
+                                    |);
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| other |),
+                                      "core::panic::location::Location",
+                                      "col"
+                                    |)
                                   ]
                                 |)
                               |)));
@@ -556,7 +580,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::panic::location::Location" "file"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::location::Location",
+                "file"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -574,7 +602,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::panic::location::Location" "line"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::location::Location",
+                "line"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -592,7 +624,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::panic::location::Location" "col"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::location::Location",
+                "col"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -665,10 +701,11 @@ Module panic.
                                 [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::panic::location::Location"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::panic::location::Location",
                                   "file"
+                                |)
                               ]
                             |);
                             M.call_closure (|
@@ -678,10 +715,11 @@ Module panic.
                                 [ Ty.path "u32" ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::panic::location::Location"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::panic::location::Location",
                                   "line"
+                                |)
                               ]
                             |);
                             M.call_closure (|
@@ -691,10 +729,11 @@ Module panic.
                                 [ Ty.path "u32" ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::panic::location::Location"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::panic::location::Location",
                                   "col"
+                                |)
                               ]
                             |)
                           ]

--- a/CoqOfRust/core/panic/panic_info.v
+++ b/CoqOfRust/core/panic/panic_info.v
@@ -42,39 +42,44 @@ Module panic.
                 M.read (| Value.String "payload" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
-                    "payload");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
+                    "payload"
+                  |));
                 M.read (| Value.String "message" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
-                    "message");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
+                    "message"
+                  |));
                 M.read (| Value.String "location" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
-                    "location");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
+                    "location"
+                  |));
                 M.read (| Value.String "can_unwind" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
-                    "can_unwind");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
+                    "can_unwind"
+                  |));
                 M.read (| Value.String "force_no_backtrace" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::panic::panic_info::PanicInfo"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::panic::panic_info::PanicInfo",
                       "force_no_backtrace"
+                    |)
                   |))
               ]
             |)))
@@ -147,10 +152,11 @@ Module panic.
             M.read (|
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
-                    "payload",
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
+                    "payload"
+                  |),
                   (* Unsize *) M.pointer_coercion (M.read (| info |))
                 |) in
               M.alloc (| Value.Tuple [] |)
@@ -175,10 +181,11 @@ Module panic.
               (* Unsize *)
               (M.pointer_coercion
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
                     "payload"
+                  |)
                 |)))))
         | _, _ => M.impossible
         end.
@@ -196,10 +203,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::panic::panic_info::PanicInfo"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::panic_info::PanicInfo",
                 "message"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -222,10 +230,11 @@ Module panic.
               "core::option::Option::Some"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::panic::panic_info::PanicInfo"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::panic::panic_info::PanicInfo",
                     "location"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -244,10 +253,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::panic::panic_info::PanicInfo"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::panic_info::PanicInfo",
                 "can_unwind"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -265,10 +275,11 @@ Module panic.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::panic::panic_info::PanicInfo"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::panic::panic_info::PanicInfo",
                 "force_no_backtrace"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -336,7 +347,7 @@ Module panic.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -372,7 +383,7 @@ Module panic.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -405,10 +416,11 @@ Module panic.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::panic::panic_info::PanicInfo"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::panic::panic_info::PanicInfo",
                                     "location"
+                                  |)
                                 |);
                                 M.read (| formatter |)
                               ]
@@ -420,7 +432,7 @@ Module panic.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -456,7 +468,7 @@ Module panic.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -472,12 +484,13 @@ Module panic.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ :=
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::panic::panic_info::PanicInfo"
-                                "message" in
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::panic::panic_info::PanicInfo",
+                                "message"
+                              |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -513,7 +526,7 @@ Module panic.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -549,7 +562,7 @@ Module panic.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -588,7 +601,7 @@ Module panic.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Break",
                                           0
@@ -624,7 +637,7 @@ Module panic.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::ops::control_flow::ControlFlow::Continue",
                                           0
@@ -651,16 +664,17 @@ Module panic.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::panic::panic_info::PanicInfo"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::panic::panic_info::PanicInfo",
                                                 "payload"
+                                              |)
                                             |)
                                           ]
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -699,7 +713,7 @@ Module panic.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -738,7 +752,7 @@ Module panic.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0
@@ -779,7 +793,7 @@ Module panic.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Break",
                                                   0
@@ -818,7 +832,7 @@ Module panic.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                   0

--- a/CoqOfRust/core/panic/unwind_safe.v
+++ b/CoqOfRust/core/panic/unwind_safe.v
@@ -277,10 +277,11 @@ Module panic.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_tuple_field
-              (M.read (| self |))
-              "core::panic::unwind_safe::AssertUnwindSafe"
-              0))
+            M.SubPointer.get_struct_tuple_field (|
+              M.read (| self |),
+              "core::panic::unwind_safe::AssertUnwindSafe",
+              0
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -309,10 +310,11 @@ Module panic.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_tuple_field
-              (M.read (| self |))
-              "core::panic::unwind_safe::AssertUnwindSafe"
-              0))
+            M.SubPointer.get_struct_tuple_field (|
+              M.read (| self |),
+              "core::panic::unwind_safe::AssertUnwindSafe",
+              0
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -354,7 +356,11 @@ Module panic.
               |),
               [
                 M.read (|
-                  M.get_struct_tuple_field self "core::panic::unwind_safe::AssertUnwindSafe" 0
+                  M.SubPointer.get_struct_tuple_field (|
+                    self,
+                    "core::panic::unwind_safe::AssertUnwindSafe",
+                    0
+                  |)
                 |);
                 Value.Tuple []
               ]
@@ -417,10 +423,11 @@ Module panic.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::panic::unwind_safe::AssertUnwindSafe"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::panic::unwind_safe::AssertUnwindSafe",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -537,10 +544,11 @@ Module panic.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let x := M.copy (| γ |) in
-                                      M.get_struct_tuple_field
-                                        (M.read (| x |))
-                                        "core::panic::unwind_safe::AssertUnwindSafe"
-                                        0))
+                                      M.SubPointer.get_struct_tuple_field (|
+                                        M.read (| x |),
+                                        "core::panic::unwind_safe::AssertUnwindSafe",
+                                        0
+                                      |)))
                                 ]
                               |)
                             | _ => M.impossible (||)
@@ -638,10 +646,11 @@ Module panic.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let x := M.copy (| γ |) in
-                                    M.get_struct_tuple_field
-                                      (M.read (| x |))
-                                      "core::panic::unwind_safe::AssertUnwindSafe"
-                                      0))
+                                    M.SubPointer.get_struct_tuple_field (|
+                                      M.read (| x |),
+                                      "core::panic::unwind_safe::AssertUnwindSafe",
+                                      0
+                                    |)))
                               ]
                             |)
                           | _ => M.impossible (||)
@@ -674,10 +683,11 @@ Module panic.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::panic::unwind_safe::AssertUnwindSafe"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::panic::unwind_safe::AssertUnwindSafe",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/panicking.v
+++ b/CoqOfRust/core/panicking.v
@@ -741,11 +741,7 @@ Module panicking.
                       |)
                     |) in
                   let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let msg := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.call_closure (|
@@ -947,10 +943,11 @@ Module panicking.
               [
                 M.read (| f |);
                 M.read (|
-                  M.get_struct_tuple_field
-                    (M.read (| self |))
-                    "core::panicking::assert_matches_failed::Pattern"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "core::panicking::assert_matches_failed::Pattern",
                     0
+                  |)
                 |)
               ]
             |)))
@@ -1019,11 +1016,7 @@ Module panicking.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let args := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/core/pin.v
+++ b/CoqOfRust/core/pin.v
@@ -37,7 +37,13 @@ Module pin.
               ("pointer",
                 M.call_closure (|
                   M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::pin::Pin",
+                      "pointer"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -555,7 +561,7 @@ Module pin.
       | [], [ pin ] =>
         ltac:(M.monadic
           (let pin := M.alloc (| pin |) in
-          M.read (| M.get_struct_record_field pin "core::pin::Pin" "pointer" |)))
+          M.read (| M.SubPointer.get_struct_record_field (| pin, "core::pin::Pin", "pointer" |) |)))
       | _, _ => M.impossible
       end.
     
@@ -602,7 +608,13 @@ Module pin.
             [
               M.call_closure (|
                 M.get_trait_method (| "core::ops::deref::Deref", P, [], "deref", [] |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::pin::Pin",
+                    "pointer"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -624,7 +636,7 @@ Module pin.
       | [], [ pin ] =>
         ltac:(M.monadic
           (let pin := M.alloc (| pin |) in
-          M.read (| M.get_struct_record_field pin "core::pin::Pin" "pointer" |)))
+          M.read (| M.SubPointer.get_struct_record_field (| pin, "core::pin::Pin", "pointer" |) |)))
       | _, _ => M.impossible
       end.
     
@@ -652,7 +664,13 @@ Module pin.
             [
               M.call_closure (|
                 M.get_trait_method (| "core::ops::deref::DerefMut", P, [], "deref_mut", [] |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer" ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::pin::Pin",
+                    "pointer"
+                  |)
+                ]
               |)
             ]
           |)))
@@ -683,7 +701,13 @@ Module pin.
               M.write (|
                 M.call_closure (|
                   M.get_trait_method (| "core::ops::deref::DerefMut", P, [], "deref_mut", [] |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::pin::Pin",
+                      "pointer"
+                    |)
+                  ]
                 |),
                 M.read (| value |)
               |) in
@@ -725,7 +749,9 @@ Module pin.
           M.read (|
             let pointer :=
               M.alloc (|
-                M.read (| M.get_struct_record_field self "core::pin::Pin" "pointer" |)
+                M.read (|
+                  M.SubPointer.get_struct_record_field (| self, "core::pin::Pin", "pointer" |)
+                |)
               |) in
             let new_pointer :=
               M.alloc (|
@@ -769,7 +795,9 @@ Module pin.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "core::pin::Pin" "pointer" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "core::pin::Pin", "pointer" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -822,7 +850,11 @@ Module pin.
           (let self := M.alloc (| self |) in
           Value.StructRecord
             "core::pin::Pin"
-            [ ("pointer", M.read (| M.get_struct_record_field self "core::pin::Pin" "pointer" |))
+            [
+              ("pointer",
+                M.read (|
+                  M.SubPointer.get_struct_record_field (| self, "core::pin::Pin", "pointer" |)
+                |))
             ]))
       | _, _ => M.impossible
       end.
@@ -845,7 +877,9 @@ Module pin.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "core::pin::Pin" "pointer" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "core::pin::Pin", "pointer" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -864,7 +898,9 @@ Module pin.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "core::pin::Pin" "pointer" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (| self, "core::pin::Pin", "pointer" |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -1150,7 +1186,11 @@ Module pin.
           M.call_closure (|
             M.get_trait_method (| "core::fmt::Debug", P, [], "fmt", [] |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::pin::Pin",
+                "pointer"
+              |);
               M.read (| f |)
             ]
           |)))
@@ -1184,7 +1224,11 @@ Module pin.
           M.call_closure (|
             M.get_trait_method (| "core::fmt::Display", P, [], "fmt", [] |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::pin::Pin",
+                "pointer"
+              |);
               M.read (| f |)
             ]
           |)))
@@ -1218,7 +1262,11 @@ Module pin.
           M.call_closure (|
             M.get_trait_method (| "core::fmt::Pointer", P, [], "fmt", [] |),
             [
-              M.get_struct_record_field (M.read (| self |)) "core::pin::Pin" "pointer";
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::pin::Pin",
+                "pointer"
+              |);
               M.read (| f |)
             ]
           |)))

--- a/CoqOfRust/core/ptr/alignment.v
+++ b/CoqOfRust/core/ptr/alignment.v
@@ -77,8 +77,16 @@ Module ptr.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::ptr::alignment::Alignment" 0;
-                M.get_struct_tuple_field (M.read (| other |)) "core::ptr::alignment::Alignment" 0
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::ptr::alignment::Alignment",
+                  0
+                |);
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "core::ptr::alignment::Alignment",
+                  0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -147,7 +155,7 @@ Module ptr.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::ptr::alignment::Alignment",
                         0
@@ -374,7 +382,9 @@ Module ptr.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.rust_cast
-              (M.read (| M.get_struct_tuple_field self "core::ptr::alignment::Alignment" 0 |))))
+              (M.read (|
+                M.SubPointer.get_struct_tuple_field (| self, "core::ptr::alignment::Alignment", 0 |)
+              |))))
         | _, _ => M.impossible
         end.
       

--- a/CoqOfRust/core/ptr/const_ptr.v
+++ b/CoqOfRust/core/ptr/const_ptr.v
@@ -1013,7 +1013,7 @@ Module ptr.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0

--- a/CoqOfRust/core/ptr/metadata.v
+++ b/CoqOfRust/core/ptr/metadata.v
@@ -22,17 +22,19 @@ Module ptr.
         ltac:(M.monadic
           (let ptr := M.alloc (| ptr |) in
           M.read (|
-            M.get_struct_record_field
-              (M.get_struct_record_field
-                (M.alloc (|
+            M.SubPointer.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.alloc (|
                   Value.StructRecord
                     "core::ptr::metadata::PtrRepr"
                     [ ("const_ptr", M.read (| ptr |)) ]
-                |))
-                "core::ptr::metadata::PtrRepr"
-                "components")
-              "core::ptr::metadata::PtrComponents"
+                |),
+                "core::ptr::metadata::PtrRepr",
+                "components"
+              |),
+              "core::ptr::metadata::PtrComponents",
               "metadata"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -55,8 +57,8 @@ Module ptr.
           (let data_address := M.alloc (| data_address |) in
           let metadata := M.alloc (| metadata |) in
           M.read (|
-            M.get_struct_record_field
-              (M.alloc (|
+            M.SubPointer.get_struct_record_field (|
+              M.alloc (|
                 Value.StructRecord
                   "core::ptr::metadata::PtrRepr"
                   [
@@ -68,9 +70,10 @@ Module ptr.
                           ("metadata", M.read (| metadata |))
                         ])
                   ]
-              |))
-              "core::ptr::metadata::PtrRepr"
+              |),
+              "core::ptr::metadata::PtrRepr",
               "const_ptr"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -93,8 +96,8 @@ Module ptr.
           (let data_address := M.alloc (| data_address |) in
           let metadata := M.alloc (| metadata |) in
           M.read (|
-            M.get_struct_record_field
-              (M.alloc (|
+            M.SubPointer.get_struct_record_field (|
+              M.alloc (|
                 Value.StructRecord
                   "core::ptr::metadata::PtrRepr"
                   [
@@ -107,9 +110,10 @@ Module ptr.
                           ("metadata", M.read (| metadata |))
                         ])
                   ]
-              |))
-              "core::ptr::metadata::PtrRepr"
+              |),
+              "core::ptr::metadata::PtrRepr",
               "mut_ptr"
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -215,10 +219,11 @@ Module ptr.
                               M.use
                                 (M.alloc (|
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::ptr::metadata::DynMetadata"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ptr::metadata::DynMetadata",
                                       "vtable_ptr"
+                                    |)
                                   |)
                                 |))
                             |))
@@ -262,10 +267,11 @@ Module ptr.
                               M.use
                                 (M.alloc (|
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::ptr::metadata::DynMetadata"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ptr::metadata::DynMetadata",
                                       "vtable_ptr"
+                                    |)
                                   |)
                                 |))
                             |))
@@ -399,10 +405,11 @@ Module ptr.
                       (M.use
                         (M.alloc (|
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::ptr::metadata::DynMetadata"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::ptr::metadata::DynMetadata",
                               "vtable_ptr"
+                            |)
                           |)
                         |)))
                   ]
@@ -508,16 +515,18 @@ Module ptr.
               M.get_function (| "core::ptr::eq", [ Ty.path "core::ptr::metadata::VTable" ] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ptr::metadata::DynMetadata"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ptr::metadata::DynMetadata",
                     "vtable_ptr"
+                  |)
                 |);
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::ptr::metadata::DynMetadata"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::ptr::metadata::DynMetadata",
                     "vtable_ptr"
+                  |)
                 |)
               ]
             |)))
@@ -561,19 +570,21 @@ Module ptr.
                 M.use
                   (M.alloc (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::ptr::metadata::DynMetadata"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::ptr::metadata::DynMetadata",
                         "vtable_ptr"
+                      |)
                     |)
                   |));
                 M.use
                   (M.alloc (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::ptr::metadata::DynMetadata"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::ptr::metadata::DynMetadata",
                         "vtable_ptr"
+                      |)
                     |)
                   |))
               ]
@@ -652,10 +663,11 @@ Module ptr.
               M.get_function (| "core::ptr::hash", [ Ty.path "core::ptr::metadata::VTable"; H ] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::ptr::metadata::DynMetadata"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::ptr::metadata::DynMetadata",
                     "vtable_ptr"
+                  |)
                 |);
                 M.read (| hasher |)
               ]

--- a/CoqOfRust/core/ptr/mod.v
+++ b/CoqOfRust/core/ptr/mod.v
@@ -1875,7 +1875,7 @@ Module ptr.
               M.alloc (|
                 M.rust_cast
                   (M.read (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.get_constant (| "core::ptr::align_offset::mod_inv::INV_TABLE_MOD_16" |),
                       M.alloc (|
                         BinOp.Panic.shr (|
@@ -1956,8 +1956,8 @@ Module ptr.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let new_gate := M.copy (| γ0_0 |) in
                           let overflow := M.copy (| γ0_1 |) in
                           let _ :=

--- a/CoqOfRust/core/ptr/non_null.v
+++ b/CoqOfRust/core/ptr/non_null.v
@@ -399,7 +399,11 @@ Module ptr.
                   M.get_associated_function (| Ty.apply (Ty.path "*const") [ T ], "addr", [] |),
                   [
                     M.read (|
-                      M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ptr::non_null::NonNull",
+                        "pointer"
+                      |)
                     |)
                   ]
                 |)
@@ -441,7 +445,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.call_closure (|
                         M.get_associated_function (|
@@ -527,7 +535,11 @@ Module ptr.
             (let self := M.alloc (| self |) in
             M.rust_cast
               (M.read (|
-                M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                M.SubPointer.get_struct_record_field (|
+                  self,
+                  "core::ptr::non_null::NonNull",
+                  "pointer"
+                |)
               |))))
         | _, _ => M.impossible
         end.
@@ -665,7 +677,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.read (| count |)
                     ]
@@ -707,7 +723,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.read (| count |)
                     ]
@@ -750,7 +770,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.read (| count |)
                     ]
@@ -792,7 +816,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.read (| count |)
                     ]
@@ -898,7 +926,11 @@ Module ptr.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ptr::non_null::NonNull",
+                          "pointer"
+                        |)
                       |);
                       M.read (| count |)
                     ]
@@ -931,10 +963,18 @@ Module ptr.
               M.get_associated_function (| Ty.apply (Ty.path "*const") [ T ], "offset_from", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.read (|
-                  M.get_struct_record_field origin "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    origin,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |)
               ]
             |)))
@@ -966,10 +1006,18 @@ Module ptr.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.read (|
-                  M.get_struct_record_field origin "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    origin,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |)
               ]
             |)))
@@ -1000,10 +1048,18 @@ Module ptr.
               M.get_associated_function (| Ty.apply (Ty.path "*const") [ T ], "sub_ptr", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.read (|
-                  M.get_struct_record_field subtracted "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    subtracted,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |)
               ]
             |)))
@@ -1031,7 +1087,14 @@ Module ptr.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::ptr::read", [ T ] |),
-              [ M.read (| M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1058,7 +1121,14 @@ Module ptr.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::ptr::read_volatile", [ T ] |),
-              [ M.read (| M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1085,7 +1155,14 @@ Module ptr.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_function (| "core::ptr::read_unaligned", [ T ] |),
-              [ M.read (| M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1116,7 +1193,11 @@ Module ptr.
               M.get_function (| "core::intrinsics::copy", [ T ] |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.call_closure (|
                   M.get_associated_function (|
@@ -1157,7 +1238,11 @@ Module ptr.
               M.get_function (| "core::intrinsics::copy_nonoverlapping", [ T ] |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.call_closure (|
                   M.get_associated_function (|
@@ -1197,7 +1282,13 @@ Module ptr.
             M.call_closure (|
               M.get_function (| "core::intrinsics::copy", [ T ] |),
               [
-                M.read (| M.get_struct_record_field src "core::ptr::non_null::NonNull" "pointer" |);
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    src,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |);
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ],
@@ -1236,7 +1327,13 @@ Module ptr.
             M.call_closure (|
               M.get_function (| "core::intrinsics::copy_nonoverlapping", [ T ] |),
               [
-                M.read (| M.get_struct_record_field src "core::ptr::non_null::NonNull" "pointer" |);
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    src,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |);
                 M.call_closure (|
                   M.get_associated_function (|
                     Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ],
@@ -1599,7 +1696,11 @@ Module ptr.
                   M.get_function (| "core::ptr::align_offset", [ T ] |),
                   [
                     M.read (|
-                      M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ptr::non_null::NonNull",
+                        "pointer"
+                      |)
                     |);
                     M.read (| align |)
                   ]
@@ -1629,7 +1730,14 @@ Module ptr.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.apply (Ty.path "*const") [ T ], "is_aligned", [] |),
-              [ M.read (| M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1659,7 +1767,11 @@ Module ptr.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::ptr::non_null::NonNull" "pointer"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::non_null::NonNull",
+                    "pointer"
+                  |)
                 |);
                 M.read (| align |)
               ]

--- a/CoqOfRust/core/ptr/unique.v
+++ b/CoqOfRust/core/ptr/unique.v
@@ -138,7 +138,7 @@ Module ptr.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -186,7 +186,15 @@ Module ptr.
                 "as_ptr",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::ptr::unique::Unique" "pointer" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ptr::unique::Unique",
+                    "pointer"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -214,7 +222,12 @@ Module ptr.
                 "as_ref",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::ptr::unique::Unique" "pointer"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ptr::unique::Unique",
+                  "pointer"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -243,7 +256,12 @@ Module ptr.
                 "as_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::ptr::unique::Unique" "pointer"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::ptr::unique::Unique",
+                  "pointer"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -288,7 +306,11 @@ Module ptr.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field self "core::ptr::unique::Unique" "pointer"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::ptr::unique::Unique",
+                            "pointer"
+                          |)
                         |)
                       ]
                     |)

--- a/CoqOfRust/core/result.v
+++ b/CoqOfRust/core/result.v
@@ -88,11 +88,11 @@ Module result.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_0,
                                 "core::result::Result::Ok",
                                 0
@@ -100,7 +100,7 @@ Module result.
                             let __self_0 := M.alloc (| γ2_0 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_1,
                                 "core::result::Result::Ok",
                                 0
@@ -114,11 +114,11 @@ Module result.
                             |)));
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_0,
                                 "core::result::Result::Err",
                                 0
@@ -126,7 +126,7 @@ Module result.
                             let __self_0 := M.alloc (| γ2_0 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_1,
                                 "core::result::Result::Err",
                                 0
@@ -203,11 +203,11 @@ Module result.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Ok",
                         0
@@ -215,7 +215,7 @@ Module result.
                     let __self_0 := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::result::Result::Ok",
                         0
@@ -235,11 +235,11 @@ Module result.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Err",
                         0
@@ -247,7 +247,7 @@ Module result.
                     let __self_0 := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::result::Result::Err",
                         0
@@ -389,11 +389,11 @@ Module result.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_0,
                                 "core::result::Result::Ok",
                                 0
@@ -401,7 +401,7 @@ Module result.
                             let __self_0 := M.alloc (| γ2_0 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_1,
                                 "core::result::Result::Ok",
                                 0
@@ -415,11 +415,11 @@ Module result.
                             |)));
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let γ0_0 := M.read (| γ0_0 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_0,
                                 "core::result::Result::Err",
                                 0
@@ -427,7 +427,7 @@ Module result.
                             let __self_0 := M.alloc (| γ2_0 |) in
                             let γ0_1 := M.read (| γ0_1 |) in
                             let γ2_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ0_1,
                                 "core::result::Result::Err",
                                 0
@@ -489,11 +489,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let __self_0 := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -513,11 +509,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let __self_0 := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -584,11 +576,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let __self_0 := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -600,11 +588,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let __self_0 := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -648,11 +632,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.Bool true |)));
                 fun γ => ltac:(M.monadic (M.alloc (| Value.Bool false |)))
               ]
@@ -687,20 +667,12 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (| Value.Bool false |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -773,20 +745,12 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.Bool false |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -831,11 +795,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| x |) ]
@@ -843,11 +803,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (| Value.StructTuple "core::option::Option::None" [] |)))
               ]
             |)
@@ -880,20 +836,12 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| x |) ]
@@ -929,21 +877,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.alloc (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| x |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let x := M.alloc (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| x |) ] |)))
               ]
@@ -977,21 +917,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.alloc (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| x |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let x := M.alloc (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| x |) ] |)))
               ]
@@ -1026,11 +958,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -1051,11 +979,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
@@ -1091,11 +1015,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -1112,11 +1032,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     default))
               ]
             |)
@@ -1151,11 +1067,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -1172,11 +1084,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -1222,21 +1130,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| t |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -1289,7 +1189,7 @@ Module result.
                     ltac:(M.monadic
                       (let γ := self in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -1346,7 +1246,7 @@ Module result.
                     ltac:(M.monadic
                       (let γ := self in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1627,21 +1527,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     t));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1685,21 +1577,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     t));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1746,21 +1630,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     x));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (|
                       M.call_closure (|
                         M.get_trait_method (| "core::default::Default", T, [], "default", [] |),
@@ -1802,11 +1678,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1819,11 +1691,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     e))
               ]
@@ -1860,11 +1728,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1882,11 +1746,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     e))
               ]
@@ -1923,21 +1783,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     x));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -1987,11 +1839,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -2010,11 +1858,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     e))
               ]
@@ -2049,20 +1893,12 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     res));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
@@ -2097,11 +1933,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -2118,11 +1950,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
@@ -2157,21 +1985,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let v := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| v |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     res))
               ]
             |)
@@ -2205,21 +2025,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| t |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -2265,21 +2077,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     t));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     default))
               ]
             |)
@@ -2313,21 +2117,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     t));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.call_closure (|
@@ -2421,21 +2217,13 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let t := M.copy (| γ0_0 |) in
                     t));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     M.alloc (|
                       M.never_to_any (|
                         M.call_closure (|
@@ -2525,11 +2313,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (|
                       M.never_to_any (|
                         M.call_closure (|
@@ -2541,11 +2325,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     e))
               ]
@@ -2793,13 +2573,9 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::option::Option::Some",
                         0
@@ -2813,20 +2589,12 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -2968,11 +2736,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let x := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -2988,11 +2752,7 @@ Module result.
                   ltac:(M.monadic
                     (let γ := M.read (| γ |) in
                     let γ1_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let x := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -3032,11 +2792,11 @@ Module result.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Ok",
                         0
@@ -3044,7 +2804,7 @@ Module result.
                     let to := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::result::Result::Ok",
                         0
@@ -3058,11 +2818,11 @@ Module result.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let γ0_0 := M.read (| γ0_0 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_0,
                         "core::result::Result::Err",
                         0
@@ -3070,7 +2830,7 @@ Module result.
                     let to := M.alloc (| γ2_0 |) in
                     let γ0_1 := M.read (| γ0_1 |) in
                     let γ2_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ0_1,
                         "core::result::Result::Err",
                         0
@@ -3084,8 +2844,8 @@ Module result.
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let to := M.copy (| γ0_0 |) in
                     let from := M.copy (| γ0_1 |) in
                     M.write (|
@@ -3294,7 +3054,11 @@ Module result.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::result::Iter" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::result::Iter",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -3333,7 +3097,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::Iter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::Iter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3370,10 +3140,11 @@ Module result.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::result::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::result::Iter",
                                     "inner"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -3427,7 +3198,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::Iter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::Iter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3496,7 +3273,11 @@ Module result.
             [
               ("inner",
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::result::Iter" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::result::Iter",
+                    "inner"
+                  |)
                 |))
             ]))
       | _, _ => M.impossible
@@ -3544,7 +3325,11 @@ Module result.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::result::IterMut" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::result::IterMut",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -3583,7 +3368,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::IterMut" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::IterMut",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3620,10 +3411,11 @@ Module result.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::result::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::result::IterMut",
                                     "inner"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -3677,7 +3469,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::IterMut" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::IterMut",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3756,7 +3554,13 @@ Module result.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::result::IntoIter" "inner" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::result::IntoIter",
+                      "inner"
+                    |)
+                  ]
                 |))
             ]))
       | _, _ => M.impossible
@@ -3795,7 +3599,11 @@ Module result.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (M.read (| self |)) "core::result::IntoIter" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::result::IntoIter",
+                    "inner"
+                  |)
                 |))
             ]
           |)))
@@ -3834,7 +3642,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::IntoIter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::IntoIter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -3869,10 +3683,11 @@ Module result.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::result::IntoIter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::result::IntoIter",
                                     "inner"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -3926,7 +3741,13 @@ Module result.
               "take",
               []
             |),
-            [ M.get_struct_record_field (M.read (| self |)) "core::result::IntoIter" "inner" ]
+            [
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::result::IntoIter",
+                "inner"
+              |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -4120,11 +3941,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let v := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -4134,11 +3951,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -4189,11 +4002,7 @@ Module result.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple
@@ -4244,11 +4053,7 @@ Module result.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::ops::try_trait::Yeet",
-                      0
-                    |) in
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::ops::try_trait::Yeet", 0 |) in
                   let e := M.copy (| γ0_0 |) in
                   Value.StructTuple
                     "core::result::Result::Err"

--- a/CoqOfRust/core/slice/ascii.v
+++ b/CoqOfRust/core/slice/ascii.v
@@ -187,8 +187,8 @@ Module slice.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let a := M.copy (| γ0_0 |) in
                                     let b := M.copy (| γ0_1 |) in
                                     M.call_closure (|
@@ -270,7 +270,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -359,7 +359,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -466,8 +466,8 @@ Module slice.
                           ltac:(M.monadic
                             (let γ := bytes in
                             let γ := M.read (| γ |) in
-                            let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                            let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                            let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                            let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                             let first := M.alloc (| γ1_0 |) in
                             let rest := M.alloc (| γ1_rest |) in
                             M.match_operator (|
@@ -553,8 +553,8 @@ Module slice.
                           ltac:(M.monadic
                             (let γ := bytes in
                             let γ := M.read (| γ |) in
-                            let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                            let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                            let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                            let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                             let rest := M.alloc (| γ1_rest |) in
                             let last := M.alloc (| γ1_rev0 |) in
                             M.match_operator (|
@@ -707,10 +707,11 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::ascii::EscapeAscii"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::ascii::EscapeAscii",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -756,10 +757,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::ascii::EscapeAscii"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::ascii::EscapeAscii",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -790,10 +792,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::ascii::EscapeAscii"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::ascii::EscapeAscii",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -830,10 +833,11 @@ Module slice.
                 [ Acc; Fold; R ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::ascii::EscapeAscii"
-                  "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::ascii::EscapeAscii",
+                  "inner"
+                |);
                 M.read (| init |);
                 M.read (| fold |)
               ]
@@ -872,7 +876,11 @@ Module slice.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::slice::ascii::EscapeAscii" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::slice::ascii::EscapeAscii",
+                    "inner"
+                  |)
                 |);
                 M.read (| init |);
                 M.read (| fold |)
@@ -948,10 +956,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::ascii::EscapeAscii"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::ascii::EscapeAscii",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1162,8 +1171,8 @@ Module slice.
                         ltac:(M.monadic
                           (let γ := bytes in
                           let γ := M.read (| γ |) in
-                          let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                          let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                          let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                          let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                           let rest := M.alloc (| γ1_rest |) in
                           let last := M.alloc (| γ1_rev0 |) in
                           let _ :=
@@ -1755,7 +1764,7 @@ Module slice.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0

--- a/CoqOfRust/core/slice/cmp.v
+++ b/CoqOfRust/core/slice/cmp.v
@@ -294,8 +294,8 @@ Module slice.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let x := M.copy (| γ0_0 |) in
                                         let y := M.copy (| γ0_1 |) in
                                         M.call_closure (|
@@ -589,7 +589,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -606,8 +606,14 @@ Module slice.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_array_field (| M.read (| lhs |), i |);
-                                                    M.get_array_field (| M.read (| rhs |), i |)
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| lhs |),
+                                                      i
+                                                    |);
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| rhs |),
+                                                      i
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -615,7 +621,7 @@ Module slice.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -1084,7 +1090,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -1101,8 +1107,14 @@ Module slice.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_array_field (| M.read (| lhs |), i |);
-                                                    M.get_array_field (| M.read (| rhs |), i |)
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| lhs |),
+                                                      i
+                                                    |);
+                                                    M.SubPointer.get_array_field (|
+                                                      M.read (| rhs |),
+                                                      i
+                                                    |)
                                                   ]
                                                 |)
                                               |),

--- a/CoqOfRust/core/slice/index.v
+++ b/CoqOfRust/core/slice/index.v
@@ -1071,7 +1071,7 @@ Module slice.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             let slice := M.alloc (| slice |) in
-            M.get_array_field (| M.read (| slice |), self |)))
+            M.SubPointer.get_array_field (| M.read (| slice |), self |)))
         | _, _ => M.impossible
         end.
       
@@ -1088,7 +1088,7 @@ Module slice.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             let slice := M.alloc (| slice |) in
-            M.get_array_field (| M.read (| slice |), self |)))
+            M.SubPointer.get_array_field (| M.read (| slice |), self |)))
         | _, _ => M.impossible
         end.
       
@@ -1773,15 +1773,27 @@ Module slice.
                             LogicalOp.or (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |)),
                               ltac:(M.monadic
                                 (BinOp.Pure.gt
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "end"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "end"
+                                    |)
                                   |))
                                   (M.call_closure (|
                                     M.get_associated_function (|
@@ -1848,15 +1860,27 @@ Module slice.
                             LogicalOp.or (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |)),
                               ltac:(M.monadic
                                 (BinOp.Pure.gt
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "end"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "end"
+                                    |)
                                   |))
                                   (M.call_closure (|
                                     M.get_associated_function (|
@@ -1939,24 +1963,27 @@ Module slice.
                                         (LogicalOp.and (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |)),
                                           ltac:(M.monadic
                                             (BinOp.Pure.le
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::ops::range::Range"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::ops::range::Range",
                                                   "end"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -2019,8 +2046,20 @@ Module slice.
                   M.call_closure (|
                     M.get_function (| "core::intrinsics::unchecked_sub", [ Ty.path "usize" ] |),
                     [
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "end" |);
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "end"
+                        |)
+                      |);
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
+                      |)
                     ]
                   |)
                 |) in
@@ -2040,7 +2079,11 @@ Module slice.
                           [ M.read (| slice |) ]
                         |);
                         M.read (|
-                          M.get_struct_record_field self "core::ops::range::Range" "start"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::ops::range::Range",
+                            "start"
+                          |)
                         |)
                       ]
                     |);
@@ -2094,24 +2137,27 @@ Module slice.
                                         (LogicalOp.and (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |)),
                                           ltac:(M.monadic
                                             (BinOp.Pure.le
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::ops::range::Range"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::ops::range::Range",
                                                   "end"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -2174,8 +2220,20 @@ Module slice.
                   M.call_closure (|
                     M.get_function (| "core::intrinsics::unchecked_sub", [ Ty.path "usize" ] |),
                     [
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "end" |);
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "end"
+                        |)
+                      |);
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
+                      |)
                     ]
                   |)
                 |) in
@@ -2195,7 +2253,11 @@ Module slice.
                           [ M.read (| slice |) ]
                         |);
                         M.read (|
-                          M.get_struct_record_field self "core::ops::range::Range" "start"
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "core::ops::range::Range",
+                            "start"
+                          |)
                         |)
                       ]
                     |);
@@ -2237,10 +2299,18 @@ Module slice.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
@@ -2251,10 +2321,18 @@ Module slice.
                               M.get_function (| "core::slice::index::slice_index_order_fail", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2272,10 +2350,11 @@ Module slice.
                                     (M.alloc (|
                                       BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "core::ops::range::Range"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::ops::range::Range",
                                             "end"
+                                          |)
                                         |))
                                         (M.call_closure (|
                                           M.get_associated_function (|
@@ -2300,10 +2379,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "core::ops::range::Range"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::ops::range::Range",
                                             "end"
+                                          |)
                                         |);
                                         M.call_closure (|
                                           M.get_associated_function (|
@@ -2368,10 +2448,18 @@ Module slice.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |))
                                 (M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
@@ -2382,10 +2470,18 @@ Module slice.
                               M.get_function (| "core::slice::index::slice_index_order_fail", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "start"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "start"
+                                  |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::Range" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::Range",
+                                    "end"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2403,10 +2499,11 @@ Module slice.
                                     (M.alloc (|
                                       BinOp.Pure.gt
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "core::ops::range::Range"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::ops::range::Range",
                                             "end"
+                                          |)
                                         |))
                                         (M.call_closure (|
                                           M.get_associated_function (|
@@ -2431,10 +2528,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            self
-                                            "core::ops::range::Range"
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::ops::range::Range",
                                             "end"
+                                          |)
                                         |);
                                         M.call_closure (|
                                           M.get_associated_function (|
@@ -2520,7 +2618,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2554,7 +2658,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2589,7 +2699,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2624,7 +2740,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2658,7 +2780,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2692,7 +2820,13 @@ Module slice.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -2751,7 +2885,11 @@ Module slice.
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |)
                       |));
                     ("end_",
                       M.call_closure (|
@@ -2791,7 +2929,11 @@ Module slice.
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |)
                       |));
                     ("end_",
                       M.call_closure (|
@@ -2832,7 +2974,11 @@ Module slice.
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |)
                       |));
                     ("end_",
                       M.call_closure (|
@@ -2877,7 +3023,11 @@ Module slice.
                   [
                     ("start",
                       M.read (|
-                        M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |)
                       |));
                     ("end_",
                       M.call_closure (|
@@ -2923,10 +3073,11 @@ Module slice.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |))
                                 (M.call_closure (|
                                   M.get_associated_function (|
@@ -2948,10 +3099,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |);
                                 M.call_closure (|
                                   M.get_associated_function (|
@@ -3012,10 +3164,11 @@ Module slice.
                             (M.alloc (|
                               BinOp.Pure.gt
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |))
                                 (M.call_closure (|
                                   M.get_associated_function (|
@@ -3037,10 +3190,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |);
                                 M.call_closure (|
                                   M.get_associated_function (|
@@ -3649,7 +3803,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3689,7 +3847,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3730,7 +3892,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3771,7 +3937,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3811,7 +3981,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3851,7 +4025,11 @@ Module slice.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -3922,7 +4100,13 @@ Module slice.
           let bounds := M.alloc (| bounds |) in
           M.read (|
             let len :=
-              M.copy (| M.get_struct_record_field bounds "core::ops::range::RangeTo" "end" |) in
+              M.copy (|
+                M.SubPointer.get_struct_record_field (|
+                  bounds,
+                  "core::ops::range::RangeTo",
+                  "end"
+                |)
+              |) in
             let start :=
               M.alloc (|
                 M.call_closure (|
@@ -3944,7 +4128,7 @@ Module slice.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Included",
                             0
@@ -3955,7 +4139,7 @@ Module slice.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Excluded",
                             0
@@ -4024,7 +4208,7 @@ Module slice.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Included",
                             0
@@ -4071,7 +4255,7 @@ Module slice.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::range::Bound::Excluded",
                             0
@@ -4164,8 +4348,8 @@ Module slice.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let start := M.copy (| γ0_0 |) in
                   let end_ := M.copy (| γ0_1 |) in
                   M.read (|
@@ -4177,7 +4361,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Included",
                                     0
@@ -4187,7 +4371,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Excluded",
                                     0
@@ -4211,7 +4395,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Included",
                                     0
@@ -4226,7 +4410,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Excluded",
                                     0
@@ -4283,8 +4467,8 @@ Module slice.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let start := M.copy (| γ0_0 |) in
                   let end_ := M.copy (| γ0_1 |) in
                   M.catch_return (|
@@ -4298,7 +4482,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::range::Bound::Included",
                                         0
@@ -4308,7 +4492,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::range::Bound::Excluded",
                                         0
@@ -4342,7 +4526,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -4379,7 +4563,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -4401,7 +4585,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::range::Bound::Included",
                                         0
@@ -4435,7 +4619,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Break",
                                                 0
@@ -4472,7 +4656,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::ops::control_flow::ControlFlow::Continue",
                                                 0
@@ -4484,7 +4668,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::range::Bound::Excluded",
                                         0
@@ -4550,8 +4734,8 @@ Module slice.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let start := M.copy (| γ0_0 |) in
                   let end_ := M.copy (| γ0_1 |) in
                   M.read (|
@@ -4563,7 +4747,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Included",
                                     0
@@ -4573,7 +4757,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Excluded",
                                     0
@@ -4633,7 +4817,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Included",
                                     0
@@ -4684,7 +4868,7 @@ Module slice.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::range::Bound::Excluded",
                                     0
@@ -4776,7 +4960,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -4813,7 +4997,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -4889,7 +5073,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -4926,7 +5110,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0

--- a/CoqOfRust/core/slice/iter.v
+++ b/CoqOfRust/core/slice/iter.v
@@ -342,21 +342,27 @@ Module slice.
               [
                 ("ptr",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Iter" "ptr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Iter",
+                      "ptr"
+                    |)
                   |));
                 ("end_or_len",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Iter",
                       "end_or_len"
+                    |)
                   |));
                 ("_marker",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Iter"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Iter",
                       "_marker"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -656,7 +662,15 @@ Module slice.
                     "as_ptr",
                     []
                   |),
-                  [ M.read (| M.get_struct_record_field self "core::slice::iter::IterMut" "ptr" |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::slice::iter::IterMut",
+                        "ptr"
+                      |)
+                    |)
+                  ]
                 |);
                 M.read (|
                   M.match_operator (|
@@ -678,10 +692,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::slice::iter::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::slice::iter::IterMut",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -698,10 +713,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    self
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -715,7 +731,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::IterMut" "ptr"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::IterMut",
+                                    "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -783,10 +803,11 @@ Module slice.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::IterMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::IterMut",
                         "ptr"
+                      |)
                     |)
                   ]
                 |);
@@ -810,10 +831,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::IterMut",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -830,10 +852,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -847,10 +870,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -965,10 +989,11 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
@@ -977,10 +1002,11 @@ Module slice.
                     ltac:(M.monadic
                       (M.alloc (|
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
                             "v"
+                          |)
                         |)
                       |)))
                 ]
@@ -1043,19 +1069,21 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::Split"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Split",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -1091,24 +1119,30 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Split" "v"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Split",
+                      "v"
+                    |)
                   |));
                 ("pred",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::Split"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Split",
                         "pred"
+                      |)
                     ]
                   |));
                 ("finished",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Split"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Split",
                       "finished"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -1163,10 +1197,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Split"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Split",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -1203,10 +1238,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Split"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Split",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1231,10 +1267,11 @@ Module slice.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Split"
-                                                "pred";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Split",
+                                                "pred"
+                                              |);
                                               Value.Tuple [ M.read (| x |) ]
                                             ]
                                           |)))
@@ -1263,7 +1300,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -1288,10 +1325,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Split"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Split",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeTo"
@@ -1302,10 +1340,11 @@ Module slice.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Split"
-                                "v",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Split",
+                                "v"
+                              |),
                               M.call_closure (|
                                 M.get_trait_method (|
                                   "core::ops::index::Index",
@@ -1320,10 +1359,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Split"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Split",
                                       "v"
+                                    |)
                                   |);
                                   Value.StructRecord
                                     "core::ops::range::RangeFrom"
@@ -1370,10 +1410,11 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         Value.Tuple
@@ -1402,10 +1443,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Split"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Split",
                                           "v"
+                                        |)
                                       |)
                                     ]
                                   |),
@@ -1470,10 +1512,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Split"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Split",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -1510,10 +1553,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Split"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Split",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1538,10 +1582,11 @@ Module slice.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Split"
-                                                "pred";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Split",
+                                                "pred"
+                                              |);
                                               Value.Tuple [ M.read (| x |) ]
                                             ]
                                           |)))
@@ -1570,7 +1615,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -1595,10 +1640,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Split"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Split",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeFrom"
@@ -1615,10 +1661,11 @@ Module slice.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Split"
-                                "v",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Split",
+                                "v"
+                              |),
                               M.call_closure (|
                                 M.get_trait_method (|
                                   "core::ops::index::Index",
@@ -1633,10 +1680,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Split"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Split",
                                       "v"
+                                    |)
                                   |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
@@ -1688,20 +1736,22 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Split"
-                            "finished",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Split",
+                            "finished"
+                          |),
                           Value.Bool true
                         |) in
                       M.alloc (|
@@ -1709,10 +1759,11 @@ Module slice.
                           "core::option::Option::Some"
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Split"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Split",
                                 "v"
+                              |)
                             |)
                           ]
                       |)))
@@ -1855,19 +1906,21 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusive"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusive",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitInclusive"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitInclusive",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -1904,27 +1957,30 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::SplitInclusive"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::SplitInclusive",
                       "v"
+                    |)
                   |));
                 ("pred",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", P, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitInclusive"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitInclusive",
                         "pred"
+                      |)
                     ]
                   |));
                 ("finished",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::SplitInclusive"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::SplitInclusive",
                       "finished"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -1980,10 +2036,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -2037,10 +2094,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusive",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -2065,10 +2123,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::SplitInclusive"
-                                                        "pred";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::SplitInclusive",
+                                                        "pred"
+                                                      |);
                                                       Value.Tuple [ M.read (| x |) ]
                                                     ]
                                                   |)))
@@ -2107,10 +2166,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -2136,10 +2196,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusive",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -2148,10 +2209,11 @@ Module slice.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
-                                  "finished",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
+                                  "finished"
+                                |),
                                 Value.Bool true
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -2174,10 +2236,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeTo"
@@ -2188,10 +2251,11 @@ Module slice.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitInclusive"
-                        "v",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitInclusive",
+                        "v"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::index::Index",
@@ -2202,10 +2266,11 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::SplitInclusive"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::SplitInclusive",
                               "v"
+                            |)
                           |);
                           Value.StructRecord
                             "core::ops::range::RangeFrom"
@@ -2245,10 +2310,11 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusive"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusive",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         Value.Tuple
@@ -2280,10 +2346,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusive",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -2352,10 +2419,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -2386,10 +2454,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusive"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusive",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -2419,10 +2488,11 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::SplitInclusive"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::SplitInclusive",
                                         "v"
+                                      |)
                                     |);
                                     Value.StructRecord
                                       "core::ops::range::RangeTo"
@@ -2437,10 +2507,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::iter::SplitInclusive"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::iter::SplitInclusive",
                                                     "v"
+                                                  |)
                                                 |)
                                               ]
                                             |),
@@ -2515,10 +2586,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::SplitInclusive"
-                                                        "pred";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::SplitInclusive",
+                                                        "pred"
+                                                      |);
                                                       Value.Tuple [ M.read (| x |) ]
                                                     ]
                                                   |)))
@@ -2568,10 +2640,11 @@ Module slice.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
-                                  "finished",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
+                                  "finished"
+                                |),
                                 Value.Bool true
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -2594,10 +2667,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusive"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusive",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeFrom"
@@ -2608,10 +2682,11 @@ Module slice.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitInclusive"
-                        "v",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitInclusive",
+                        "v"
+                      |),
                       M.call_closure (|
                         M.get_trait_method (|
                           "core::ops::index::Index",
@@ -2622,10 +2697,11 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::SplitInclusive"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::SplitInclusive",
                               "v"
+                            |)
                           |);
                           Value.StructRecord
                             "core::ops::range::RangeTo"
@@ -2754,19 +2830,21 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitMut"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitMut",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitMut"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitMut",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -2811,20 +2889,22 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitMut"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitMut",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitMut"
-                            "finished",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitMut",
+                            "finished"
+                          |),
                           Value.Bool true
                         |) in
                       M.alloc (|
@@ -2837,10 +2917,11 @@ Module slice.
                                 [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitMut",
                                   "v"
+                                |)
                               ]
                             |)
                           ]
@@ -2906,10 +2987,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitMut"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitMut",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -2946,10 +3028,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::SplitMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::SplitMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2974,10 +3057,11 @@ Module slice.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::SplitMut"
-                                                "pred";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::SplitMut",
+                                                "pred"
+                                              |);
                                               Value.Tuple [ M.read (| x |) ]
                                             ]
                                           |)))
@@ -3006,7 +3090,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -3020,10 +3104,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::SplitMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::SplitMut",
                                     "v"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -3047,16 +3132,17 @@ Module slice.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let head := M.copy (| γ0_0 |) in
                                   let tail := M.copy (| γ0_1 |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::SplitMut"
-                                        "v",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::SplitMut",
+                                        "v"
+                                      |),
                                       M.read (| tail |)
                                     |) in
                                   M.alloc (|
@@ -3118,10 +3204,11 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitMut"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitMut",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         Value.Tuple
@@ -3150,10 +3237,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::SplitMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::SplitMut",
                                           "v"
+                                        |)
                                       |)
                                     ]
                                   |),
@@ -3225,10 +3313,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitMut"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitMut",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3245,10 +3334,11 @@ Module slice.
                     M.copy (|
                       let pred :=
                         M.alloc (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitMut",
                             "pred"
+                          |)
                         |) in
                       M.alloc (|
                         M.call_closure (|
@@ -3273,10 +3363,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::SplitMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::SplitMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -3330,7 +3421,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -3344,10 +3435,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::SplitMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::SplitMut",
                                     "v"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -3365,16 +3457,17 @@ Module slice.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let head := M.copy (| γ0_0 |) in
                                   let tail := M.copy (| γ0_1 |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::SplitMut"
-                                        "v",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::SplitMut",
+                                        "v"
+                                      |),
                                       M.read (| head |)
                                     |) in
                                   M.alloc (|
@@ -3545,19 +3638,21 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusiveMut"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusiveMut",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitInclusiveMut"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitInclusiveMut",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -3620,10 +3715,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusiveMut"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusiveMut",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3640,10 +3736,11 @@ Module slice.
                     M.copy (|
                       let pred :=
                         M.alloc (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusiveMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusiveMut",
                             "pred"
+                          |)
                         |) in
                       M.alloc (|
                         M.call_closure (|
@@ -3668,10 +3765,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::SplitInclusiveMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::SplitInclusiveMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -3754,10 +3852,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusiveMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusiveMut",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -3783,10 +3882,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusiveMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusiveMut",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |))
@@ -3795,10 +3895,11 @@ Module slice.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusiveMut"
-                                  "finished",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusiveMut",
+                                  "finished"
+                                |),
                                 Value.Bool true
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -3813,10 +3914,11 @@ Module slice.
                           [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusiveMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusiveMut",
                             "v"
+                          |)
                         ]
                       |)
                     |) in
@@ -3834,16 +3936,17 @@ Module slice.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let head := M.copy (| γ0_0 |) in
                           let tail := M.copy (| γ0_1 |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::SplitInclusiveMut"
-                                "v",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::SplitInclusiveMut",
+                                "v"
+                              |),
                               M.read (| tail |)
                             |) in
                           M.alloc (|
@@ -3882,10 +3985,11 @@ Module slice.
                     ltac:(M.monadic
                       (let γ :=
                         M.use
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusiveMut"
-                            "finished") in
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusiveMut",
+                            "finished"
+                          |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       M.alloc (|
                         Value.Tuple
@@ -3917,10 +4021,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusiveMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusiveMut",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -3998,10 +4103,11 @@ Module slice.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusiveMut"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusiveMut",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -4032,10 +4138,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::SplitInclusiveMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::SplitInclusiveMut",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -4050,10 +4157,11 @@ Module slice.
                             ltac:(M.monadic
                               (let pred :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::SplitInclusiveMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::SplitInclusiveMut",
                                     "pred"
+                                  |)
                                 |) in
                               let remainder :=
                                 M.alloc (|
@@ -4071,10 +4179,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::SplitInclusiveMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::SplitInclusiveMut",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeTo"
@@ -4089,10 +4198,11 @@ Module slice.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::SplitInclusiveMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::SplitInclusiveMut",
                                                       "v"
+                                                    |)
                                                   |)
                                                 ]
                                               |),
@@ -4221,10 +4331,11 @@ Module slice.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::SplitInclusiveMut"
-                                  "finished",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::SplitInclusiveMut",
+                                  "finished"
+                                |),
                                 Value.Bool true
                               |) in
                             M.alloc (| Value.Tuple [] |)));
@@ -4239,10 +4350,11 @@ Module slice.
                           [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::SplitInclusiveMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::SplitInclusiveMut",
                             "v"
+                          |)
                         ]
                       |)
                     |) in
@@ -4260,16 +4372,17 @@ Module slice.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let head := M.copy (| γ0_0 |) in
                           let tail := M.copy (| γ0_1 |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::SplitInclusiveMut"
-                                "v",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::SplitInclusiveMut",
+                                "v"
+                              |),
                               M.read (| head |)
                             |) in
                           M.alloc (|
@@ -4401,25 +4514,29 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::RSplit"
-                              "inner")
-                            "core::slice::iter::Split"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::RSplit",
+                              "inner"
+                            |),
+                            "core::slice::iter::Split",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RSplit"
-                          "inner")
-                        "core::slice::iter::Split"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RSplit",
+                          "inner"
+                        |),
+                        "core::slice::iter::Split",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -4464,10 +4581,11 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RSplit"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RSplit",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -4510,7 +4628,13 @@ Module slice.
                 "next_back",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplit" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplit",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4534,7 +4658,13 @@ Module slice.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplit" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplit",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4576,7 +4706,13 @@ Module slice.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplit" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplit",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4613,7 +4749,13 @@ Module slice.
                 "finish",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplit" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplit",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4737,25 +4879,29 @@ Module slice.
                         M.read (| Value.String "v" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::RSplitMut"
-                              "inner")
-                            "core::slice::iter::SplitMut"
-                            "v")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::RSplitMut",
+                              "inner"
+                            |),
+                            "core::slice::iter::SplitMut",
+                            "v"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RSplitMut"
-                          "inner")
-                        "core::slice::iter::SplitMut"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RSplitMut",
+                          "inner"
+                        |),
+                        "core::slice::iter::SplitMut",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -4795,7 +4941,12 @@ Module slice.
                 "finish",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4837,7 +4988,12 @@ Module slice.
                 "next_back",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4862,7 +5018,12 @@ Module slice.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4905,7 +5066,12 @@ Module slice.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4964,18 +5130,20 @@ Module slice.
                 M.read (| Value.String "iter" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::GenericSplitN"
-                    "iter");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::GenericSplitN",
+                    "iter"
+                  |));
                 M.read (| Value.String "count" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::GenericSplitN"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::GenericSplitN",
                       "count"
+                    |)
                   |))
               ]
             |)))
@@ -5021,10 +5189,11 @@ Module slice.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::GenericSplitN"
-                  "count",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::GenericSplitN",
+                  "count"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -5043,10 +5212,11 @@ Module slice.
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::GenericSplitN"
-                            "count" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::GenericSplitN",
+                            "count"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -5061,10 +5231,11 @@ Module slice.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::GenericSplitN"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::GenericSplitN",
                               "iter"
+                            |)
                           ]
                         |)
                       |)));
@@ -5072,10 +5243,11 @@ Module slice.
                     ltac:(M.monadic
                       (let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::GenericSplitN"
-                            "count" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::GenericSplitN",
+                            "count"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -5090,10 +5262,11 @@ Module slice.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::GenericSplitN"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::GenericSplitN",
                               "iter"
+                            |)
                           ]
                         |)
                       |)))
@@ -5130,18 +5303,19 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::GenericSplitN"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::GenericSplitN",
                         "iter"
+                      |)
                     ]
                   |)
                 |),
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let lower := M.copy (| γ0_0 |) in
                       let upper_opt := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -5151,10 +5325,11 @@ Module slice.
                               M.get_function (| "core::cmp::min", [ Ty.path "usize" ] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GenericSplitN"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GenericSplitN",
                                     "count"
+                                  |)
                                 |);
                                 M.read (| lower |)
                               ]
@@ -5174,10 +5349,11 @@ Module slice.
                                   [
                                     M.read (| upper_opt |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::GenericSplitN"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::GenericSplitN",
                                         "count"
+                                      |)
                                     |);
                                     M.closure
                                       (fun γ =>
@@ -5197,10 +5373,11 @@ Module slice.
                                                       |),
                                                       [
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::slice::iter::GenericSplitN"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::slice::iter::GenericSplitN",
                                                             "count"
+                                                          |)
                                                         |);
                                                         M.read (| upper |)
                                                       ]
@@ -5322,10 +5499,11 @@ Module slice.
                     M.read (| Value.String "inner" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitN"
-                        "inner")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitN",
+                        "inner"
+                      |))
                   ]
                 |)
               ]
@@ -5430,10 +5608,11 @@ Module slice.
                     M.read (| Value.String "inner" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RSplitN"
-                        "inner")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RSplitN",
+                        "inner"
+                      |))
                   ]
                 |)
               ]
@@ -5538,10 +5717,11 @@ Module slice.
                     M.read (| Value.String "inner" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::SplitNMut"
-                        "inner")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::SplitNMut",
+                        "inner"
+                      |))
                   ]
                 |)
               ]
@@ -5646,10 +5826,11 @@ Module slice.
                     M.read (| Value.String "inner" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RSplitNMut"
-                        "inner")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RSplitNMut",
+                        "inner"
+                      |))
                   ]
                 |)
               ]
@@ -5700,15 +5881,20 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Windows" "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::Windows",
+                    "v"
+                  |));
                 M.read (| Value.String "size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Windows"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Windows",
                       "size"
+                    |)
                   |))
               ]
             |)))
@@ -5769,14 +5955,19 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Windows" "v"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Windows",
+                      "v"
+                    |)
                   |));
                 ("size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Windows"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Windows",
                       "size"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -5833,10 +6024,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "size"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -5848,10 +6040,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -5879,10 +6072,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |);
                                   Value.StructRecord
                                     "core::ops::range::RangeTo"
@@ -5896,10 +6090,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Windows"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Windows",
                                                 "size"
+                                              |)
                                             |)
                                           ]
                                         |))
@@ -5910,10 +6105,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Windows"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Windows",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -5925,10 +6121,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Windows"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Windows",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeFrom"
@@ -5977,10 +6174,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "size"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -5992,10 +6190,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -6024,10 +6223,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |),
@@ -6039,10 +6239,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "size"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -6121,10 +6322,11 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::Windows"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::Windows",
                               "size"
+                            |)
                           |)
                         ]
                       |);
@@ -6135,8 +6337,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -6158,10 +6360,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Windows"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Windows",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -6175,10 +6378,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Windows"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -6200,10 +6404,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Windows"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Windows",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::Range"
@@ -6213,10 +6418,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Windows"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |),
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::index::Index",
@@ -6231,10 +6437,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Windows"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Windows",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeFrom"
@@ -6293,10 +6500,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::slice::iter::Windows",
                                       "size"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -6308,7 +6516,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field self "core::slice::iter::Windows" "v"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::slice::iter::Windows",
+                                      "v"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -6328,7 +6540,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::Windows" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |),
@@ -6340,7 +6556,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::Windows" "size"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::Windows",
+                                    "size"
+                                  |)
                                 |)
                               ]
                             |)
@@ -6364,7 +6584,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::Windows" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |)
                                 |);
                                 Value.StructRecord
                                   "core::ops::range::RangeFrom"
@@ -6409,10 +6633,11 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Windows"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Windows",
                             "v"
+                          |)
                         |)
                       ]
                     |);
@@ -6427,10 +6652,11 @@ Module slice.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::Windows"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Windows",
                         "size"
+                      |)
                     |)
                   ]
                 |)
@@ -6495,10 +6721,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "size"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -6510,10 +6737,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
@@ -6541,10 +6769,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Windows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Windows",
                                       "v"
+                                    |)
                                   |);
                                   Value.StructRecord
                                     "core::ops::range::RangeFrom"
@@ -6559,10 +6788,11 @@ Module slice.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::slice::iter::Windows"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::slice::iter::Windows",
                                                   "v"
+                                                |)
                                               |)
                                             ]
                                           |),
@@ -6574,10 +6804,11 @@ Module slice.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::slice::iter::Windows"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::slice::iter::Windows",
                                                   "size"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -6589,10 +6820,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Windows"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Windows",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -6604,10 +6836,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Windows"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Windows",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeTo"
@@ -6622,10 +6855,11 @@ Module slice.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::Windows"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::Windows",
                                               "v"
+                                            |)
                                           |)
                                         ]
                                       |),
@@ -6672,10 +6906,11 @@ Module slice.
                         M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::Windows"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::Windows",
                               "v"
+                            |)
                           |)
                         ]
                       |);
@@ -6686,8 +6921,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -6709,10 +6944,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Windows"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Windows",
                                                 "size"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -6726,10 +6962,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Windows"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -6751,10 +6988,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Windows"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Windows",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::Range"
@@ -6770,10 +7008,11 @@ Module slice.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::Windows"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::Windows",
                                                       "size"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -6785,10 +7024,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Windows"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Windows",
+                                    "v"
+                                  |),
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::index::Index",
@@ -6803,10 +7043,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Windows"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Windows",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeTo"
@@ -6945,15 +7186,20 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Chunks" "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::Chunks",
+                    "v"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Chunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Chunks",
                       "chunk_size"
+                    |)
                   |))
               ]
             |)))
@@ -7014,14 +7260,19 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Chunks" "v"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Chunks",
+                      "v"
+                    |)
                   |));
                 ("chunk_size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::Chunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::Chunks",
                       "chunk_size"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -7078,10 +7329,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -7103,18 +7355,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Chunks"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Chunks",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -7129,10 +7383,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "v"
+                                |)
                               |);
                               M.read (| chunksz |)
                             ]
@@ -7141,16 +7396,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |),
                                   M.read (| snd |)
                                 |) in
                               M.alloc (|
@@ -7199,10 +7455,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -7230,18 +7487,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Chunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -7256,18 +7515,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Chunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -7369,10 +7630,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::Chunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::Chunks",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -7380,8 +7642,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -7403,10 +7665,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Chunks"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Chunks",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -7420,10 +7683,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -7442,10 +7706,11 @@ Module slice.
                                         [
                                           M.read (| start |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::Chunks"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::Chunks",
                                               "chunk_size"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -7454,7 +7719,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -7475,10 +7740,11 @@ Module slice.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::Chunks"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::Chunks",
                                                         "v"
+                                                      |)
                                                     |)
                                                   ]
                                                 |);
@@ -7497,10 +7763,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::iter::Chunks"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::iter::Chunks",
                                                     "v"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -7524,10 +7791,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Chunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Chunks",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::Range"
@@ -7538,10 +7806,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |),
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::index::Index",
@@ -7556,10 +7825,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Chunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Chunks",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::RangeFrom"
@@ -7611,7 +7881,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::Chunks" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -7633,24 +7907,30 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field self "core::slice::iter::Chunks" "v"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::Chunks",
+                                        "v"
+                                      |)
                                     |)
                                   ]
                                 |),
                                 Value.Integer Integer.Usize 1
                               |),
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::slice::iter::Chunks",
                                   "chunk_size"
+                                |)
                               |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::Chunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -7672,7 +7952,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::Chunks" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |)
                                 |);
                                 Value.StructRecord
                                   "core::ops::range::RangeFrom"
@@ -7716,10 +8000,11 @@ Module slice.
                   BinOp.Panic.mul (|
                     M.read (| idx |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::Chunks"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Chunks",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -7739,10 +8024,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "v"
+                                |)
                               |)
                             ]
                           |);
@@ -7750,10 +8036,11 @@ Module slice.
                         ]
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::Chunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::Chunks",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -7773,10 +8060,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Chunks",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -7862,10 +8150,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -7885,18 +8174,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Chunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -7922,10 +8213,11 @@ Module slice.
                                   remainder));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
-                                    "chunk_size"))
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
+                                    "chunk_size"
+                                  |)))
                             ]
                           |)
                         |) in
@@ -7939,10 +8231,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.call_closure (|
@@ -7953,10 +8246,11 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::Chunks"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::Chunks",
                                         "v"
+                                      |)
                                     |)
                                   ]
                                 |),
@@ -7968,16 +8262,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Chunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Chunks",
+                                    "v"
+                                  |),
                                   M.read (| fst |)
                                 |) in
                               M.alloc (|
@@ -8042,10 +8337,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Chunks"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Chunks",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -8059,10 +8355,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Chunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Chunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -8075,10 +8372,11 @@ Module slice.
                                 [
                                   M.read (| start |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Chunks"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Chunks",
                                       "chunk_size"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -8087,7 +8385,7 @@ Module slice.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -8105,10 +8403,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Chunks"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Chunks",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -8127,10 +8426,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::Chunks"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::Chunks",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -8150,10 +8450,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::Range"
@@ -8163,10 +8464,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::Chunks"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::Chunks",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -8178,10 +8480,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Chunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Chunks",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeTo"
@@ -8314,25 +8617,28 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksMut"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksMut",
+                    "v"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksMut"
-                    "chunk_size");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksMut",
+                    "chunk_size"
+                  |));
                 M.read (| Value.String "_marker" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksMut",
                       "_marker"
+                    |)
                   |))
               ]
             |)))
@@ -8422,10 +8728,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -8447,18 +8754,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksMut",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -8473,10 +8782,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksMut",
                                   "v"
+                                |)
                               |);
                               M.read (| sz |)
                             ]
@@ -8485,16 +8795,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
+                                    "v"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -8543,10 +8854,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -8574,18 +8886,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -8600,18 +8914,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -8717,10 +9033,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::ChunksMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::ChunksMut",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -8728,8 +9045,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -8753,10 +9070,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::ChunksMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::ChunksMut",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -8770,10 +9088,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -8792,10 +9111,11 @@ Module slice.
                                         [
                                           M.read (| start |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::ChunksMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::ChunksMut",
                                               "chunk_size"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -8804,7 +9124,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -8827,10 +9147,11 @@ Module slice.
                                                   |),
                                                   [
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::ChunksMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::ChunksMut",
                                                         "v"
+                                                      |)
                                                     |)
                                                   ]
                                                 |);
@@ -8851,10 +9172,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::iter::ChunksMut"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::iter::ChunksMut",
                                                     "v"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -8874,10 +9196,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::ChunksMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::ChunksMut",
                                           "v"
+                                        |)
                                       |);
                                       M.read (| end_ |)
                                     ]
@@ -8886,8 +9209,8 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let head := M.copy (| γ0_0 |) in
                                       let tail := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -8906,15 +9229,17 @@ Module slice.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let nth := M.copy (| γ0_1 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::iter::ChunksMut"
-                                                    "v",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::iter::ChunksMut",
+                                                    "v"
+                                                  |),
                                                   M.read (| tail |)
                                                 |) in
                                               M.alloc (|
@@ -8968,7 +9293,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::ChunksMut" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::ChunksMut",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -8990,27 +9319,30 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "core::slice::iter::ChunksMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::ChunksMut",
                                         "v"
+                                      |)
                                     |)
                                   ]
                                 |),
                                 Value.Integer Integer.Usize 1
                               |),
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::slice::iter::ChunksMut",
                                   "chunk_size"
+                                |)
                               |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "core::slice::iter::ChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::ChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -9030,7 +9362,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::ChunksMut" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::ChunksMut",
+                                    "v"
+                                  |)
                                 |);
                                 Value.StructRecord
                                   "core::ops::range::RangeFrom"
@@ -9073,10 +9409,11 @@ Module slice.
                   BinOp.Panic.mul (|
                     M.read (| idx |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksMut",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -9098,10 +9435,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |);
@@ -9109,10 +9447,11 @@ Module slice.
                             ]
                           |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::ChunksMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::ChunksMut",
                               "chunk_size"
+                            |)
                           |)
                         ]
                       |)
@@ -9136,10 +9475,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |);
@@ -9216,10 +9556,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -9239,18 +9580,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -9276,10 +9619,11 @@ Module slice.
                                   remainder));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
-                                    "chunk_size"))
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
+                                    "chunk_size"
+                                  |)))
                             ]
                           |)
                         |) in
@@ -9293,10 +9637,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksMut",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -9311,10 +9656,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksMut",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (| M.read (| len |), M.read (| sz |) |)
                             ]
@@ -9323,16 +9669,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksMut",
+                                    "v"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -9401,10 +9748,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksMut"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksMut",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -9418,10 +9766,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -9434,10 +9783,11 @@ Module slice.
                                 [
                                   M.read (| start |);
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksMut",
                                       "chunk_size"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -9446,7 +9796,7 @@ Module slice.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -9466,10 +9816,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::ChunksMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::ChunksMut",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -9490,10 +9841,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::ChunksMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::ChunksMut",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -9511,10 +9863,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksMut",
                                   "v"
+                                |)
                               |);
                               M.read (| end_ |)
                             ]
@@ -9523,8 +9876,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let temp := M.copy (| γ0_0 |) in
                               let _tail := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -9543,16 +9896,17 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let head := M.copy (| γ0_0 |) in
                                       let nth_back := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::ChunksMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::ChunksMut",
+                                            "v"
+                                          |),
                                           M.read (| head |)
                                         |) in
                                       M.alloc (|
@@ -9710,25 +10064,28 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExact"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExact",
+                    "v"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExact"
-                    "rem");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExact",
+                    "rem"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksExact",
                       "chunk_size"
+                    |)
                   |))
               ]
             |)))
@@ -9799,8 +10156,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let fst := M.copy (| γ0_0 |) in
                       let snd := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -9834,7 +10191,11 @@ Module slice.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::slice::iter::ChunksExact" "rem"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::slice::iter::ChunksExact",
+                "rem"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -9864,24 +10225,27 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksExact",
                       "v"
+                    |)
                   |));
                 ("rem",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksExact",
                       "rem"
+                    |)
                   |));
                 ("chunk_size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksExact",
                       "chunk_size"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -9939,18 +10303,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksExact"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksExact",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -9967,16 +10333,18 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "v"
+                                |)
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -9984,16 +10352,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExact",
+                                    "v"
+                                  |),
                                   M.read (| snd |)
                                 |) in
                               M.alloc (|
@@ -10027,18 +10396,20 @@ Module slice.
                       M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksExact"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksExact",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -10105,10 +10476,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::ChunksExact"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::ChunksExact",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -10116,8 +10488,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -10139,10 +10511,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::ChunksExact"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::ChunksExact",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -10156,10 +10529,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExact",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -10175,10 +10549,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::ChunksExact"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::ChunksExact",
                                           "v"
+                                        |)
                                       |);
                                       M.read (| start |)
                                     ]
@@ -10187,15 +10562,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let snd := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::ChunksExact"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::ChunksExact",
+                                            "v"
+                                          |),
                                           M.read (| snd |)
                                         |) in
                                       M.alloc (|
@@ -10266,10 +10642,11 @@ Module slice.
                   BinOp.Panic.mul (|
                     M.read (| idx |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -10288,10 +10665,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExact",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -10299,10 +10677,11 @@ Module slice.
                       ]
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   ]
                 |)
@@ -10368,18 +10747,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksExact"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksExact",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -10396,10 +10777,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.call_closure (|
@@ -10410,18 +10792,20 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ChunksExact"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ChunksExact",
                                         "v"
+                                      |)
                                     |)
                                   ]
                                 |),
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExact"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExact",
                                     "chunk_size"
+                                  |)
                                 |)
                               |)
                             ]
@@ -10430,16 +10814,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExact",
+                                    "v"
+                                  |),
                                   M.read (| fst |)
                                 |) in
                               M.alloc (|
@@ -10501,10 +10886,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksExact"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksExact",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -10518,10 +10904,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExact",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -10530,10 +10917,11 @@ Module slice.
                           BinOp.Panic.add (|
                             M.read (| start |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExact",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -10549,10 +10937,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::Range"
@@ -10562,10 +10951,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksExact"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksExact",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -10577,10 +10967,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExact",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeTo"
@@ -10629,7 +11020,11 @@ Module slice.
               M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "is_empty", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::slice::iter::ChunksExact" "v"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExact",
+                    "v"
+                  |)
                 |)
               ]
             |)))
@@ -10742,32 +11137,36 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExactMut"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExactMut",
+                    "v"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExactMut"
-                    "rem");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExactMut",
+                    "rem"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExactMut"
-                    "chunk_size");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExactMut",
+                    "chunk_size"
+                  |));
                 M.read (| Value.String "_marker" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ChunksExactMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ChunksExactMut",
                       "_marker"
+                    |)
                   |))
               ]
             |)))
@@ -10838,8 +11237,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let fst := M.copy (| γ0_0 |) in
                       let snd := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -10873,7 +11272,13 @@ Module slice.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_record_field self "core::slice::iter::ChunksExactMut" "rem" |)))
+            M.read (|
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "core::slice::iter::ChunksExactMut",
+                "rem"
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -10927,18 +11332,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksExactMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksExactMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExactMut",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -10955,16 +11362,18 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExactMut",
                                   "v"
+                                |)
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExactMut",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -10972,16 +11381,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExactMut",
+                                    "v"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -11019,18 +11429,20 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksExactMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksExactMut",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -11098,10 +11510,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::ChunksExactMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::ChunksExactMut",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -11109,8 +11522,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -11134,10 +11547,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::ChunksExactMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::ChunksExactMut",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -11151,10 +11565,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExactMut",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -11172,10 +11587,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::ChunksExactMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::ChunksExactMut",
                                           "v"
+                                        |)
                                       |);
                                       M.read (| start |)
                                     ]
@@ -11184,15 +11600,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let snd := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::ChunksExactMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::ChunksExactMut",
+                                            "v"
+                                          |),
                                           M.read (| snd |)
                                         |) in
                                       M.alloc (|
@@ -11263,10 +11680,11 @@ Module slice.
                   BinOp.Panic.mul (|
                     M.read (| idx |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -11285,10 +11703,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExactMut",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -11296,10 +11715,11 @@ Module slice.
                       ]
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   ]
                 |)
@@ -11367,18 +11787,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::ChunksExactMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::ChunksExactMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExactMut",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -11395,10 +11817,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ChunksExactMut",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.call_closure (|
@@ -11409,18 +11832,20 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ChunksExactMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ChunksExactMut",
                                         "v"
+                                      |)
                                     |)
                                   ]
                                 |),
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExactMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExactMut",
                                     "chunk_size"
+                                  |)
                                 |)
                               |)
                             ]
@@ -11429,16 +11854,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExactMut",
+                                    "v"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -11504,10 +11930,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::ChunksExactMut"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::ChunksExactMut",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -11521,10 +11948,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExactMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -11533,10 +11961,11 @@ Module slice.
                           BinOp.Panic.add (|
                             M.read (| start |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::ChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::ChunksExactMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -11555,10 +11984,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "*mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ChunksExactMut"
-                                    "v";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ChunksExactMut",
+                                    "v"
+                                  |);
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 ]
                               |);
@@ -11569,8 +11999,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let temp := M.copy (| γ0_0 |) in
                               let _tail := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -11589,16 +12019,17 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let head := M.copy (| γ0_0 |) in
                                       let nth_back := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::ChunksExactMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::ChunksExactMut",
+                                            "v"
+                                          |),
                                           M.read (| head |)
                                         |) in
                                       M.alloc (|
@@ -11652,10 +12083,11 @@ Module slice.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ChunksExactMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ChunksExactMut",
                     "v"
+                  |)
                 |)
               ]
             |)))
@@ -11795,25 +12227,28 @@ Module slice.
                 M.read (| Value.String "slice_head" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ArrayWindows"
-                    "slice_head");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ArrayWindows",
+                    "slice_head"
+                  |));
                 M.read (| Value.String "num" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ArrayWindows"
-                    "num");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ArrayWindows",
+                    "num"
+                  |));
                 M.read (| Value.String "marker" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ArrayWindows"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ArrayWindows",
                       "marker"
+                    |)
                   |))
               ]
             |)))
@@ -11853,20 +12288,22 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
                         "slice_head"
+                      |)
                     ]
                   |));
                 ("num",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
                         "num"
+                      |)
                     ]
                   |));
                 ("marker",
@@ -11881,10 +12318,11 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
                         "marker"
+                      |)
                     ]
                   |))
               ]))
@@ -12016,10 +12454,11 @@ Module slice.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
                                         "num"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -12045,20 +12484,22 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::ArrayWindows"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::ArrayWindows",
                               "slice_head"
+                            |)
                           |)
                         ]
                       |)
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "slice_head",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "slice_head"
+                      |),
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply (Ty.path "*const") [ T ],
@@ -12067,10 +12508,11 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::ArrayWindows"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::ArrayWindows",
                               "slice_head"
+                            |)
                           |);
                           Value.Integer Integer.Usize 1
                         ]
@@ -12078,10 +12520,11 @@ Module slice.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "num" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "num"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -12106,19 +12549,21 @@ Module slice.
             Value.Tuple
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ArrayWindows"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ArrayWindows",
                     "num"
+                  |)
                 |);
                 Value.StructTuple
                   "core::option::Option::Some"
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
                         "num"
+                      |)
                     |)
                   ]
               ]))
@@ -12136,7 +12581,13 @@ Module slice.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_record_field self "core::slice::iter::ArrayWindows" "num" |)))
+            M.read (|
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "core::slice::iter::ArrayWindows",
+                "num"
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -12177,10 +12628,11 @@ Module slice.
                                 (M.alloc (|
                                   BinOp.Pure.le
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
                                         "num"
+                                      |)
                                     |))
                                     (M.read (| n |))
                                 |)) in
@@ -12191,10 +12643,11 @@ Module slice.
                                 M.read (|
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
-                                        "num",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
+                                        "num"
+                                      |),
                                       Value.Integer Integer.Usize 0
                                     |) in
                                   M.return_ (| Value.StructTuple "core::option::Option::None" [] |)
@@ -12221,10 +12674,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ArrayWindows"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ArrayWindows",
                                   "slice_head"
+                                |)
                               |);
                               M.read (| n |)
                             ]
@@ -12234,10 +12688,11 @@ Module slice.
                     |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "slice_head",
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "slice_head"
+                      |),
                       M.call_closure (|
                         M.get_associated_function (|
                           Ty.apply (Ty.path "*const") [ T ],
@@ -12246,10 +12701,11 @@ Module slice.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::ArrayWindows"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::ArrayWindows",
                               "slice_head"
+                            |)
                           |);
                           BinOp.Panic.add (| M.read (| n |), Value.Integer Integer.Usize 1 |)
                         ]
@@ -12257,10 +12713,11 @@ Module slice.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "num" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "num"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.sub (|
@@ -12313,10 +12770,11 @@ Module slice.
                                 M.get_associated_function (| Ty.path "usize", "checked_sub", [] |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      self
-                                      "core::slice::iter::ArrayWindows"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::slice::iter::ArrayWindows",
                                       "num"
+                                    |)
                                   |);
                                   Value.Integer Integer.Usize 1
                                 ]
@@ -12328,7 +12786,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -12365,7 +12823,7 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -12433,10 +12891,11 @@ Module slice.
                                 (M.alloc (|
                                   BinOp.Pure.eq
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
                                         "num"
+                                      |)
                                     |))
                                     (Value.Integer Integer.Usize 0)
                                 |)) in
@@ -12469,17 +12928,19 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ArrayWindows"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ArrayWindows",
                                   "slice_head"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ArrayWindows"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ArrayWindows",
                                     "num"
+                                  |)
                                 |),
                                 Value.Integer Integer.Usize 1
                               |)
@@ -12490,10 +12951,11 @@ Module slice.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "num" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "num"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -12537,10 +12999,11 @@ Module slice.
                                 (M.alloc (|
                                   BinOp.Pure.le
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
                                         "num"
+                                      |)
                                     |))
                                     (M.read (| n |))
                                 |)) in
@@ -12551,10 +13014,11 @@ Module slice.
                                 M.read (|
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::ArrayWindows"
-                                        "num",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::ArrayWindows",
+                                        "num"
+                                      |),
                                       Value.Integer Integer.Usize 0
                                     |) in
                                   M.return_ (| Value.StructTuple "core::option::Option::None" [] |)
@@ -12581,17 +13045,19 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::ArrayWindows"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::ArrayWindows",
                                   "slice_head"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::ArrayWindows"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::ArrayWindows",
                                     "num"
+                                  |)
                                 |),
                                 BinOp.Panic.add (| M.read (| n |), Value.Integer Integer.Usize 1 |)
                               |)
@@ -12602,10 +13068,11 @@ Module slice.
                     |) in
                   let _ :=
                     let β :=
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayWindows"
-                        "num" in
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayWindows",
+                        "num"
+                      |) in
                     M.write (|
                       β,
                       BinOp.Panic.sub (|
@@ -12649,10 +13116,11 @@ Module slice.
             (let self := M.alloc (| self |) in
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayWindows"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayWindows",
                   "num"
+                |)
               |))
               (Value.Integer Integer.Usize 0)))
         | _, _ => M.impossible
@@ -12703,18 +13171,20 @@ Module slice.
                 M.read (| Value.String "iter" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ArrayChunks"
-                    "iter");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ArrayChunks",
+                    "iter"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ArrayChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ArrayChunks",
                       "rem"
+                    |)
                   |))
               ]
             |)))
@@ -12761,8 +13231,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let array_slice := M.copy (| γ0_0 |) in
                       let rem := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -12803,7 +13273,11 @@ Module slice.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::slice::iter::ArrayChunks" "rem"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::slice::iter::ArrayChunks",
+                "rem"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -12843,18 +13317,20 @@ Module slice.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::ArrayChunks"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::ArrayChunks",
                         "iter"
+                      |)
                     ]
                   |));
                 ("rem",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ArrayChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ArrayChunks",
                       "rem"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -12897,10 +13373,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12926,10 +13403,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12954,7 +13432,14 @@ Module slice.
                 "count",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::slice::iter::ArrayChunks" "iter" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::slice::iter::ArrayChunks",
+                    "iter"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12981,10 +13466,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
+                  "iter"
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -13010,7 +13496,14 @@ Module slice.
                 "last",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::slice::iter::ArrayChunks" "iter" |)
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::slice::iter::ArrayChunks",
+                    "iter"
+                  |)
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13039,10 +13532,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
+                  "iter"
+                |);
                 M.read (| i |)
               ]
             |)))
@@ -13091,10 +13585,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13121,10 +13616,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
+                  "iter"
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -13168,10 +13664,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunks"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunks",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13281,18 +13778,20 @@ Module slice.
                 M.read (| Value.String "iter" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::ArrayChunksMut"
-                    "iter");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::ArrayChunksMut",
+                    "iter"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::ArrayChunksMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::ArrayChunksMut",
                       "rem"
+                    |)
                   |))
               ]
             |)))
@@ -13339,8 +13838,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let array_slice := M.copy (| γ0_0 |) in
                       let rem := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -13380,7 +13879,13 @@ Module slice.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_record_field self "core::slice::iter::ArrayChunksMut" "rem" |)))
+            M.read (|
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "core::slice::iter::ArrayChunksMut",
+                "rem"
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -13419,10 +13924,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13450,10 +13956,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13482,7 +13989,11 @@ Module slice.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::slice::iter::ArrayChunksMut" "iter"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::slice::iter::ArrayChunksMut",
+                    "iter"
+                  |)
                 |)
               ]
             |)))
@@ -13512,10 +14023,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
+                  "iter"
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -13545,7 +14057,11 @@ Module slice.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::slice::iter::ArrayChunksMut" "iter"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::slice::iter::ArrayChunksMut",
+                    "iter"
+                  |)
                 |)
               ]
             |)))
@@ -13577,10 +14093,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
+                  "iter"
+                |);
                 M.read (| i |)
               ]
             |)))
@@ -13631,10 +14148,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13663,10 +14181,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
-                  "iter";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
+                  "iter"
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -13712,10 +14231,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::ArrayChunksMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::ArrayChunksMut",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13823,15 +14343,20 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RChunks" "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunks",
+                    "v"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunks",
                       "chunk_size"
+                    |)
                   |))
               ]
             |)))
@@ -13892,14 +14417,19 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RChunks" "v"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunks",
+                      "v"
+                    |)
                   |));
                 ("chunk_size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunks"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunks",
                       "chunk_size"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -13962,10 +14492,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -13984,10 +14515,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -13999,10 +14531,11 @@ Module slice.
                             [
                               M.read (| len |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -14017,10 +14550,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (| M.read (| len |), M.read (| chunksz |) |)
                             ]
@@ -14029,16 +14563,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |),
                                   M.read (| fst |)
                                 |) in
                               M.alloc (|
@@ -14087,10 +14622,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -14118,18 +14654,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -14144,18 +14682,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -14259,10 +14799,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunks",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -14270,8 +14811,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -14293,10 +14834,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::RChunks"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::RChunks",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -14310,10 +14852,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -14330,10 +14873,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunks"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunks",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |),
@@ -14353,10 +14897,11 @@ Module slice.
                                         [
                                           M.read (| end_ |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::RChunks"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::RChunks",
                                               "chunk_size"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -14365,7 +14910,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -14394,10 +14939,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunks",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::Range"
@@ -14408,10 +14954,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |),
                                   M.call_closure (|
                                     M.get_trait_method (|
                                       "core::ops::index::Index",
@@ -14426,10 +14973,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunks",
                                           "v"
+                                        |)
                                       |);
                                       Value.StructRecord
                                         "core::ops::range::Range"
@@ -14485,7 +15033,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunks" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -14505,15 +15057,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunks" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::RChunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -14536,10 +15093,11 @@ Module slice.
                                       M.read (| γ |),
                                       Value.Bool true
                                     |) in
-                                  M.get_struct_record_field
-                                    self
-                                    "core::slice::iter::RChunks"
-                                    "chunk_size"));
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunks",
+                                    "chunk_size"
+                                  |)));
                               fun γ => ltac:(M.monadic rem)
                             ]
                           |)
@@ -14559,7 +15117,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunks" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |)
                                 |);
                                 Value.StructRecord
                                   "core::ops::range::Range"
@@ -14603,20 +15165,22 @@ Module slice.
                       M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunks"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunks",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     BinOp.Panic.mul (|
                       M.read (| idx |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunks"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunks",
                           "chunk_size"
+                        |)
                       |)
                     |)
                   |)
@@ -14630,10 +15194,11 @@ Module slice.
                         [
                           M.read (| end_ |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::RChunks"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::RChunks",
                               "chunk_size"
+                            |)
                           |)
                         ]
                       |)
@@ -14643,7 +15208,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -14668,10 +15233,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunks",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -14744,10 +15310,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -14767,18 +15334,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -14804,10 +15373,11 @@ Module slice.
                                   remainder));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
-                                    "chunk_size"))
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
+                                    "chunk_size"
+                                  |)))
                             ]
                           |)
                         |) in
@@ -14821,10 +15391,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "v"
+                                |)
                               |);
                               M.read (| chunksz |)
                             ]
@@ -14833,16 +15404,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
+                                    "v"
+                                  |),
                                   M.read (| snd |)
                                 |) in
                               M.alloc (|
@@ -14906,10 +15478,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunks"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunks",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -14923,10 +15496,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunks"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunks",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -14941,10 +15515,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunks"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunks",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
@@ -14958,10 +15533,11 @@ Module slice.
                             [
                               M.read (| end_ |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -14978,10 +15554,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::Range"
@@ -14991,10 +15568,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunks"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunks",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -15006,10 +15584,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunks"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunks",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeFrom"
@@ -15142,25 +15721,28 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksMut"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksMut",
+                    "v"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksMut"
-                    "chunk_size");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksMut",
+                    "chunk_size"
+                  |));
                 M.read (| Value.String "_marker" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksMut",
                       "_marker"
+                    |)
                   |))
               ]
             |)))
@@ -15255,10 +15837,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -15280,18 +15863,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::RChunksMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::RChunksMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -15306,10 +15891,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -15324,10 +15910,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (| M.read (| len |), M.read (| sz |) |)
                             ]
@@ -15336,16 +15923,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -15394,10 +15982,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -15425,18 +16014,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -15451,18 +16042,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -15572,10 +16165,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksMut",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -15583,8 +16177,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -15608,10 +16202,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::RChunksMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::RChunksMut",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -15625,10 +16220,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -15647,10 +16243,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunksMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunksMut",
                                             "v"
+                                          |)
                                         |)
                                       ]
                                     |),
@@ -15670,10 +16267,11 @@ Module slice.
                                         [
                                           M.read (| end_ |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::RChunksMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::RChunksMut",
                                               "chunk_size"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -15682,7 +16280,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -15707,10 +16305,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunksMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunksMut",
                                           "v"
+                                        |)
                                       |);
                                       M.read (| start |)
                                     ]
@@ -15719,8 +16318,8 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let head := M.copy (| γ0_0 |) in
                                       let tail := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -15745,15 +16344,17 @@ Module slice.
                                         [
                                           fun γ =>
                                             ltac:(M.monadic
-                                              (let γ0_0 := M.get_tuple_field γ 0 in
-                                              let γ0_1 := M.get_tuple_field γ 1 in
+                                              (let γ0_0 :=
+                                                M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                               let nth := M.copy (| γ0_0 |) in
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::iter::RChunksMut"
-                                                    "v",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::iter::RChunksMut",
+                                                    "v"
+                                                  |),
                                                   M.read (| head |)
                                                 |) in
                                               M.alloc (|
@@ -15808,7 +16409,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunksMut" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -15828,15 +16433,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunksMut" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                self
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::RChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -15859,10 +16469,11 @@ Module slice.
                                       M.read (| γ |),
                                       Value.Bool true
                                     |) in
-                                  M.get_struct_record_field
-                                    self
-                                    "core::slice::iter::RChunksMut"
-                                    "chunk_size"));
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunksMut",
+                                    "chunk_size"
+                                  |)));
                               fun γ => ltac:(M.monadic rem)
                             ]
                           |)
@@ -15879,7 +16490,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::slice::iter::RChunksMut" "v"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |)
                                 |);
                                 Value.StructRecord
                                   "core::ops::range::Range"
@@ -15928,20 +16543,22 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksMut",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     BinOp.Panic.mul (|
                       M.read (| idx |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksMut",
                           "chunk_size"
+                        |)
                       |)
                     |)
                   |)
@@ -15955,10 +16572,11 @@ Module slice.
                         [
                           M.read (| end_ |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::RChunksMut"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::RChunksMut",
                               "chunk_size"
+                            |)
                           |)
                         ]
                       |)
@@ -15968,7 +16586,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -15993,10 +16611,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksMut",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -16070,10 +16689,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |)
@@ -16093,18 +16713,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -16130,10 +16752,11 @@ Module slice.
                                   remainder));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
-                                    "chunk_size"))
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
+                                    "chunk_size"
+                                  |)))
                             ]
                           |)
                         |) in
@@ -16147,10 +16770,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "v"
+                                |)
                               |);
                               M.read (| sz |)
                             ]
@@ -16159,16 +16783,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
+                                    "v"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -16236,10 +16861,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksMut"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksMut",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -16253,10 +16879,11 @@ Module slice.
                               M.read (| n |)
                             |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -16271,10 +16898,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
@@ -16288,10 +16916,11 @@ Module slice.
                             [
                               M.read (| end_ |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -16306,10 +16935,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksMut",
                                   "v"
+                                |)
                               |);
                               M.read (| end_ |)
                             ]
@@ -16318,8 +16948,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let tmp := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -16338,15 +16968,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let nth_back := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunksMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunksMut",
+                                            "v"
+                                          |),
                                           M.read (| tail |)
                                         |) in
                                       M.alloc (|
@@ -16504,25 +17135,28 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExact"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExact",
+                    "v"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExact"
-                    "rem");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExact",
+                    "rem"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksExact",
                       "chunk_size"
+                    |)
                   |))
               ]
             |)))
@@ -16582,8 +17216,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let fst := M.copy (| γ0_0 |) in
                       let snd := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -16617,7 +17251,11 @@ Module slice.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RChunksExact" "rem"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::slice::iter::RChunksExact",
+                "rem"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -16647,24 +17285,27 @@ Module slice.
               [
                 ("v",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksExact",
                       "v"
+                    |)
                   |));
                 ("rem",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksExact",
                       "rem"
+                    |)
                   |));
                 ("chunk_size",
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksExact"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksExact",
                       "chunk_size"
+                    |)
                   |))
               ]))
         | _, _ => M.impossible
@@ -16722,18 +17363,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::RChunksExact"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::RChunksExact",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -16750,10 +17393,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.call_closure (|
@@ -16764,18 +17408,20 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::RChunksExact"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::RChunksExact",
                                         "v"
+                                      |)
                                     |)
                                   ]
                                 |),
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExact"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExact",
                                     "chunk_size"
+                                  |)
                                 |)
                               |)
                             ]
@@ -16784,16 +17430,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExact",
+                                    "v"
+                                  |),
                                   M.read (| fst |)
                                 |) in
                               M.alloc (|
@@ -16827,18 +17474,20 @@ Module slice.
                       M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExact"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExact",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -16905,10 +17554,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksExact"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksExact",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -16916,8 +17566,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -16939,10 +17589,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::RChunksExact"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::RChunksExact",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -16956,10 +17607,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExact",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -16975,10 +17627,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunksExact"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunksExact",
                                           "v"
+                                        |)
                                       |);
                                       BinOp.Panic.sub (|
                                         M.call_closure (|
@@ -16989,10 +17642,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::RChunksExact"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::RChunksExact",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |),
@@ -17004,15 +17658,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let fst := M.copy (| γ0_0 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunksExact"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunksExact",
+                                            "v"
+                                          |),
                                           M.read (| fst |)
                                         |) in
                                       M.alloc (|
@@ -17086,20 +17741,22 @@ Module slice.
                       M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "len", [] |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExact"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExact",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     BinOp.Panic.mul (|
                       M.read (| idx |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksExact"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksExact",
                           "chunk_size"
+                        |)
                       |)
                     |)
                   |)
@@ -17109,10 +17766,11 @@ Module slice.
                   BinOp.Panic.sub (|
                     M.read (| end_ |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -17131,10 +17789,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExact",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -17142,10 +17801,11 @@ Module slice.
                       ]
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExact"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExact",
                         "chunk_size"
+                      |)
                     |)
                   ]
                 |)
@@ -17211,18 +17871,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::RChunksExact"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::RChunksExact",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -17239,16 +17901,18 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "v"
+                                |)
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -17256,16 +17920,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let fst := M.copy (| γ0_0 |) in
                               let snd := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExact"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExact",
+                                    "v"
+                                  |),
                                   M.read (| snd |)
                                 |) in
                               M.alloc (|
@@ -17330,10 +17995,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExact"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExact",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -17344,10 +18010,11 @@ Module slice.
                           BinOp.Panic.mul (|
                             BinOp.Panic.sub (| M.read (| len |), M.read (| n |) |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExact",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -17362,10 +18029,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExact"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExact",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
@@ -17377,10 +18045,11 @@ Module slice.
                           BinOp.Panic.add (|
                             M.read (| start |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExact"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExact",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -17396,10 +18065,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::Range"
@@ -17409,10 +18079,11 @@ Module slice.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExact"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExact",
+                            "v"
+                          |),
                           M.call_closure (|
                             M.get_trait_method (|
                               "core::ops::index::Index",
@@ -17424,10 +18095,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExact"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExact",
                                   "v"
+                                |)
                               |);
                               Value.StructRecord
                                 "core::ops::range::RangeFrom"
@@ -17476,10 +18148,11 @@ Module slice.
               M.get_associated_function (| Ty.apply (Ty.path "slice") [ T ], "is_empty", [] |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExact"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExact",
                     "v"
+                  |)
                 |)
               ]
             |)))
@@ -17590,25 +18263,28 @@ Module slice.
                 M.read (| Value.String "v" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExactMut"
-                    "v");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExactMut",
+                    "v"
+                  |));
                 M.read (| Value.String "rem" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExactMut"
-                    "rem");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExactMut",
+                    "rem"
+                  |));
                 M.read (| Value.String "chunk_size" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::iter::RChunksExactMut"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::iter::RChunksExactMut",
                       "chunk_size"
+                    |)
                   |))
               ]
             |)))
@@ -17668,8 +18344,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let fst := M.copy (| γ0_0 |) in
                       let snd := M.copy (| γ0_1 |) in
                       M.alloc (|
@@ -17702,7 +18378,13 @@ Module slice.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_record_field self "core::slice::iter::RChunksExactMut" "rem" |)))
+            M.read (|
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "core::slice::iter::RChunksExactMut",
+                "rem"
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -17757,18 +18439,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::RChunksExactMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::RChunksExactMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -17785,10 +18469,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "v"
+                                |)
                               |)
                             ]
                           |)
@@ -17803,18 +18488,20 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "v"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.read (| len |),
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExactMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExactMut",
                                     "chunk_size"
+                                  |)
                                 |)
                               |)
                             ]
@@ -17823,16 +18510,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExactMut",
+                                    "v"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -17870,18 +18558,20 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExactMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExactMut",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -17950,10 +18640,11 @@ Module slice.
                     [
                       M.read (| n |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksExactMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksExactMut",
                           "chunk_size"
+                        |)
                       |)
                     ]
                   |)
@@ -17961,8 +18652,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let end_ := M.copy (| γ0_0 |) in
                       let overflow := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -17986,10 +18677,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::RChunksExactMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::RChunksExactMut",
                                                 "v"
+                                              |)
                                             |)
                                           ]
                                         |)),
@@ -18003,10 +18695,11 @@ Module slice.
                                 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExactMut",
+                                    "v"
+                                  |),
                                   (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                                 |) in
                               M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -18024,10 +18717,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunksExactMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunksExactMut",
                                           "v"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -18044,10 +18738,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::RChunksExactMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::RChunksExactMut",
                                           "v"
+                                        |)
                                       |);
                                       BinOp.Panic.sub (| M.read (| len |), M.read (| end_ |) |)
                                     ]
@@ -18056,15 +18751,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let fst := M.copy (| γ0_0 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunksExactMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunksExactMut",
+                                            "v"
+                                          |),
                                           M.read (| fst |)
                                         |) in
                                       M.alloc (|
@@ -18142,20 +18838,22 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExactMut"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExactMut",
                             "v"
+                          |)
                         |)
                       ]
                     |),
                     BinOp.Panic.mul (|
                       M.read (| idx |),
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::RChunksExactMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::RChunksExactMut",
                           "chunk_size"
+                        |)
                       |)
                     |)
                   |)
@@ -18165,10 +18863,11 @@ Module slice.
                   BinOp.Panic.sub (|
                     M.read (| end_ |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   |)
                 |) in
@@ -18187,10 +18886,11 @@ Module slice.
                           |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExactMut",
                                 "v"
+                              |)
                             |)
                           ]
                         |);
@@ -18198,10 +18898,11 @@ Module slice.
                       ]
                     |);
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::RChunksExactMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::RChunksExactMut",
                         "chunk_size"
+                      |)
                     |)
                   ]
                 |)
@@ -18269,18 +18970,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::RChunksExactMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::RChunksExactMut",
                                       "v"
+                                    |)
                                   |)
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "chunk_size"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -18297,16 +19000,18 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "v"
+                                |)
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "chunk_size"
+                                |)
                               |)
                             ]
                           |)
@@ -18314,16 +19019,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExactMut"
-                                    "v",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExactMut",
+                                    "v"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -18392,10 +19098,11 @@ Module slice.
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::iter::RChunksExactMut"
-                            "v",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::iter::RChunksExactMut",
+                            "v"
+                          |),
                           (* Unsize *) M.pointer_coercion (M.alloc (| Value.Array [] |))
                         |) in
                       M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
@@ -18406,10 +19113,11 @@ Module slice.
                           BinOp.Panic.mul (|
                             BinOp.Panic.sub (| M.read (| len |), M.read (| n |) |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExactMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -18424,10 +19132,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::RChunksExactMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::RChunksExactMut",
                                     "v"
+                                  |)
                                 |)
                               ]
                             |),
@@ -18439,10 +19148,11 @@ Module slice.
                           BinOp.Panic.add (|
                             M.read (| start |),
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::RChunksExactMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::RChunksExactMut",
                                 "chunk_size"
+                              |)
                             |)
                           |)
                         |) in
@@ -18456,10 +19166,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::RChunksExactMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::RChunksExactMut",
                                   "v"
+                                |)
                               |);
                               M.read (| end_ |)
                             ]
@@ -18468,8 +19179,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let tmp := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -18488,15 +19199,16 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let nth_back := M.copy (| γ0_1 |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::RChunksExactMut"
-                                            "v",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::RChunksExactMut",
+                                            "v"
+                                          |),
                                           M.read (| tail |)
                                         |) in
                                       M.alloc (|
@@ -18550,10 +19262,11 @@ Module slice.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::iter::RChunksExactMut"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::RChunksExactMut",
                     "v"
+                  |)
                 |)
               ]
             |)))
@@ -18799,10 +19512,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupBy"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupBy",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -18822,10 +19536,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupBy",
                                   "slice"
+                                |)
                               |);
                               Value.Integer Integer.Usize 2
                             ]
@@ -18853,14 +19568,14 @@ Module slice.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
                                     let γ0_0 := M.read (| γ0_0 |) in
-                                    let γ2_0 := M.get_slice_index_or_break_match (| γ0_0, 0 |) in
-                                    let γ2_1 := M.get_slice_index_or_break_match (| γ0_0, 1 |) in
+                                    let γ2_0 := M.SubPointer.get_slice_index (| γ0_0, 0 |) in
+                                    let γ2_1 := M.SubPointer.get_slice_index (| γ0_0, 1 |) in
                                     let l := M.alloc (| γ2_0 |) in
                                     let r := M.alloc (| γ2_1 |) in
                                     M.match_operator (|
@@ -18886,10 +19601,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::GroupBy"
-                                                        "predicate";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::GroupBy",
+                                                        "predicate"
+                                                      |);
                                                       Value.Tuple [ M.read (| l |); M.read (| r |) ]
                                                     ]
                                                   |)
@@ -18940,10 +19656,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupBy",
                                   "slice"
+                                |)
                               |);
                               M.read (| len |)
                             ]
@@ -18952,16 +19669,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupBy"
-                                    "slice",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupBy",
+                                    "slice"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -19003,10 +19721,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupBy"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupBy",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -19038,10 +19757,11 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::GroupBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::GroupBy",
                                         "slice"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -19136,10 +19856,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupBy"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupBy",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -19159,10 +19880,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupBy",
                                   "slice"
+                                |)
                               |);
                               Value.Integer Integer.Usize 2
                             ]
@@ -19190,14 +19912,14 @@ Module slice.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
                                     let γ0_0 := M.read (| γ0_0 |) in
-                                    let γ2_0 := M.get_slice_index_or_break_match (| γ0_0, 0 |) in
-                                    let γ2_1 := M.get_slice_index_or_break_match (| γ0_0, 1 |) in
+                                    let γ2_0 := M.SubPointer.get_slice_index (| γ0_0, 0 |) in
+                                    let γ2_1 := M.SubPointer.get_slice_index (| γ0_0, 1 |) in
                                     let l := M.alloc (| γ2_0 |) in
                                     let r := M.alloc (| γ2_1 |) in
                                     M.match_operator (|
@@ -19223,10 +19945,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::GroupBy"
-                                                        "predicate";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::GroupBy",
+                                                        "predicate"
+                                                      |);
                                                       Value.Tuple [ M.read (| l |); M.read (| r |) ]
                                                     ]
                                                   |)
@@ -19277,10 +20000,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupBy"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupBy",
                                   "slice"
+                                |)
                               |);
                               BinOp.Panic.sub (|
                                 M.call_closure (|
@@ -19291,10 +20015,11 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::GroupBy"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::GroupBy",
                                         "slice"
+                                      |)
                                     |)
                                   ]
                                 |),
@@ -19306,16 +20031,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupBy"
-                                    "slice",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupBy",
+                                    "slice"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -19394,10 +20120,11 @@ Module slice.
                     M.read (| Value.String "slice" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::GroupBy"
-                        "slice")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::GroupBy",
+                        "slice"
+                      |))
                   ]
                 |)
               ]
@@ -19500,10 +20227,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupByMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupByMut",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -19523,10 +20251,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupByMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupByMut",
                                   "slice"
+                                |)
                               |);
                               Value.Integer Integer.Usize 2
                             ]
@@ -19554,14 +20283,14 @@ Module slice.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
                                     let γ0_0 := M.read (| γ0_0 |) in
-                                    let γ2_0 := M.get_slice_index_or_break_match (| γ0_0, 0 |) in
-                                    let γ2_1 := M.get_slice_index_or_break_match (| γ0_0, 1 |) in
+                                    let γ2_0 := M.SubPointer.get_slice_index (| γ0_0, 0 |) in
+                                    let γ2_1 := M.SubPointer.get_slice_index (| γ0_0, 1 |) in
                                     let l := M.alloc (| γ2_0 |) in
                                     let r := M.alloc (| γ2_1 |) in
                                     M.match_operator (|
@@ -19587,10 +20316,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::GroupByMut"
-                                                        "predicate";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::GroupByMut",
+                                                        "predicate"
+                                                      |);
                                                       Value.Tuple [ M.read (| l |); M.read (| r |) ]
                                                     ]
                                                   |)
@@ -19639,10 +20369,11 @@ Module slice.
                               [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::GroupByMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::GroupByMut",
                                 "slice"
+                              |)
                             ]
                           |)
                         |) in
@@ -19660,16 +20391,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupByMut"
-                                    "slice",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupByMut",
+                                    "slice"
+                                  |),
                                   M.read (| tail |)
                                 |) in
                               M.alloc (|
@@ -19711,10 +20443,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupByMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupByMut",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -19746,10 +20479,11 @@ Module slice.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::GroupByMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::GroupByMut",
                                         "slice"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -19845,10 +20579,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupByMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupByMut",
                                     "slice"
+                                  |)
                                 |)
                               ]
                             |)
@@ -19868,10 +20603,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::GroupByMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::GroupByMut",
                                   "slice"
+                                |)
                               |);
                               Value.Integer Integer.Usize 2
                             ]
@@ -19899,14 +20635,14 @@ Module slice.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
                                     let γ0_0 := M.read (| γ0_0 |) in
-                                    let γ2_0 := M.get_slice_index_or_break_match (| γ0_0, 0 |) in
-                                    let γ2_1 := M.get_slice_index_or_break_match (| γ0_0, 1 |) in
+                                    let γ2_0 := M.SubPointer.get_slice_index (| γ0_0, 0 |) in
+                                    let γ2_1 := M.SubPointer.get_slice_index (| γ0_0, 1 |) in
                                     let l := M.alloc (| γ2_0 |) in
                                     let r := M.alloc (| γ2_1 |) in
                                     M.match_operator (|
@@ -19932,10 +20668,11 @@ Module slice.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::GroupByMut"
-                                                        "predicate";
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::GroupByMut",
+                                                        "predicate"
+                                                      |);
                                                       Value.Tuple [ M.read (| l |); M.read (| r |) ]
                                                     ]
                                                   |)
@@ -19984,10 +20721,11 @@ Module slice.
                               [ Ty.apply (Ty.path "&mut") [ Ty.apply (Ty.path "slice") [ T ] ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::GroupByMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::GroupByMut",
                                 "slice"
+                              |)
                             ]
                           |)
                         |) in
@@ -20018,16 +20756,17 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let head := M.copy (| γ0_0 |) in
                               let tail := M.copy (| γ0_1 |) in
                               let _ :=
                                 M.write (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::GroupByMut"
-                                    "slice",
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::GroupByMut",
+                                    "slice"
+                                  |),
                                   M.read (| head |)
                                 |) in
                               M.alloc (|
@@ -20106,10 +20845,11 @@ Module slice.
                     M.read (| Value.String "slice" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::GroupByMut"
-                        "slice")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::GroupByMut",
+                        "slice"
+                      |))
                   ]
                 |)
               ]

--- a/CoqOfRust/core/slice/iter/macros.v
+++ b/CoqOfRust/core/slice/iter/macros.v
@@ -33,10 +33,11 @@ Module slice.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::Iter"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::Iter",
                           "ptr"
+                        |)
                       |)
                     ]
                   |));
@@ -60,10 +61,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Iter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Iter",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -80,10 +82,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -97,10 +100,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -142,7 +146,11 @@ Module slice.
             M.read (|
               let old :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Iter" "ptr"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::Iter",
+                    "ptr"
+                  |)
                 |) in
               let _ :=
                 let _ :=
@@ -164,10 +172,11 @@ Module slice.
                                   [ Ty.path "usize" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -189,18 +198,20 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::Iter"
-                              "ptr",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::Iter",
+                              "ptr"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ],
@@ -209,10 +220,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "ptr"
+                                  |)
                                 |);
                                 M.read (| offset |)
                               ]
@@ -274,10 +286,11 @@ Module slice.
                               [ Ty.path "usize" ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Iter",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -289,10 +302,11 @@ Module slice.
                             [ M.read (| M.read (| len |) |); M.read (| offset |) ]
                           |)
                         |) in
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::Iter"
-                        "ptr"));
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Iter",
+                        "ptr"
+                      |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let end_ :=
@@ -304,10 +318,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Iter",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -368,10 +383,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Iter",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -388,10 +404,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Iter",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -405,10 +422,11 @@ Module slice.
                           [
                             M.read (| end_ |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Iter",
                                 "ptr"
+                              |)
                             |)
                           ]
                         |)
@@ -449,10 +467,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::Iter",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -471,10 +490,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::Iter"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::Iter",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -488,10 +508,11 @@ Module slice.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::Iter"
-                              "ptr";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::Iter",
+                              "ptr"
+                            |);
                             end_
                           ]
                         |)
@@ -573,10 +594,11 @@ Module slice.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::Iter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::Iter",
                                               "end_or_len"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -598,10 +620,11 @@ Module slice.
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::Iter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::Iter",
                                             "end_or_len"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -615,10 +638,11 @@ Module slice.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
-                                          "ptr";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
+                                          "ptr"
+                                        |);
                                         end_
                                       ]
                                     |)
@@ -694,10 +718,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::Iter"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::Iter",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -714,10 +739,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -731,10 +757,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::Iter"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::Iter",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -783,10 +810,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::slice::iter::Iter"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::slice::iter::Iter",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -802,7 +830,12 @@ Module slice.
                               "cast",
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
-                            [ M.get_struct_record_field self "core::slice::iter::Iter" "end_or_len"
+                            [
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::Iter",
+                                "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -816,7 +849,11 @@ Module slice.
                           [
                             M.read (| end_ |);
                             M.read (|
-                              M.get_struct_record_field self "core::slice::iter::Iter" "ptr"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::Iter",
+                                "ptr"
+                              |)
                             |)
                           ]
                         |)
@@ -891,10 +928,11 @@ Module slice.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::slice::iter::Iter"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::slice::iter::Iter",
                                                           "end_or_len"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -917,10 +955,11 @@ Module slice.
                                                       ]
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::Iter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::Iter",
                                                         "end_or_len"
+                                                      |)
                                                     ]
                                                   |)
                                                 |) in
@@ -936,10 +975,11 @@ Module slice.
                                                   [
                                                     M.read (| end_ |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::Iter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::Iter",
                                                         "ptr"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -980,10 +1020,11 @@ Module slice.
                                                     [ Ty.path "usize" ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::Iter"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::Iter",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -1008,18 +1049,20 @@ Module slice.
                                                     ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::Iter"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::Iter",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::Iter"
-                                                "ptr",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::Iter",
+                                                "ptr"
+                                              |),
                                               M.read (| M.read (| end_ |) |)
                                             |)))
                                       ]
@@ -1119,10 +1162,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::Iter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::Iter",
                                             "end_or_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -1141,10 +1185,11 @@ Module slice.
                                         [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "end_or_len"
+                                        |)
                                       ]
                                     |)
                                   |) in
@@ -1158,10 +1203,11 @@ Module slice.
                                     [
                                       M.read (| end_ |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "ptr"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1321,10 +1367,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "core::slice::iter::Iter"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "core::slice::iter::Iter",
                                                     "end_or_len"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -1351,10 +1398,11 @@ Module slice.
                                                 ]
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::slice::iter::Iter"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::slice::iter::Iter",
                                                   "end_or_len"
+                                                |)
                                               ]
                                             |)
                                           |) in
@@ -1374,10 +1422,11 @@ Module slice.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                self
-                                                "core::slice::iter::Iter"
-                                                "ptr";
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::slice::iter::Iter",
+                                                "ptr"
+                                              |);
                                               end_
                                             ]
                                           |)
@@ -1419,10 +1468,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::slice::iter::Iter",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1441,10 +1491,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        self
-                                        "core::slice::iter::Iter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::Iter",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -1458,7 +1509,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field self "core::slice::iter::Iter" "ptr"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::Iter",
+                                        "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -1500,10 +1555,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::slice::iter::Iter"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::slice::iter::Iter",
                                                 "ptr"
+                                              |)
                                             |);
                                             M.read (| i |)
                                           ]
@@ -1588,7 +1644,7 @@ Module slice.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -1672,7 +1728,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1779,7 +1835,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1885,7 +1941,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2004,7 +2060,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2029,7 +2085,7 @@ Module slice.
                                             |)
                                           |) in
                                         let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -2125,10 +2181,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -2147,10 +2204,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::Iter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::Iter",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -2164,10 +2222,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::Iter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::Iter",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -2198,7 +2257,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2343,10 +2402,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -2365,10 +2425,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::Iter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::Iter",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -2382,10 +2443,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::Iter"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::Iter",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -2416,7 +2478,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2538,7 +2600,11 @@ Module slice.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field (M.read (| self |)) "core::slice::iter::Iter" "ptr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::Iter",
+                        "ptr"
+                      |)
                     |)
                   ]
                 |);
@@ -2716,10 +2782,11 @@ Module slice.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::Iter"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::Iter",
                                               "end_or_len"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -2741,10 +2808,11 @@ Module slice.
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::Iter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::Iter",
                                             "end_or_len"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -2758,10 +2826,11 @@ Module slice.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
-                                          "ptr";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
+                                          "ptr"
+                                        |);
                                         end_
                                       ]
                                     |)
@@ -2867,10 +2936,11 @@ Module slice.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::slice::iter::Iter"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::slice::iter::Iter",
                                                           "end_or_len"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -2893,10 +2963,11 @@ Module slice.
                                                       ]
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::Iter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::Iter",
                                                         "end_or_len"
+                                                      |)
                                                     ]
                                                   |)
                                                 |) in
@@ -2912,10 +2983,11 @@ Module slice.
                                                   [
                                                     M.read (| end_ |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::Iter"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::Iter",
                                                         "ptr"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -2956,10 +3028,11 @@ Module slice.
                                                     [ Ty.path "usize" ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::Iter"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::Iter",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -2984,20 +3057,22 @@ Module slice.
                                                     ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::Iter"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::Iter",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
                                             M.write (|
                                               M.read (| end_ |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::slice::iter::Iter"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::slice::iter::Iter",
                                                   "ptr"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -3097,10 +3172,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::Iter"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::Iter",
                                             "end_or_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -3119,10 +3195,11 @@ Module slice.
                                         [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "end_or_len"
+                                        |)
                                       ]
                                     |)
                                   |) in
@@ -3136,10 +3213,11 @@ Module slice.
                                     [
                                       M.read (| end_ |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::Iter"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::Iter",
                                           "ptr"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -3349,10 +3427,11 @@ Module slice.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::iter::IterMut"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::iter::IterMut",
                           "ptr"
+                        |)
                       |)
                     ]
                   |));
@@ -3376,10 +3455,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::IterMut",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -3396,10 +3476,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -3413,10 +3494,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -3458,7 +3540,11 @@ Module slice.
             M.read (|
               let old :=
                 M.copy (|
-                  M.get_struct_record_field (M.read (| self |)) "core::slice::iter::IterMut" "ptr"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::iter::IterMut",
+                    "ptr"
+                  |)
                 |) in
               let _ :=
                 let _ :=
@@ -3480,10 +3566,11 @@ Module slice.
                                   [ Ty.path "usize" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -3505,18 +3592,20 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
                           M.write (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::IterMut"
-                              "ptr",
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::IterMut",
+                              "ptr"
+                            |),
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ],
@@ -3525,10 +3614,11 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "ptr"
+                                  |)
                                 |);
                                 M.read (| offset |)
                               ]
@@ -3590,10 +3680,11 @@ Module slice.
                               [ Ty.path "usize" ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::IterMut",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -3605,10 +3696,11 @@ Module slice.
                             [ M.read (| M.read (| len |) |); M.read (| offset |) ]
                           |)
                         |) in
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::IterMut"
-                        "ptr"));
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::IterMut",
+                        "ptr"
+                      |)));
                   fun γ =>
                     ltac:(M.monadic
                       (let end_ :=
@@ -3620,10 +3712,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::IterMut",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -3684,10 +3777,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::IterMut",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -3704,10 +3798,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::IterMut",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -3721,10 +3816,11 @@ Module slice.
                           [
                             M.read (| end_ |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::IterMut",
                                 "ptr"
+                              |)
                             |)
                           ]
                         |)
@@ -3765,10 +3861,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::iter::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::iter::IterMut",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -3787,10 +3884,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::iter::IterMut",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -3804,10 +3902,11 @@ Module slice.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::iter::IterMut"
-                              "ptr";
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::iter::IterMut",
+                              "ptr"
+                            |);
                             end_
                           ]
                         |)
@@ -3889,10 +3988,11 @@ Module slice.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::IterMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::IterMut",
                                               "end_or_len"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -3914,10 +4014,11 @@ Module slice.
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::IterMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::IterMut",
                                             "end_or_len"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -3931,10 +4032,11 @@ Module slice.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
-                                          "ptr";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
+                                          "ptr"
+                                        |);
                                         end_
                                       ]
                                     |)
@@ -4010,10 +4112,11 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::iter::IterMut"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::iter::IterMut",
                                       "end_or_len"
+                                    |)
                                   |)
                                 ]
                               |)
@@ -4030,10 +4133,11 @@ Module slice.
                                   [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "end_or_len"
+                                  |)
                                 ]
                               |)
                             |) in
@@ -4047,10 +4151,11 @@ Module slice.
                               [
                                 M.read (| end_ |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::iter::IterMut"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::iter::IterMut",
                                     "ptr"
+                                  |)
                                 |)
                               ]
                             |)
@@ -4099,10 +4204,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  self
-                                  "core::slice::iter::IterMut"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::slice::iter::IterMut",
                                   "end_or_len"
+                                |)
                               |)
                             ]
                           |)
@@ -4119,10 +4225,11 @@ Module slice.
                               [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                             |),
                             [
-                              M.get_struct_record_field
-                                self
-                                "core::slice::iter::IterMut"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::IterMut",
                                 "end_or_len"
+                              |)
                             ]
                           |)
                         |) in
@@ -4136,7 +4243,11 @@ Module slice.
                           [
                             M.read (| end_ |);
                             M.read (|
-                              M.get_struct_record_field self "core::slice::iter::IterMut" "ptr"
+                              M.SubPointer.get_struct_record_field (|
+                                self,
+                                "core::slice::iter::IterMut",
+                                "ptr"
+                              |)
                             |)
                           ]
                         |)
@@ -4211,10 +4322,11 @@ Module slice.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::slice::iter::IterMut"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::slice::iter::IterMut",
                                                           "end_or_len"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -4237,10 +4349,11 @@ Module slice.
                                                       ]
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::IterMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::IterMut",
                                                         "end_or_len"
+                                                      |)
                                                     ]
                                                   |)
                                                 |) in
@@ -4256,10 +4369,11 @@ Module slice.
                                                   [
                                                     M.read (| end_ |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::IterMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::IterMut",
                                                         "ptr"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -4300,10 +4414,11 @@ Module slice.
                                                     [ Ty.path "usize" ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::IterMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::IterMut",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -4328,18 +4443,20 @@ Module slice.
                                                     ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::IterMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::IterMut",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::slice::iter::IterMut"
-                                                "ptr",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::slice::iter::IterMut",
+                                                "ptr"
+                                              |),
                                               M.read (| M.read (| end_ |) |)
                                             |)))
                                       ]
@@ -4439,10 +4556,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::IterMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::IterMut",
                                             "end_or_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -4461,10 +4579,11 @@ Module slice.
                                         [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "end_or_len"
+                                        |)
                                       ]
                                     |)
                                   |) in
@@ -4478,10 +4597,11 @@ Module slice.
                                     [
                                       M.read (| end_ |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "ptr"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -4641,10 +4761,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    self
-                                                    "core::slice::iter::IterMut"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    self,
+                                                    "core::slice::iter::IterMut",
                                                     "end_or_len"
+                                                  |)
                                                 |)
                                               ]
                                             |)
@@ -4671,10 +4792,11 @@ Module slice.
                                                 ]
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::slice::iter::IterMut"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::slice::iter::IterMut",
                                                   "end_or_len"
+                                                |)
                                               ]
                                             |)
                                           |) in
@@ -4694,10 +4816,11 @@ Module slice.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                self
-                                                "core::slice::iter::IterMut"
-                                                "ptr";
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::slice::iter::IterMut",
+                                                "ptr"
+                                              |);
                                               end_
                                             ]
                                           |)
@@ -4739,10 +4862,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::slice::iter::IterMut",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -4761,10 +4885,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        self
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::IterMut",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -4778,10 +4903,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        self
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::slice::iter::IterMut",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -4823,10 +4949,11 @@ Module slice.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::slice::iter::IterMut"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::slice::iter::IterMut",
                                                 "ptr"
+                                              |)
                                             |);
                                             M.read (| i |)
                                           ]
@@ -4911,7 +5038,7 @@ Module slice.
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -4995,7 +5122,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5103,7 +5230,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5209,7 +5336,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5328,7 +5455,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5353,7 +5480,7 @@ Module slice.
                                             |)
                                           |) in
                                         let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -5449,10 +5576,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -5471,10 +5599,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::IterMut",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -5488,10 +5617,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::IterMut",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -5522,7 +5652,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5668,10 +5798,11 @@ Module slice.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "end_or_len"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -5690,10 +5821,11 @@ Module slice.
                                       [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::IterMut",
                                         "end_or_len"
+                                      |)
                                     ]
                                   |)
                                 |) in
@@ -5707,10 +5839,11 @@ Module slice.
                                   [
                                     M.read (| end_ |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::slice::iter::IterMut"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::slice::iter::IterMut",
                                         "ptr"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -5741,7 +5874,7 @@ Module slice.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5863,10 +5996,11 @@ Module slice.
                   |),
                   [
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::slice::iter::IterMut"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::slice::iter::IterMut",
                         "ptr"
+                      |)
                     |)
                   ]
                 |);
@@ -5960,10 +6094,11 @@ Module slice.
                                         |),
                                         [
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::slice::iter::IterMut"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::slice::iter::IterMut",
                                               "end_or_len"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -5985,10 +6120,11 @@ Module slice.
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::IterMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::IterMut",
                                             "end_or_len"
+                                          |)
                                         ]
                                       |)
                                     |) in
@@ -6002,10 +6138,11 @@ Module slice.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
-                                          "ptr";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
+                                          "ptr"
+                                        |);
                                         end_
                                       ]
                                     |)
@@ -6111,10 +6248,11 @@ Module slice.
                                                     |),
                                                     [
                                                       M.read (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::slice::iter::IterMut"
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::slice::iter::IterMut",
                                                           "end_or_len"
+                                                        |)
                                                       |)
                                                     ]
                                                   |)
@@ -6137,10 +6275,11 @@ Module slice.
                                                       ]
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::IterMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::IterMut",
                                                         "end_or_len"
+                                                      |)
                                                     ]
                                                   |)
                                                 |) in
@@ -6156,10 +6295,11 @@ Module slice.
                                                   [
                                                     M.read (| end_ |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::slice::iter::IterMut"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::slice::iter::IterMut",
                                                         "ptr"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -6200,10 +6340,11 @@ Module slice.
                                                     [ Ty.path "usize" ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::IterMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::IterMut",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -6228,20 +6369,22 @@ Module slice.
                                                     ]
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::slice::iter::IterMut"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::slice::iter::IterMut",
                                                       "end_or_len"
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
                                             M.write (|
                                               M.read (| end_ |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::slice::iter::IterMut"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::slice::iter::IterMut",
                                                   "ptr"
+                                                |)
                                               |)
                                             |)))
                                       ]
@@ -6341,10 +6484,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::iter::IterMut"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::iter::IterMut",
                                             "end_or_len"
+                                          |)
                                         |)
                                       ]
                                     |)
@@ -6363,10 +6507,11 @@ Module slice.
                                         [ Ty.apply (Ty.path "core::ptr::non_null::NonNull") [ T ] ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "end_or_len"
+                                        |)
                                       ]
                                     |)
                                   |) in
@@ -6380,10 +6525,11 @@ Module slice.
                                     [
                                       M.read (| end_ |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::slice::iter::IterMut"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::slice::iter::IterMut",
                                           "ptr"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -6592,7 +6738,13 @@ Module slice.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::SplitN" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::SplitN",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6618,7 +6770,13 @@ Module slice.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::SplitN" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::SplitN",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6679,7 +6837,13 @@ Module slice.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitN" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitN",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6705,7 +6869,13 @@ Module slice.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::RSplitN" "inner" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitN",
+                  "inner"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6766,7 +6936,12 @@ Module slice.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::SplitNMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::SplitNMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6793,7 +6968,12 @@ Module slice.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::slice::iter::SplitNMut" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::SplitNMut",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6856,10 +7036,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::RSplitNMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitNMut",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6887,10 +7068,11 @@ Module slice.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::iter::RSplitNMut"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::iter::RSplitNMut",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/slice/memchr.v
+++ b/CoqOfRust/core/slice/memchr.v
@@ -192,7 +192,10 @@ Module slice.
                                             (M.alloc (|
                                               BinOp.Pure.eq
                                                 (M.read (|
-                                                  M.get_array_field (| M.read (| text |), i |)
+                                                  M.SubPointer.get_array_field (|
+                                                    M.read (| text |),
+                                                    i
+                                                  |)
                                                 |))
                                                 (M.read (| x |))
                                             |)) in
@@ -418,7 +421,7 @@ Module slice.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -644,7 +647,7 @@ Module slice.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -764,9 +767,9 @@ Module slice.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
-                          let γ0_2 := M.get_tuple_field γ 2 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                          let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                           let prefix := M.copy (| γ0_0 |) in
                           let suffix := M.copy (| γ0_2 |) in
                           M.alloc (|
@@ -798,8 +801,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let min_aligned_offset := M.copy (| γ0_0 |) in
                         let max_aligned_offset := M.copy (| γ0_1 |) in
                         let offset := M.copy (| max_aligned_offset |) in
@@ -879,7 +882,7 @@ Module slice.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/core/slice/mod.v
+++ b/CoqOfRust/core/slice/mod.v
@@ -55,10 +55,10 @@ Module slice.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_1,
                               "core::ops::range::Bound::Excluded",
                               0
@@ -73,10 +73,10 @@ Module slice.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_1,
                               "core::ops::range::Bound::Included",
                               0
@@ -118,7 +118,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -157,7 +157,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -171,10 +171,10 @@ Module slice.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "core::ops::range::Bound::Excluded",
                               0
@@ -216,7 +216,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Break",
                                               0
@@ -255,7 +255,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::ops::control_flow::ControlFlow::Continue",
                                               0
@@ -269,10 +269,10 @@ Module slice.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ1_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "core::ops::range::Bound::Included",
                               0
@@ -396,8 +396,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                    let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                     let first := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| first |) ]
@@ -433,8 +433,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                    let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                     let first := M.alloc (| γ1_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| first |) ]
@@ -470,8 +470,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                    let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                     let first := M.alloc (| γ1_0 |) in
                     let tail := M.alloc (| γ1_rest |) in
                     M.alloc (|
@@ -510,8 +510,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 1, 0 |) in
+                    let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 1, 0 |) in
                     let first := M.alloc (| γ1_0 |) in
                     let tail := M.alloc (| γ1_rest |) in
                     M.alloc (|
@@ -550,8 +550,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                    let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                    let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                     let init := M.alloc (| γ1_rest |) in
                     let last := M.alloc (| γ1_rev0 |) in
                     M.alloc (|
@@ -590,8 +590,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                    let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                    let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                     let init := M.alloc (| γ1_rest |) in
                     let last := M.alloc (| γ1_rev0 |) in
                     M.alloc (|
@@ -630,8 +630,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                    let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                    let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                     let last := M.alloc (| γ1_rev0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| last |) ]
@@ -667,8 +667,8 @@ Module slice.
                   ltac:(M.monadic
                     (let γ := self in
                     let γ := M.read (| γ |) in
-                    let γ1_rest := M.get_slice_rest_or_break_match (| γ, 0, 1 |) in
-                    let γ1_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                    let γ1_rest := M.SubPointer.get_slice_rest (| γ, 0, 1 |) in
+                    let γ1_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                     let last := M.alloc (| γ1_rev0 |) in
                     M.alloc (|
                       Value.StructTuple "core::option::Option::Some" [ M.read (| last |) ]
@@ -879,8 +879,8 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let first := M.copy (| γ0_0 |) in
                             let tail := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -982,8 +982,8 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let first := M.copy (| γ0_0 |) in
                             let tail := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -1088,8 +1088,8 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let init := M.copy (| γ0_0 |) in
                             let last := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -1201,8 +1201,8 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let init := M.copy (| γ0_0 |) in
                             let last := M.copy (| γ0_1 |) in
                             M.alloc (|
@@ -1283,8 +1283,8 @@ Module slice.
                   ltac:(M.monadic
                     (let last :=
                       M.copy (|
-                        M.get_tuple_field
-                          (M.alloc (|
+                        M.SubPointer.get_tuple_field (|
+                          M.alloc (|
                             M.call_closure (|
                               M.get_associated_function (|
                                 Ty.apply (Ty.path "slice") [ T ],
@@ -1306,8 +1306,9 @@ Module slice.
                                 |)
                               ]
                             |)
-                          |))
+                          |),
                           1
+                        |)
                       |) in
                     M.alloc (|
                       Value.StructTuple
@@ -1383,8 +1384,8 @@ Module slice.
                     (let last :=
                       M.alloc (|
                         M.read (|
-                          M.get_tuple_field
-                            (M.alloc (|
+                          M.SubPointer.get_tuple_field (|
+                            M.alloc (|
                               M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply (Ty.path "slice") [ T ],
@@ -1408,8 +1409,9 @@ Module slice.
                                   |)
                                 ]
                               |)
-                            |))
+                            |),
                             1
+                          |)
                         |)
                       |) in
                     M.alloc (|
@@ -1747,8 +1749,8 @@ Module slice.
           let a := M.alloc (| a |) in
           let b := M.alloc (| b |) in
           M.read (|
-            let pa := M.alloc (| M.get_array_field (| M.read (| self |), a |) |) in
-            let pb := M.alloc (| M.get_array_field (| M.read (| self |), b |) |) in
+            let pa := M.alloc (| M.SubPointer.get_array_field (| M.read (| self |), a |) |) in
+            let pb := M.alloc (| M.SubPointer.get_array_field (| M.read (| self |), b |) |) in
             let _ :=
               M.alloc (|
                 M.call_closure (|
@@ -1980,13 +1982,13 @@ Module slice.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "start"
                       |) in
                     let γ0_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "end"
@@ -2020,8 +2022,8 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let front_half := M.copy (| γ0_0 |) in
                             let back_half := M.copy (| γ0_1 |) in
                             let _ :=
@@ -2692,8 +2694,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let multiple_of_n := M.copy (| γ0_0 |) in
                     let remainder := M.copy (| γ0_1 |) in
                     let array_slice :=
@@ -2810,8 +2812,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let remainder := M.copy (| γ0_0 |) in
                     let multiple_of_n := M.copy (| γ0_1 |) in
                     let array_slice :=
@@ -3154,8 +3156,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let multiple_of_n := M.copy (| γ0_0 |) in
                     let remainder := M.copy (| γ0_1 |) in
                     let array_slice :=
@@ -3276,8 +3278,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let remainder := M.copy (| γ0_0 |) in
                     let multiple_of_n := M.copy (| γ0_1 |) in
                     let array_slice :=
@@ -4228,8 +4230,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4288,8 +4290,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4386,8 +4388,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4488,8 +4490,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let a := M.copy (| γ0_0 |) in
                     let b := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -4914,7 +4916,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -4957,7 +4959,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -5084,7 +5086,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -5127,7 +5129,7 @@ Module slice.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -5325,8 +5327,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let m := M.copy (| γ0_0 |) in
                     let n := M.copy (| γ0_1 |) in
                     M.alloc (|
@@ -5458,8 +5460,8 @@ Module slice.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let head := M.copy (| γ0_0 |) in
                                   let tail := M.copy (| γ0_1 |) in
                                   M.match_operator (|
@@ -5580,8 +5582,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let len := M.copy (| γ0_0 |) in
                         let n := M.copy (| γ0_1 |) in
                         let _ :=
@@ -5617,8 +5619,8 @@ Module slice.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let head := M.copy (| γ0_0 |) in
                                           let tail := M.copy (| γ0_1 |) in
                                           M.match_operator (|
@@ -7423,7 +7425,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -7684,13 +7686,13 @@ Module slice.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "start"
                       |) in
                     let γ0_1 :=
-                      M.get_struct_record_field_or_break_match (|
+                      M.SubPointer.get_struct_record_field (|
                         γ,
                         "core::ops::range::Range",
                         "end"
@@ -8172,8 +8174,8 @@ Module slice.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let left := M.copy (| γ0_0 |) in
                                 let rest := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -8190,8 +8192,8 @@ Module slice.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let us_len := M.copy (| γ0_0 |) in
                                         let ts_len := M.copy (| γ0_1 |) in
                                         M.alloc (|
@@ -8428,8 +8430,8 @@ Module slice.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let left := M.copy (| γ0_0 |) in
                                 let rest := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -8446,8 +8448,8 @@ Module slice.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let us_len := M.copy (| γ0_0 |) in
                                         let ts_len := M.copy (| γ0_1 |) in
                                         let rest_len :=
@@ -8578,8 +8580,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let left_val := M.copy (| γ0_0 |) in
                       let right_val := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -8699,8 +8701,8 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let left_val := M.copy (| γ0_0 |) in
                       let right_val := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -8885,8 +8887,8 @@ Module slice.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ := M.read (| γ |) in
-                              let γ1_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                              let γ1_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
+                              let γ1_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                              let γ1_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
                               let a := M.alloc (| γ1_0 |) in
                               let b := M.alloc (| γ1_1 |) in
                               M.call_closure (|
@@ -9143,7 +9145,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9180,7 +9182,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9192,8 +9194,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let direction := M.copy (| γ0_0 |) in
                         let split_index := M.copy (| γ0_1 |) in
                         let _ :=
@@ -9247,8 +9249,8 @@ Module slice.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let front := M.copy (| γ0_0 |) in
                                 let back := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -9344,7 +9346,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9381,7 +9383,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9393,8 +9395,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let direction := M.copy (| γ0_0 |) in
                         let split_index := M.copy (| γ0_1 |) in
                         let _ :=
@@ -9458,8 +9460,8 @@ Module slice.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let front := M.copy (| γ0_0 |) in
                                 let back := M.copy (| γ0_1 |) in
                                 M.match_operator (|
@@ -9549,7 +9551,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9582,7 +9584,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9594,8 +9596,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let first := M.copy (| γ0_0 |) in
                         let rem := M.copy (| γ0_1 |) in
                         let _ := M.write (| M.read (| self |), M.read (| rem |) |) in
@@ -9672,7 +9674,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9705,7 +9707,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9717,8 +9719,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let first := M.copy (| γ0_0 |) in
                         let rem := M.copy (| γ0_1 |) in
                         let _ := M.write (| M.read (| self |), M.read (| rem |) |) in
@@ -9787,7 +9789,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9820,7 +9822,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9832,8 +9834,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let last := M.copy (| γ0_0 |) in
                         let rem := M.copy (| γ0_1 |) in
                         let _ := M.write (| M.read (| self |), M.read (| rem |) |) in
@@ -9910,7 +9912,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -9943,7 +9945,7 @@ Module slice.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -9955,8 +9957,8 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let last := M.copy (| γ0_0 |) in
                         let rem := M.copy (| γ0_1 |) in
                         let _ := M.write (| M.read (| self |), M.read (| rem |) |) in
@@ -10089,7 +10091,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -10730,7 +10732,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -10747,8 +10749,8 @@ Module slice.
                                             []
                                           |),
                                           [
-                                            M.get_array_field (| M.read (| self |), i |);
-                                            M.get_array_field (| M.read (| src |), i |)
+                                            M.SubPointer.get_array_field (| M.read (| self |), i |);
+                                            M.SubPointer.get_array_field (| M.read (| src |), i |)
                                           ]
                                         |)
                                       |) in
@@ -11020,13 +11022,13 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
                                       |) in
-                                    let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                    let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                    let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                    let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                     let i := M.copy (| γ1_0 |) in
                                     let γ1_1 := M.read (| γ1_1 |) in
                                     let idx := M.copy (| γ1_1 |) in
@@ -11107,7 +11109,7 @@ Module slice.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0

--- a/CoqOfRust/core/slice/raw.v
+++ b/CoqOfRust/core/slice/raw.v
@@ -191,12 +191,26 @@ Module slice.
           M.call_closure (|
             M.get_function (| "core::slice::raw::from_raw_parts", [ T ] |),
             [
-              M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |);
+              M.read (|
+                M.SubPointer.get_struct_record_field (| range, "core::ops::range::Range", "start" |)
+              |);
               M.call_closure (|
                 M.get_associated_function (| Ty.apply (Ty.path "*const") [ T ], "sub_ptr", [] |),
                 [
-                  M.read (| M.get_struct_record_field range "core::ops::range::Range" "end" |);
-                  M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |)
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      range,
+                      "core::ops::range::Range",
+                      "end"
+                    |)
+                  |);
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      range,
+                      "core::ops::range::Range",
+                      "start"
+                    |)
+                  |)
                 ]
               |)
             ]
@@ -218,14 +232,28 @@ Module slice.
           M.call_closure (|
             M.get_function (| "core::slice::raw::from_raw_parts_mut", [ T ] |),
             [
-              M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |);
+              M.read (|
+                M.SubPointer.get_struct_record_field (| range, "core::ops::range::Range", "start" |)
+              |);
               M.call_closure (|
                 M.get_associated_function (| Ty.apply (Ty.path "*mut") [ T ], "sub_ptr", [] |),
                 [
-                  M.read (| M.get_struct_record_field range "core::ops::range::Range" "end" |);
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      range,
+                      "core::ops::range::Range",
+                      "end"
+                    |)
+                  |);
                   (* MutToConstPointer *)
                   M.pointer_coercion
-                    (M.read (| M.get_struct_record_field range "core::ops::range::Range" "start" |))
+                    (M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        range,
+                        "core::ops::range::Range",
+                        "start"
+                      |)
+                    |))
                 ]
               |)
             ]

--- a/CoqOfRust/core/slice/rotate.v
+++ b/CoqOfRust/core/slice/rotate.v
@@ -498,7 +498,7 @@ Module slice.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                       γ,
                                                                       "core::option::Option::Some",
                                                                       0

--- a/CoqOfRust/core/slice/select.v
+++ b/CoqOfRust/core/slice/select.v
@@ -281,8 +281,8 @@ Module slice.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let pivot := M.copy (| γ0_0 |) in
                                   let _ :=
                                     M.match_operator (|
@@ -292,7 +292,7 @@ Module slice.
                                           ltac:(M.monadic
                                             (let γ := pred in
                                             let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -326,7 +326,7 @@ Module slice.
                                                                 Value.Tuple
                                                                   [
                                                                     M.read (| p |);
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       M.read (| v |),
                                                                       pivot
                                                                     |)
@@ -451,8 +451,8 @@ Module slice.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let mid := M.copy (| γ0_0 |) in
                                           let _ :=
                                             M.write (|
@@ -504,8 +504,10 @@ Module slice.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let left := M.copy (| γ0_0 |) in
                                                   let right := M.copy (| γ0_1 |) in
                                                   M.match_operator (|
@@ -525,13 +527,21 @@ Module slice.
                                                     [
                                                       fun γ =>
                                                         ltac:(M.monadic
-                                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                                          (let γ0_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              0
+                                                            |) in
+                                                          let γ0_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              1
+                                                            |) in
                                                           let pivot := M.copy (| γ0_0 |) in
                                                           let right := M.copy (| γ0_1 |) in
                                                           let pivot :=
                                                             M.alloc (|
-                                                              M.get_array_field (|
+                                                              M.SubPointer.get_array_field (|
                                                                 M.read (| pivot |),
                                                                 M.alloc (|
                                                                   Value.Integer Integer.Usize 0
@@ -756,10 +766,16 @@ Module slice.
                                                               Value.Tuple
                                                                 [
                                                                   M.read (|
-                                                                    M.get_tuple_field t 1
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      t,
+                                                                      1
+                                                                    |)
                                                                   |);
                                                                   M.read (|
-                                                                    M.get_tuple_field acc 1
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      acc,
+                                                                      1
+                                                                    |)
                                                                   |)
                                                                 ]
                                                             ]
@@ -793,8 +809,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let i := M.copy (| γ0_0 |) in
                               M.read (| i |)))
                         ]
@@ -920,9 +936,17 @@ Module slice.
                                                               Value.Tuple
                                                                 [
                                                                   M.read (|
-                                                                    M.get_tuple_field acc 1
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      acc,
+                                                                      1
+                                                                    |)
                                                                   |);
-                                                                  M.read (| M.get_tuple_field t 1 |)
+                                                                  M.read (|
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      t,
+                                                                      1
+                                                                    |)
+                                                                  |)
                                                                 ]
                                                             ]
                                                           |)
@@ -955,8 +979,8 @@ Module slice.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let i := M.copy (| γ0_0 |) in
                               M.read (| i |)))
                         ]
@@ -1260,8 +1284,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left := M.copy (| γ0_0 |) in
                     let right := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1278,13 +1302,13 @@ Module slice.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let pivot := M.copy (| γ0_0 |) in
                             let right := M.copy (| γ0_1 |) in
                             let pivot :=
                               M.alloc (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| pivot |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
                                 |)
@@ -2043,7 +2067,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -2142,8 +2166,8 @@ Module slice.
                   ]
                 |)
               |) in
-            M.get_tuple_field
-              (M.alloc (|
+            M.SubPointer.get_tuple_field (|
+              M.alloc (|
                 M.call_closure (|
                   M.get_function (| "core::slice::sort::partition", [ T; F ] |),
                   [
@@ -2152,8 +2176,9 @@ Module slice.
                     M.read (| is_less |)
                   ]
                 |)
-              |))
+              |),
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -2272,8 +2297,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), h |);
-                                        M.get_array_field (| M.read (| v |), b |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), h |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), b |)
                                       ]
                                   ]
                                 |)
@@ -2316,8 +2341,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), f |);
-                                        M.get_array_field (| M.read (| v |), d |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), f |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), d |)
                                       ]
                                   ]
                                 |)
@@ -2360,8 +2385,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), e |);
-                                        M.get_array_field (| M.read (| v |), d |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), e |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), d |)
                                       ]
                                   ]
                                 |)
@@ -2397,8 +2422,11 @@ Module slice.
                                             M.read (| is_less |);
                                             Value.Tuple
                                               [
-                                                M.get_array_field (| M.read (| v |), f |);
-                                                M.get_array_field (| M.read (| v |), e |)
+                                                M.SubPointer.get_array_field (|
+                                                  M.read (| v |),
+                                                  f
+                                                |);
+                                                M.SubPointer.get_array_field (| M.read (| v |), e |)
                                               ]
                                           ]
                                         |)
@@ -2442,11 +2470,11 @@ Module slice.
                                                             M.read (| is_less |);
                                                             Value.Tuple
                                                               [
-                                                                M.get_array_field (|
+                                                                M.SubPointer.get_array_field (|
                                                                   M.read (| v |),
                                                                   e
                                                                 |);
-                                                                M.get_array_field (|
+                                                                M.SubPointer.get_array_field (|
                                                                   M.read (| v |),
                                                                   b
                                                                 |)
@@ -2507,11 +2535,11 @@ Module slice.
                                                                     M.read (| is_less |);
                                                                     Value.Tuple
                                                                       [
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           h
                                                                         |);
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           e
                                                                         |)
@@ -2580,8 +2608,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), d |);
-                                        M.get_array_field (| M.read (| v |), b |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), d |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), b |)
                                       ]
                                   ]
                                 |)
@@ -2618,8 +2646,11 @@ Module slice.
                                             M.read (| is_less |);
                                             Value.Tuple
                                               [
-                                                M.get_array_field (| M.read (| v |), h |);
-                                                M.get_array_field (| M.read (| v |), d |)
+                                                M.SubPointer.get_array_field (|
+                                                  M.read (| v |),
+                                                  h
+                                                |);
+                                                M.SubPointer.get_array_field (| M.read (| v |), d |)
                                               ]
                                           ]
                                         |)
@@ -2706,8 +2737,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), c |);
-                                        M.get_array_field (| M.read (| v |), a |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), c |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), a |)
                                       ]
                                   ]
                                 |)
@@ -2750,8 +2781,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), c |);
-                                        M.get_array_field (| M.read (| v |), b |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), c |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), b |)
                                       ]
                                   ]
                                 |)
@@ -2789,8 +2820,8 @@ Module slice.
                                     M.read (| is_less |);
                                     Value.Tuple
                                       [
-                                        M.get_array_field (| M.read (| v |), b |);
-                                        M.get_array_field (| M.read (| v |), a |)
+                                        M.SubPointer.get_array_field (| M.read (| v |), b |);
+                                        M.SubPointer.get_array_field (| M.read (| v |), a |)
                                       ]
                                   ]
                                 |)

--- a/CoqOfRust/core/slice/sort.v
+++ b/CoqOfRust/core/slice/sort.v
@@ -38,16 +38,18 @@ Module slice.
                     M.get_function (| "core::intrinsics::copy_nonoverlapping", [ T ] |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::sort::InsertionHole"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::sort::InsertionHole",
                           "src"
+                        |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::sort::InsertionHole"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::sort::InsertionHole",
                           "dest"
+                        |)
                       |);
                       Value.Integer Integer.Usize 1
                     ]
@@ -290,10 +292,11 @@ Module slice.
                             (* MutToConstPointer *)
                             M.pointer_coercion
                               (M.read (|
-                                M.get_struct_record_field
-                                  hole
-                                  "core::slice::sort::InsertionHole"
+                                M.SubPointer.get_struct_record_field (|
+                                  hole,
+                                  "core::slice::sort::InsertionHole",
                                   "dest"
+                                |)
                               |));
                             M.read (| i_ptr |);
                             Value.Integer Integer.Usize 1
@@ -374,7 +377,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -464,10 +467,11 @@ Module slice.
                                                     (* MutToConstPointer *)
                                                     M.pointer_coercion (M.read (| j_ptr |));
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        hole
-                                                        "core::slice::sort::InsertionHole"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        hole,
+                                                        "core::slice::sort::InsertionHole",
                                                         "dest"
+                                                      |)
                                                     |);
                                                     Value.Integer Integer.Usize 1
                                                   ]
@@ -475,10 +479,11 @@ Module slice.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_struct_record_field
-                                                  hole
-                                                  "core::slice::sort::InsertionHole"
-                                                  "dest",
+                                                M.SubPointer.get_struct_record_field (|
+                                                  hole,
+                                                  "core::slice::sort::InsertionHole",
+                                                  "dest"
+                                                |),
                                                 M.read (| j_ptr |)
                                               |) in
                                             M.alloc (| Value.Tuple [] |)))
@@ -792,7 +797,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -910,10 +915,11 @@ Module slice.
                                               |) in
                                             let _ :=
                                               M.write (|
-                                                M.get_struct_record_field
-                                                  hole
-                                                  "core::slice::sort::InsertionHole"
-                                                  "dest",
+                                                M.SubPointer.get_struct_record_field (|
+                                                  hole,
+                                                  "core::slice::sort::InsertionHole",
+                                                  "dest"
+                                                |),
                                                 M.call_closure (|
                                                   M.get_associated_function (|
                                                     Ty.apply (Ty.path "*mut") [ T ],
@@ -1052,7 +1058,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -1245,7 +1251,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -1420,7 +1426,7 @@ Module slice.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -1902,11 +1908,11 @@ Module slice.
                                                                     is_less;
                                                                     Value.Tuple
                                                                       [
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           child
                                                                         |);
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           M.alloc (|
                                                                             BinOp.Panic.add (|
@@ -1960,11 +1966,11 @@ Module slice.
                                                                     is_less;
                                                                     Value.Tuple
                                                                       [
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           node
                                                                         |);
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           child
                                                                         |)
@@ -2094,7 +2100,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -2216,7 +2222,7 @@ Module slice.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -3005,7 +3011,7 @@ Module slice.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -3169,7 +3175,7 @@ Module slice.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -3420,7 +3426,7 @@ Module slice.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -3779,8 +3785,8 @@ Module slice.
                                   [
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (let γ0_0 := M.get_tuple_field γ 0 in
-                                        let γ0_1 := M.get_tuple_field γ 1 in
+                                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                         let left_val := M.copy (| γ0_0 |) in
                                         let right_val := M.copy (| γ0_1 |) in
                                         M.match_operator (|
@@ -3995,8 +4001,10 @@ Module slice.
                                           [
                                             fun γ =>
                                               ltac:(M.monadic
-                                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                                let γ0_1 := M.get_tuple_field γ 1 in
+                                                (let γ0_0 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                let γ0_1 :=
+                                                  M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                 let left_val := M.copy (| γ0_0 |) in
                                                 let right_val := M.copy (| γ0_1 |) in
                                                 M.match_operator (|
@@ -4360,13 +4368,13 @@ Module slice.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let pivot := M.copy (| γ0_0 |) in
                       let v := M.copy (| γ0_1 |) in
                       let pivot :=
                         M.alloc (|
-                          M.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (| pivot |),
                             M.alloc (| Value.Integer Integer.Usize 0 |)
                           |)
@@ -4637,8 +4645,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let mid := M.copy (| γ0_0 |) in
                     let was_partitioned := M.copy (| γ0_1 |) in
                     let _ :=
@@ -4753,13 +4761,13 @@ Module slice.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let pivot := M.copy (| γ0_0 |) in
                         let v := M.copy (| γ0_1 |) in
                         let pivot :=
                           M.alloc (|
-                            M.get_array_field (|
+                            M.SubPointer.get_array_field (|
                               M.read (| pivot |),
                               M.alloc (| Value.Integer Integer.Usize 0 |)
                             |)
@@ -5346,7 +5354,7 @@ Module slice.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -6371,8 +6379,8 @@ Module slice.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let pivot := M.copy (| γ0_0 |) in
                                   let likely_sorted := M.copy (| γ0_1 |) in
                                   let _ :=
@@ -6439,7 +6447,7 @@ Module slice.
                                           ltac:(M.monadic
                                             (let γ := pred in
                                             let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -6473,7 +6481,7 @@ Module slice.
                                                                 Value.Tuple
                                                                   [
                                                                     M.read (| p |);
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       M.read (| v |),
                                                                       pivot
                                                                     |)
@@ -6551,8 +6559,8 @@ Module slice.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let mid := M.copy (| γ0_0 |) in
                                           let was_p := M.copy (| γ0_1 |) in
                                           let _ :=
@@ -6593,8 +6601,10 @@ Module slice.
                                             [
                                               fun γ =>
                                                 ltac:(M.monadic
-                                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                                  (let γ0_0 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                  let γ0_1 :=
+                                                    M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                   let left := M.copy (| γ0_0 |) in
                                                   let right := M.copy (| γ0_1 |) in
                                                   M.match_operator (|
@@ -6614,13 +6624,21 @@ Module slice.
                                                     [
                                                       fun γ =>
                                                         ltac:(M.monadic
-                                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                                          (let γ0_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              0
+                                                            |) in
+                                                          let γ0_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              1
+                                                            |) in
                                                           let pivot := M.copy (| γ0_0 |) in
                                                           let right := M.copy (| γ0_1 |) in
                                                           let pivot :=
                                                             M.alloc (|
-                                                              M.get_array_field (|
+                                                              M.SubPointer.get_array_field (|
                                                                 M.read (| pivot |),
                                                                 M.alloc (|
                                                                   Value.Integer Integer.Usize 0
@@ -6969,8 +6987,8 @@ Module slice.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let v_mid := M.copy (| γ0_0 |) in
                     let v_end := M.copy (| γ0_1 |) in
                     let hole := M.copy (| Value.DeclaredButUndefined |) in
@@ -7029,18 +7047,20 @@ Module slice.
                                 M.alloc (| Value.Tuple [] |) in
                               let left :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    hole
-                                    "core::slice::sort::merge::MergeHole"
+                                  M.SubPointer.get_struct_record_field (|
+                                    hole,
+                                    "core::slice::sort::merge::MergeHole",
                                     "start"
+                                  |)
                                 |) in
                               let right := M.copy (| v_mid |) in
                               let out :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    hole
-                                    "core::slice::sort::merge::MergeHole"
+                                  M.SubPointer.get_struct_record_field (|
+                                    hole,
+                                    "core::slice::sort::merge::MergeHole",
                                     "dest"
+                                  |)
                                 |) in
                               M.loop (|
                                 ltac:(M.monadic
@@ -7056,10 +7076,11 @@ Module slice.
                                                   BinOp.Pure.lt
                                                     (M.read (| M.read (| left |) |))
                                                     (M.read (|
-                                                      M.get_struct_record_field
-                                                        hole
-                                                        "core::slice::sort::merge::MergeHole"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        hole,
+                                                        "core::slice::sort::merge::MergeHole",
                                                         "end"
+                                                      |)
                                                     |)),
                                                   ltac:(M.monadic
                                                     (BinOp.Pure.lt
@@ -7239,17 +7260,19 @@ Module slice.
                                 M.alloc (| Value.Tuple [] |) in
                               let left :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    hole
-                                    "core::slice::sort::merge::MergeHole"
+                                  M.SubPointer.get_struct_record_field (|
+                                    hole,
+                                    "core::slice::sort::merge::MergeHole",
                                     "dest"
+                                  |)
                                 |) in
                               let right :=
                                 M.alloc (|
-                                  M.get_struct_record_field
-                                    hole
-                                    "core::slice::sort::merge::MergeHole"
+                                  M.SubPointer.get_struct_record_field (|
+                                    hole,
+                                    "core::slice::sort::merge::MergeHole",
                                     "end"
+                                  |)
                                 |) in
                               let out := M.copy (| v_end |) in
                               M.loop (|
@@ -7467,18 +7490,20 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::sort::merge::MergeHole"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::sort::merge::MergeHole",
                             "end"
+                          |)
                         |);
                         (* MutToConstPointer *)
                         M.pointer_coercion
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::sort::merge::MergeHole"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::sort::merge::MergeHole",
                               "start"
+                            |)
                           |))
                       ]
                     |)
@@ -7491,16 +7516,18 @@ Module slice.
                         (* MutToConstPointer *)
                         M.pointer_coercion
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::slice::sort::merge::MergeHole"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::slice::sort::merge::MergeHole",
                               "start"
+                            |)
                           |));
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::sort::merge::MergeHole"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::sort::merge::MergeHole",
                             "dest"
+                          |)
                         |);
                         M.read (| len |)
                       ]
@@ -7959,10 +7986,11 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            buf
-                            "core::slice::sort::merge_sort::BufGuard"
+                          M.SubPointer.get_struct_record_field (|
+                            buf,
+                            "core::slice::sort::merge_sort::BufGuard",
                             "buf_ptr"
+                          |)
                         |)
                       ]
                     |)
@@ -8034,8 +8062,8 @@ Module slice.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let streak_end := M.copy (| γ0_0 |) in
                                       let was_reversed := M.copy (| γ0_1 |) in
                                       let _ :=
@@ -8170,7 +8198,7 @@ Module slice.
                                                       |)
                                                     |) in
                                                   let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -8235,24 +8263,27 @@ Module slice.
                                                             [
                                                               ("start",
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    left
-                                                                    "core::slice::sort::TimSortRun"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    left,
+                                                                    "core::slice::sort::TimSortRun",
                                                                     "start"
+                                                                  |)
                                                                 |));
                                                               ("end_",
                                                                 BinOp.Panic.add (|
                                                                   M.read (|
-                                                                    M.get_struct_record_field
-                                                                      right
-                                                                      "core::slice::sort::TimSortRun"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      right,
+                                                                      "core::slice::sort::TimSortRun",
                                                                       "start"
+                                                                    |)
                                                                   |),
                                                                   M.read (|
-                                                                    M.get_struct_record_field
-                                                                      right
-                                                                      "core::slice::sort::TimSortRun"
+                                                                    M.SubPointer.get_struct_record_field (|
+                                                                      right,
+                                                                      "core::slice::sort::TimSortRun",
                                                                       "len"
+                                                                    |)
                                                                   |)
                                                                 |))
                                                             ]
@@ -8270,10 +8301,11 @@ Module slice.
                                                           [
                                                             M.read (| merge_slice |);
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                left
-                                                                "core::slice::sort::TimSortRun"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                left,
+                                                                "core::slice::sort::TimSortRun",
                                                                 "len"
+                                                              |)
                                                             |);
                                                             M.read (| buf_ptr |);
                                                             M.read (| is_less |)
@@ -8307,24 +8339,27 @@ Module slice.
                                                         [
                                                           ("start",
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                left
-                                                                "core::slice::sort::TimSortRun"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                left,
+                                                                "core::slice::sort::TimSortRun",
                                                                 "start"
+                                                              |)
                                                             |));
                                                           ("len",
                                                             BinOp.Panic.add (|
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  left
-                                                                  "core::slice::sort::TimSortRun"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  left,
+                                                                  "core::slice::sort::TimSortRun",
                                                                   "len"
+                                                                |)
                                                               |),
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  right
-                                                                  "core::slice::sort::TimSortRun"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  right,
+                                                                  "core::slice::sort::TimSortRun",
                                                                   "len"
+                                                                |)
                                                               |)
                                                             |))
                                                         ]
@@ -8417,8 +8452,8 @@ Module slice.
                                                 ltac:(M.monadic
                                                   (BinOp.Pure.eq
                                                     (M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.call_closure (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.call_closure (|
                                                           M.get_trait_method (|
                                                             "core::ops::index::Index",
                                                             Ty.apply
@@ -8430,17 +8465,18 @@ Module slice.
                                                             []
                                                           |),
                                                           [ runs; Value.Integer Integer.Usize 0 ]
-                                                        |))
-                                                        "core::slice::sort::TimSortRun"
+                                                        |),
+                                                        "core::slice::sort::TimSortRun",
                                                         "start"
+                                                      |)
                                                     |))
                                                     (Value.Integer Integer.Usize 0)))
                                               |),
                                               ltac:(M.monadic
                                                 (BinOp.Pure.eq
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.call_closure (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.call_closure (|
                                                         M.get_trait_method (|
                                                           "core::ops::index::Index",
                                                           Ty.apply
@@ -8452,9 +8488,10 @@ Module slice.
                                                           []
                                                         |),
                                                         [ runs; Value.Integer Integer.Usize 0 ]
-                                                      |))
-                                                      "core::slice::sort::TimSortRun"
+                                                      |),
+                                                      "core::slice::sort::TimSortRun",
                                                       "len"
+                                                    |)
                                                   |))
                                                   (M.read (| len |))))
                                             |))
@@ -8544,8 +8581,8 @@ Module slice.
                                       BinOp.Pure.eq
                                         (BinOp.Panic.add (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8553,13 +8590,14 @@ Module slice.
                                                     Value.Integer Integer.Usize 1
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "start"
+                                            |)
                                           |),
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8567,17 +8605,18 @@ Module slice.
                                                     Value.Integer Integer.Usize 1
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |)
                                         |))
                                         (M.read (| stop |)),
                                       ltac:(M.monadic
                                         (BinOp.Pure.le
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8585,13 +8624,14 @@ Module slice.
                                                     Value.Integer Integer.Usize 2
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8599,9 +8639,10 @@ Module slice.
                                                     Value.Integer Integer.Usize 1
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |))))
                                     |),
                                     ltac:(M.monadic
@@ -8612,8 +8653,8 @@ Module slice.
                                         ltac:(M.monadic
                                           (BinOp.Pure.le
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.SubPointer.get_array_field (|
                                                   M.read (| runs |),
                                                   M.alloc (|
                                                     BinOp.Panic.sub (|
@@ -8621,14 +8662,15 @@ Module slice.
                                                       Value.Integer Integer.Usize 3
                                                     |)
                                                   |)
-                                                |))
-                                                "core::slice::sort::TimSortRun"
+                                                |),
+                                                "core::slice::sort::TimSortRun",
                                                 "len"
+                                              |)
                                             |))
                                             (BinOp.Panic.add (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     M.read (| runs |),
                                                     M.alloc (|
                                                       BinOp.Panic.sub (|
@@ -8636,13 +8678,14 @@ Module slice.
                                                         Value.Integer Integer.Usize 2
                                                       |)
                                                     |)
-                                                  |))
-                                                  "core::slice::sort::TimSortRun"
+                                                  |),
+                                                  "core::slice::sort::TimSortRun",
                                                   "len"
+                                                |)
                                               |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.get_array_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.SubPointer.get_array_field (|
                                                     M.read (| runs |),
                                                     M.alloc (|
                                                       BinOp.Panic.sub (|
@@ -8650,9 +8693,10 @@ Module slice.
                                                         Value.Integer Integer.Usize 1
                                                       |)
                                                     |)
-                                                  |))
-                                                  "core::slice::sort::TimSortRun"
+                                                  |),
+                                                  "core::slice::sort::TimSortRun",
                                                   "len"
+                                                |)
                                               |)
                                             |))))
                                       |)))
@@ -8665,8 +8709,8 @@ Module slice.
                                       ltac:(M.monadic
                                         (BinOp.Pure.le
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8674,14 +8718,15 @@ Module slice.
                                                     Value.Integer Integer.Usize 4
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |))
                                           (BinOp.Panic.add (|
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.SubPointer.get_array_field (|
                                                   M.read (| runs |),
                                                   M.alloc (|
                                                     BinOp.Panic.sub (|
@@ -8689,13 +8734,14 @@ Module slice.
                                                       Value.Integer Integer.Usize 3
                                                     |)
                                                   |)
-                                                |))
-                                                "core::slice::sort::TimSortRun"
+                                                |),
+                                                "core::slice::sort::TimSortRun",
                                                 "len"
+                                              |)
                                             |),
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.get_array_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.SubPointer.get_array_field (|
                                                   M.read (| runs |),
                                                   M.alloc (|
                                                     BinOp.Panic.sub (|
@@ -8703,9 +8749,10 @@ Module slice.
                                                       Value.Integer Integer.Usize 2
                                                     |)
                                                   |)
-                                                |))
-                                                "core::slice::sort::TimSortRun"
+                                                |),
+                                                "core::slice::sort::TimSortRun",
                                                 "len"
+                                              |)
                                             |)
                                           |))))
                                     |)))
@@ -8728,8 +8775,8 @@ Module slice.
                                       ltac:(M.monadic
                                         (BinOp.Pure.lt
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8737,13 +8784,14 @@ Module slice.
                                                     Value.Integer Integer.Usize 3
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |))
                                           (M.read (|
-                                            M.get_struct_record_field
-                                              (M.get_array_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| runs |),
                                                 M.alloc (|
                                                   BinOp.Panic.sub (|
@@ -8751,9 +8799,10 @@ Module slice.
                                                     Value.Integer Integer.Usize 1
                                                   |)
                                                 |)
-                                              |))
-                                              "core::slice::sort::TimSortRun"
+                                              |),
+                                              "core::slice::sort::TimSortRun",
                                               "len"
+                                            |)
                                           |))))
                                     |)
                                   |)) in
@@ -8907,10 +8956,11 @@ Module slice.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::sort::merge_sort::BufGuard"
-                          "elem_dealloc_fn";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::sort::merge_sort::BufGuard",
+                          "elem_dealloc_fn"
+                        |);
                         Value.Tuple
                           [
                             M.call_closure (|
@@ -8921,18 +8971,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::sort::merge_sort::BufGuard"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::sort::merge_sort::BufGuard",
                                     "buf_ptr"
+                                  |)
                                 |)
                               ]
                             |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::sort::merge_sort::BufGuard"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::sort::merge_sort::BufGuard",
                                 "capacity"
+                              |)
                             |)
                           ]
                       ]
@@ -9103,26 +9155,29 @@ Module slice.
                               (M.alloc (|
                                 BinOp.Pure.eq
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::sort::merge_sort::RunVec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::sort::merge_sort::RunVec",
                                       "len"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::sort::merge_sort::RunVec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::sort::merge_sort::RunVec",
                                       "capacity"
+                                    |)
                                   |))
                               |)) in
                           let _ :=
                             M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                           let old_capacity :=
                             M.copy (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::sort::merge_sort::RunVec"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::sort::merge_sort::RunVec",
                                 "capacity"
+                              |)
                             |) in
                           let old_buf_ptr :=
                             M.alloc (|
@@ -9136,36 +9191,40 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::sort::merge_sort::RunVec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::sort::merge_sort::RunVec",
                                       "buf_ptr"
+                                    |)
                                   |)
                                 ]
                               |)
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::sort::merge_sort::RunVec"
-                                "capacity",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::sort::merge_sort::RunVec",
+                                "capacity"
+                              |),
                               BinOp.Panic.mul (|
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::sort::merge_sort::RunVec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::sort::merge_sort::RunVec",
                                     "capacity"
+                                  |)
                                 |),
                                 Value.Integer Integer.Usize 2
                               |)
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::sort::merge_sort::RunVec"
-                                "buf_ptr",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::sort::merge_sort::RunVec",
+                                "buf_ptr"
+                              |),
                               M.call_closure (|
                                 M.get_associated_function (|
                                   Ty.apply
@@ -9197,17 +9256,19 @@ Module slice.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::sort::merge_sort::RunVec"
-                                            "run_alloc_fn";
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::sort::merge_sort::RunVec",
+                                            "run_alloc_fn"
+                                          |);
                                           Value.Tuple
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::slice::sort::merge_sort::RunVec"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::slice::sort::merge_sort::RunVec",
                                                   "capacity"
+                                                |)
                                               |)
                                             ]
                                         ]
@@ -9238,10 +9299,11 @@ Module slice.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::sort::merge_sort::RunVec"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::sort::merge_sort::RunVec",
                                             "buf_ptr"
+                                          |)
                                         |)
                                       ]
                                     |);
@@ -9269,10 +9331,11 @@ Module slice.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::sort::merge_sort::RunVec"
-                                    "run_dealloc_fn";
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::sort::merge_sort::RunVec",
+                                    "run_dealloc_fn"
+                                  |);
                                   Value.Tuple
                                     [ M.read (| old_buf_ptr |); M.read (| old_capacity |) ]
                                 ]
@@ -9309,18 +9372,20 @@ Module slice.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::sort::merge_sort::RunVec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::sort::merge_sort::RunVec",
                                       "buf_ptr"
+                                    |)
                                   |)
                                 ]
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::sort::merge_sort::RunVec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::sort::merge_sort::RunVec",
                                   "len"
+                                |)
                               |)
                             ]
                           |);
@@ -9331,10 +9396,11 @@ Module slice.
                   M.alloc (| Value.Tuple [] |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::sort::merge_sort::RunVec"
-                      "len" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::sort::merge_sort::RunVec",
+                      "len"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9385,10 +9451,11 @@ Module slice.
                                 BinOp.Pure.ge
                                   (M.read (| index |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::slice::sort::merge_sort::RunVec"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::slice::sort::merge_sort::RunVec",
                                       "len"
+                                    |)
                                   |))
                               |)) in
                           let _ :=
@@ -9440,10 +9507,11 @@ Module slice.
                             |),
                             [
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::sort::merge_sort::RunVec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::sort::merge_sort::RunVec",
                                   "buf_ptr"
+                                |)
                               |)
                             ]
                           |);
@@ -9475,10 +9543,11 @@ Module slice.
                           BinOp.Panic.sub (|
                             BinOp.Panic.sub (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::slice::sort::merge_sort::RunVec"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::slice::sort::merge_sort::RunVec",
                                   "len"
+                                |)
                               |),
                               M.read (| index |)
                             |),
@@ -9490,10 +9559,11 @@ Module slice.
                   M.alloc (| Value.Tuple [] |) in
                 let _ :=
                   let β :=
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::sort::merge_sort::RunVec"
-                      "len" in
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::sort::merge_sort::RunVec",
+                      "len"
+                    |) in
                   M.write (|
                     β,
                     BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -9540,18 +9610,20 @@ Module slice.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::slice::sort::merge_sort::RunVec"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::slice::sort::merge_sort::RunVec",
                             "buf_ptr"
+                          |)
                         |)
                       ]
                     |));
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::sort::merge_sort::RunVec"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::sort::merge_sort::RunVec",
                       "len"
+                    |)
                   |)
                 ]
               |)))
@@ -9577,10 +9649,11 @@ Module slice.
             ltac:(M.monadic
               (let self := M.alloc (| self |) in
               M.read (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::slice::sort::merge_sort::RunVec"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::slice::sort::merge_sort::RunVec",
                   "len"
+                |)
               |)))
           | _, _ => M.impossible
           end.
@@ -9633,10 +9706,11 @@ Module slice.
                                       BinOp.Pure.lt
                                         (M.read (| index |))
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::sort::merge_sort::RunVec"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::sort::merge_sort::RunVec",
                                             "len"
+                                          |)
                                         |))
                                     |)) in
                                 let _ :=
@@ -9667,10 +9741,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::sort::merge_sort::RunVec"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::sort::merge_sort::RunVec",
                                                     "buf_ptr"
+                                                  |)
                                                 |)
                                               ]
                                             |);
@@ -9767,10 +9842,11 @@ Module slice.
                                       BinOp.Pure.lt
                                         (M.read (| index |))
                                         (M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::slice::sort::merge_sort::RunVec"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::slice::sort::merge_sort::RunVec",
                                             "len"
+                                          |)
                                         |))
                                     |)) in
                                 let _ :=
@@ -9801,10 +9877,11 @@ Module slice.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::slice::sort::merge_sort::RunVec"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::slice::sort::merge_sort::RunVec",
                                                     "buf_ptr"
+                                                  |)
                                                 |)
                                               ]
                                             |);
@@ -9890,10 +9967,11 @@ Module slice.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::slice::sort::merge_sort::RunVec"
-                          "run_dealloc_fn";
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::slice::sort::merge_sort::RunVec",
+                          "run_dealloc_fn"
+                        |);
                         Value.Tuple
                           [
                             M.call_closure (|
@@ -9906,18 +9984,20 @@ Module slice.
                               |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::slice::sort::merge_sort::RunVec"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::slice::sort::merge_sort::RunVec",
                                     "buf_ptr"
+                                  |)
                                 |)
                               ]
                             |);
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::slice::sort::merge_sort::RunVec"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::slice::sort::merge_sort::RunVec",
                                 "capacity"
+                              |)
                             |)
                           ]
                       ]
@@ -10004,18 +10084,20 @@ Module slice.
                 M.read (| Value.String "len" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::slice::sort::TimSortRun"
-                    "len");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::slice::sort::TimSortRun",
+                    "len"
+                  |));
                 M.read (| Value.String "start" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::slice::sort::TimSortRun"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::slice::sort::TimSortRun",
                       "start"
+                    |)
                   |))
               ]
             |)))

--- a/CoqOfRust/core/slice/specialize.v
+++ b/CoqOfRust/core/slice/specialize.v
@@ -45,13 +45,13 @@ Module slice.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let last := M.copy (| γ1_0 |) in
                       let elems := M.copy (| γ1_1 |) in
                       let _ :=
@@ -100,7 +100,7 @@ Module slice.
                                             fun γ =>
                                               ltac:(M.monadic
                                                 (let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -213,7 +213,7 @@ Module slice.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0

--- a/CoqOfRust/core/str/converts.v
+++ b/CoqOfRust/core/str/converts.v
@@ -32,11 +32,7 @@ Module str.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (|
                       Value.StructTuple
                         "core::result::Result::Ok"
@@ -50,11 +46,7 @@ Module str.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let err := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::result::Result::Err" [ M.read (| err |) ]
@@ -94,11 +86,7 @@ Module str.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (|
                       Value.StructTuple
                         "core::result::Result::Ok"
@@ -112,11 +100,7 @@ Module str.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let err := M.copy (| γ0_0 |) in
                     M.alloc (|
                       Value.StructTuple "core::result::Result::Err" [ M.read (| err |) ]

--- a/CoqOfRust/core/str/count.v
+++ b/CoqOfRust/core/str/count.v
@@ -175,9 +175,9 @@ Module str.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
-                        let γ0_2 := M.get_tuple_field γ 2 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                        let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                         let head := M.copy (| γ0_0 |) in
                         let body := M.copy (| γ0_1 |) in
                         let tail := M.copy (| γ0_2 |) in
@@ -353,7 +353,7 @@ Module str.
                                               fun γ =>
                                                 ltac:(M.monadic
                                                   (let γ0_0 :=
-                                                    M.get_struct_tuple_field_or_break_match (|
+                                                    M.SubPointer.get_struct_tuple_field (|
                                                       γ,
                                                       "core::option::Option::Some",
                                                       0
@@ -377,8 +377,16 @@ Module str.
                                                     [
                                                       fun γ =>
                                                         ltac:(M.monadic
-                                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                                          (let γ0_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              0
+                                                            |) in
+                                                          let γ0_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ,
+                                                              1
+                                                            |) in
                                                           let unrolled_chunks :=
                                                             M.copy (| γ0_0 |) in
                                                           let remainder := M.copy (| γ0_1 |) in
@@ -451,7 +459,7 @@ Module str.
                                                                                 fun γ =>
                                                                                   ltac:(M.monadic
                                                                                     (let γ0_0 :=
-                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                         γ,
                                                                                         "core::option::Option::Some",
                                                                                         0
@@ -538,7 +546,7 @@ Module str.
                                                                                                           ltac:(M.monadic
                                                                                                             (let
                                                                                                                   γ0_0 :=
-                                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                                 γ,
                                                                                                                 "core::option::Option::Some",
                                                                                                                 0
@@ -724,7 +732,7 @@ Module str.
                                                                                                 ltac:(M.monadic
                                                                                                   (let
                                                                                                         γ0_0 :=
-                                                                                                    M.get_struct_tuple_field_or_break_match (|
+                                                                                                    M.SubPointer.get_struct_tuple_field (|
                                                                                                       γ,
                                                                                                       "core::option::Option::Some",
                                                                                                       0

--- a/CoqOfRust/core/str/error.v
+++ b/CoqOfRust/core/str/error.v
@@ -94,16 +94,18 @@ Module str.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::error::Utf8Error"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::error::Utf8Error",
                     "valid_up_to"
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::str::error::Utf8Error"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::str::error::Utf8Error",
                     "valid_up_to"
+                  |)
                 |)),
               ltac:(M.monadic
                 (M.call_closure (|
@@ -115,14 +117,16 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::error::Utf8Error"
-                      "error_len";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::str::error::Utf8Error"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::error::Utf8Error",
                       "error_len"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::str::error::Utf8Error",
+                      "error_len"
+                    |)
                   ]
                 |)))
             |)))
@@ -192,18 +196,20 @@ Module str.
                 M.read (| Value.String "valid_up_to" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::error::Utf8Error"
-                    "valid_up_to");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::error::Utf8Error",
+                    "valid_up_to"
+                  |));
                 M.read (| Value.String "error_len" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::error::Utf8Error"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::error::Utf8Error",
                       "error_len"
+                    |)
                   |))
               ]
             |)))
@@ -232,10 +238,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::str::error::Utf8Error"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::error::Utf8Error",
                 "valid_up_to"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -258,15 +265,16 @@ Module str.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::error::Utf8Error"
-                  "error_len",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::error::Utf8Error",
+                  "error_len"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -318,12 +326,13 @@ Module str.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ :=
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::str::error::Utf8Error"
-                          "error_len" in
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::str::error::Utf8Error",
+                          "error_len"
+                        |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -374,10 +383,11 @@ Module str.
                                             [ Ty.path "usize" ]
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::error::Utf8Error"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::error::Utf8Error",
                                               "valid_up_to"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -427,10 +437,11 @@ Module str.
                                             [ Ty.path "usize" ]
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::error::Utf8Error"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::error::Utf8Error",
                                               "valid_up_to"
+                                            |)
                                           ]
                                         |)
                                       ]

--- a/CoqOfRust/core/str/iter.v
+++ b/CoqOfRust/core/str/iter.v
@@ -31,7 +31,12 @@ Module str.
                       "clone",
                       []
                     |),
-                    [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::Chars" "iter"
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::Chars",
+                        "iter"
+                      |)
                     ]
                   |))
               ]))
@@ -76,7 +81,13 @@ Module str.
                     "core::str::validations::next_code_point",
                     [ Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u8" ] ]
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::Chars" "iter" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::Chars",
+                      "iter"
+                    |)
+                  ]
                 |);
                 M.closure
                   (fun γ =>
@@ -217,10 +228,11 @@ Module str.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::iter::Chars"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::iter::Chars",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -267,7 +279,7 @@ Module str.
                                           |)
                                         |) in
                                       let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -351,7 +363,7 @@ Module str.
                                                             fun γ =>
                                                               ltac:(M.monadic
                                                                 (let γ0_0 :=
-                                                                  M.get_struct_tuple_field_or_break_match (|
+                                                                  M.SubPointer.get_struct_tuple_field (|
                                                                     γ,
                                                                     "core::option::Option::Some",
                                                                     0
@@ -359,7 +371,7 @@ Module str.
                                                                 let i := M.copy (| γ0_0 |) in
                                                                 let _ :=
                                                                   M.write (|
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       start_bytes,
                                                                       i
                                                                     |),
@@ -371,7 +383,7 @@ Module str.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_array_field (|
+                                                                            M.SubPointer.get_array_field (|
                                                                               M.read (| chunk |),
                                                                               i
                                                                             |)
@@ -498,10 +510,11 @@ Module str.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::iter::Chars"
-                                      "iter";
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::iter::Chars",
+                                      "iter"
+                                    |);
                                     M.read (| bytes_skipped |)
                                   ]
                                 |)
@@ -530,10 +543,11 @@ Module str.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::iter::Chars"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::iter::Chars",
                                                   "iter"
+                                                |)
                                               ]
                                             |))
                                             (Value.Integer Integer.Usize 0)
@@ -545,7 +559,7 @@ Module str.
                                       |) in
                                     let b :=
                                       M.copy (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.call_closure (|
                                             M.get_associated_function (|
                                               Ty.apply
@@ -555,10 +569,11 @@ Module str.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::iter::Chars"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::iter::Chars",
                                                 "iter"
+                                              |)
                                             ]
                                           |),
                                           M.alloc (| Value.Integer Integer.Usize 0 |)
@@ -618,10 +633,11 @@ Module str.
                                                 []
                                               |),
                                               [
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::iter::Chars"
-                                                  "iter";
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::iter::Chars",
+                                                  "iter"
+                                                |);
                                                 Value.Integer Integer.Usize 1
                                               ]
                                             |)
@@ -676,10 +692,11 @@ Module str.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::iter::Chars"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::Chars",
                                               "iter"
+                                            |)
                                           ]
                                         |))
                                         (Value.Integer Integer.Usize 0)))
@@ -695,7 +712,7 @@ Module str.
                               |) in
                             let b :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.call_closure (|
                                     M.get_associated_function (|
                                       Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u8" ],
@@ -703,10 +720,11 @@ Module str.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::Chars"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::Chars",
                                         "iter"
+                                      |)
                                     ]
                                   |),
                                   M.alloc (| Value.Integer Integer.Usize 0 |)
@@ -744,10 +762,11 @@ Module str.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::iter::Chars"
-                                          "iter";
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::iter::Chars",
+                                          "iter"
+                                        |);
                                         M.read (| slurp |)
                                       ]
                                     |)
@@ -830,7 +849,12 @@ Module str.
                       "len",
                       []
                     |),
-                    [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::Chars" "iter"
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::Chars",
+                        "iter"
+                      |)
                     ]
                   |)
                 |) in
@@ -953,7 +977,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -989,7 +1013,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1057,7 +1081,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1093,7 +1117,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1145,7 +1169,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -1181,7 +1205,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -1231,7 +1255,13 @@ Module str.
                     "core::str::validations::next_code_point_reverse",
                     [ Ty.apply (Ty.path "core::slice::iter::Iter") [ Ty.path "u8" ] ]
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::Chars" "iter" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::Chars",
+                      "iter"
+                    |)
+                  ]
                 |);
                 M.closure
                   (fun γ =>
@@ -1303,7 +1333,13 @@ Module str.
                     "as_slice",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::Chars" "iter" ]
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::Chars",
+                      "iter"
+                    |)
+                  ]
                 |)
               ]
             |)))
@@ -1336,10 +1372,11 @@ Module str.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::CharIndices"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::CharIndices",
                         "front_offset"
+                      |)
                     ]
                   |));
                 ("iter",
@@ -1352,10 +1389,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::CharIndices"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::CharIndices",
                         "iter"
+                      |)
                     ]
                   |))
               ]))
@@ -1392,18 +1430,20 @@ Module str.
                 M.read (| Value.String "front_offset" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::iter::CharIndices"
-                    "front_offset");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::iter::CharIndices",
+                    "front_offset"
+                  |));
                 M.read (| Value.String "iter" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::CharIndices"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::CharIndices",
                       "iter"
+                    |)
                   |))
               ]
             |)))
@@ -1455,13 +1495,15 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::str::iter::CharIndices"
-                          "iter")
-                        "core::str::iter::Chars"
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::str::iter::CharIndices",
+                          "iter"
+                        |),
+                        "core::str::iter::Chars",
                         "iter"
+                      |)
                     ]
                   |)
                 |) in
@@ -1476,10 +1518,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::CharIndices"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::CharIndices",
                         "iter"
+                      |)
                     ]
                   |)
                 |),
@@ -1490,7 +1533,7 @@ Module str.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1498,10 +1541,11 @@ Module str.
                       let ch := M.copy (| γ0_0 |) in
                       let index :=
                         M.copy (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::CharIndices"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::CharIndices",
                             "front_offset"
+                          |)
                         |) in
                       let len :=
                         M.alloc (|
@@ -1514,22 +1558,25 @@ Module str.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::CharIndices"
-                                  "iter")
-                                "core::str::iter::Chars"
+                              M.SubPointer.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::CharIndices",
+                                  "iter"
+                                |),
+                                "core::str::iter::Chars",
                                 "iter"
+                              |)
                             ]
                           |)
                         |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::CharIndices"
-                            "front_offset" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::CharIndices",
+                            "front_offset"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (|
@@ -1566,7 +1613,15 @@ Module str.
                 "count",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::str::iter::CharIndices" "iter" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::str::iter::CharIndices",
+                    "iter"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1589,7 +1644,12 @@ Module str.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::CharIndices" "iter"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::CharIndices",
+                  "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1671,10 +1731,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::CharIndices"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::CharIndices",
                       "iter"
+                    |)
                   ]
                 |);
                 M.closure
@@ -1693,10 +1754,11 @@ Module str.
                                     M.alloc (|
                                       BinOp.Panic.add (|
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::iter::CharIndices"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::iter::CharIndices",
                                             "front_offset"
+                                          |)
                                         |),
                                         M.call_closure (|
                                           M.get_trait_method (|
@@ -1709,13 +1771,15 @@ Module str.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::iter::CharIndices"
-                                                "iter")
-                                              "core::str::iter::Chars"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::iter::CharIndices",
+                                                "iter"
+                                              |),
+                                              "core::str::iter::Chars",
                                               "iter"
+                                            |)
                                           ]
                                         |)
                                       |)
@@ -1765,7 +1829,12 @@ Module str.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.get_associated_function (| Ty.path "core::str::iter::Chars", "as_str", [] |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::CharIndices" "iter"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::CharIndices",
+                  "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -1784,10 +1853,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::str::iter::CharIndices"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::iter::CharIndices",
                 "front_offset"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -1829,7 +1899,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Bytes",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -1865,7 +1941,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Bytes",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -1906,7 +1986,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1931,7 +2017,13 @@ Module str.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1956,7 +2048,11 @@ Module str.
                 "count",
                 []
               |),
-              [ M.read (| M.get_struct_tuple_field self "core::str::iter::Bytes" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::str::iter::Bytes", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1981,7 +2077,11 @@ Module str.
                 "last",
                 []
               |),
-              [ M.read (| M.get_struct_tuple_field self "core::str::iter::Bytes" 0 |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_tuple_field (| self, "core::str::iter::Bytes", 0 |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2008,7 +2108,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -2040,7 +2144,11 @@ Module str.
                 [ F ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -2072,7 +2180,11 @@ Module str.
                 [ F ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| f |)
               ]
             |)))
@@ -2104,7 +2216,11 @@ Module str.
                 [ P ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| predicate |)
               ]
             |)))
@@ -2136,7 +2252,11 @@ Module str.
                 [ P ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| predicate |)
               ]
             |)))
@@ -2168,7 +2288,11 @@ Module str.
                 [ P ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| predicate |)
               ]
             |)))
@@ -2199,7 +2323,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| idx |)
               ]
             |)))
@@ -2251,7 +2379,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2278,7 +2412,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| n |)
               ]
             |)))
@@ -2310,7 +2448,11 @@ Module str.
                 [ P ]
               |),
               [
-                M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0;
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |);
                 M.read (| predicate |)
               ]
             |)))
@@ -2353,7 +2495,13 @@ Module str.
                 "len",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2378,7 +2526,13 @@ Module str.
                 "is_empty",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Bytes" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Bytes",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2474,10 +2628,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| s |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| s |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |))
                   ]
@@ -2587,46 +2742,51 @@ Module str.
                                     M.read (| Value.String "start" |);
                                     (* Unsize *)
                                     M.pointer_coercion
-                                      (M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::SplitInternal"
-                                        "start")
+                                      (M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::SplitInternal",
+                                        "start"
+                                      |))
                                   ]
                                 |);
                                 M.read (| Value.String "end" |);
                                 (* Unsize *)
                                 M.pointer_coercion
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::str::iter::SplitInternal"
-                                    "end")
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::str::iter::SplitInternal",
+                                    "end"
+                                  |))
                               ]
                             |);
                             M.read (| Value.String "matcher" |);
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "matcher")
+                              (M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "matcher"
+                              |))
                           ]
                         |);
                         M.read (| Value.String "allow_trailing_empty" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
-                            "allow_trailing_empty")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
+                            "allow_trailing_empty"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "finished" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitInternal"
-                        "finished")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitInternal",
+                        "finished"
+                      |))
                   ]
                 |)
               ]
@@ -2682,20 +2842,22 @@ Module str.
                                 (M.alloc (|
                                   UnOp.Pure.not
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::SplitInternal"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::SplitInternal",
                                         "finished"
+                                      |)
                                     |))
                                 |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |),
                                 Value.Bool true
                               |) in
                             M.match_operator (|
@@ -2708,25 +2870,28 @@ Module str.
                                         (M.alloc (|
                                           LogicalOp.or (|
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::iter::SplitInternal"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::iter::SplitInternal",
                                                 "allow_trailing_empty"
+                                              |)
                                             |),
                                             ltac:(M.monadic
                                               (BinOp.Pure.gt
                                                 (BinOp.Panic.sub (|
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::iter::SplitInternal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::iter::SplitInternal",
                                                       "end"
+                                                    |)
                                                   |),
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::iter::SplitInternal"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::iter::SplitInternal",
                                                       "start"
+                                                    |)
                                                   |)
                                                 |))
                                                 (Value.Integer Integer.Usize 0)))
@@ -2762,10 +2927,11 @@ Module str.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::str::iter::SplitInternal"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::str::iter::SplitInternal",
                                                         "matcher"
+                                                      |)
                                                     ]
                                                   |);
                                                   Value.StructRecord
@@ -2773,17 +2939,19 @@ Module str.
                                                     [
                                                       ("start",
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::str::iter::SplitInternal"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::str::iter::SplitInternal",
                                                             "start"
+                                                          |)
                                                         |));
                                                       ("end_",
                                                         M.read (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::str::iter::SplitInternal"
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::str::iter::SplitInternal",
                                                             "end"
+                                                          |)
                                                         |))
                                                     ]
                                                 ]
@@ -2848,10 +3016,11 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -2875,10 +3044,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |) in
@@ -2893,10 +3063,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |),
@@ -2904,13 +3075,13 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let a := M.copy (| γ1_0 |) in
                           let b := M.copy (| γ1_1 |) in
                           let elt :=
@@ -2929,10 +3100,11 @@ Module str.
                                     [
                                       ("start",
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::iter::SplitInternal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::iter::SplitInternal",
                                             "start"
+                                          |)
                                         |));
                                       ("end_", M.read (| a |))
                                     ]
@@ -2941,10 +3113,11 @@ Module str.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "start",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "start"
+                              |),
                               M.read (| b |)
                             |) in
                           M.alloc (|
@@ -3010,10 +3183,11 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3037,10 +3211,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |) in
@@ -3055,10 +3230,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |),
@@ -3066,13 +3242,13 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let b := M.copy (| γ1_1 |) in
                           let elt :=
                             M.alloc (|
@@ -3090,10 +3266,11 @@ Module str.
                                     [
                                       ("start",
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::iter::SplitInternal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::iter::SplitInternal",
                                             "start"
+                                          |)
                                         |));
                                       ("end_", M.read (| b |))
                                     ]
@@ -3102,10 +3279,11 @@ Module str.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "start",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "start"
+                              |),
                               M.read (| b |)
                             |) in
                           M.alloc (|
@@ -3188,10 +3366,11 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3215,20 +3394,22 @@ Module str.
                                 (M.alloc (|
                                   UnOp.Pure.not
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::SplitInternal"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::SplitInternal",
                                         "allow_trailing_empty"
+                                      |)
                                     |))
                                 |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "allow_trailing_empty",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "allow_trailing_empty"
+                                |),
                                 Value.Bool true
                               |) in
                             M.match_operator (|
@@ -3246,7 +3427,7 @@ Module str.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -3289,10 +3470,11 @@ Module str.
                                           ltac:(M.monadic
                                             (let γ :=
                                               M.use
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::iter::SplitInternal"
-                                                  "finished") in
+                                                (M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::iter::SplitInternal",
+                                                  "finished"
+                                                |)) in
                                             let _ :=
                                               M.is_constant_or_break_match (|
                                                 M.read (| γ |),
@@ -3328,10 +3510,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |) in
@@ -3346,10 +3529,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |),
@@ -3357,13 +3541,13 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let a := M.copy (| γ1_0 |) in
                           let b := M.copy (| γ1_1 |) in
                           let elt :=
@@ -3383,10 +3567,11 @@ Module str.
                                       ("start", M.read (| b |));
                                       ("end_",
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::iter::SplitInternal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::iter::SplitInternal",
                                             "end"
+                                          |)
                                         |))
                                     ]
                                 ]
@@ -3394,10 +3579,11 @@ Module str.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "end",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "end"
+                              |),
                               M.read (| a |)
                             |) in
                           M.alloc (|
@@ -3407,10 +3593,11 @@ Module str.
                         ltac:(M.monadic
                           (let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "finished",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "finished"
+                              |),
                               Value.Bool true
                             |) in
                           M.alloc (|
@@ -3434,17 +3621,19 @@ Module str.
                                       [
                                         ("start",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::iter::SplitInternal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::SplitInternal",
                                               "start"
+                                            |)
                                           |));
                                         ("end_",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::iter::SplitInternal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::SplitInternal",
                                               "end"
+                                            |)
                                           |))
                                       ]
                                   ]
@@ -3522,10 +3711,11 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3549,20 +3739,22 @@ Module str.
                                 (M.alloc (|
                                   UnOp.Pure.not
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::SplitInternal"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::SplitInternal",
                                         "allow_trailing_empty"
+                                      |)
                                     |))
                                 |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let _ :=
                               M.write (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "allow_trailing_empty",
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "allow_trailing_empty"
+                                |),
                                 Value.Bool true
                               |) in
                             M.match_operator (|
@@ -3580,7 +3772,7 @@ Module str.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -3623,10 +3815,11 @@ Module str.
                                           ltac:(M.monadic
                                             (let γ :=
                                               M.use
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::iter::SplitInternal"
-                                                  "finished") in
+                                                (M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::iter::SplitInternal",
+                                                  "finished"
+                                                |)) in
                                             let _ :=
                                               M.is_constant_or_break_match (|
                                                 M.read (| γ |),
@@ -3662,10 +3855,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |) in
@@ -3680,10 +3874,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitInternal",
                             "matcher"
+                          |)
                         ]
                       |)
                     |),
@@ -3691,13 +3886,13 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
                             |) in
-                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                          let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                          let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                           let b := M.copy (| γ1_1 |) in
                           let elt :=
                             M.alloc (|
@@ -3716,10 +3911,11 @@ Module str.
                                       ("start", M.read (| b |));
                                       ("end_",
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::iter::SplitInternal"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::iter::SplitInternal",
                                             "end"
+                                          |)
                                         |))
                                     ]
                                 ]
@@ -3727,10 +3923,11 @@ Module str.
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "end",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "end"
+                              |),
                               M.read (| b |)
                             |) in
                           M.alloc (|
@@ -3740,10 +3937,11 @@ Module str.
                         ltac:(M.monadic
                           (let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::iter::SplitInternal"
-                                "finished",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::iter::SplitInternal",
+                                "finished"
+                              |),
                               Value.Bool true
                             |) in
                           M.alloc (|
@@ -3767,17 +3965,19 @@ Module str.
                                       [
                                         ("start",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::iter::SplitInternal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::SplitInternal",
                                               "start"
+                                            |)
                                           |));
                                         ("end_",
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::iter::SplitInternal"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::SplitInternal",
                                               "end"
+                                            |)
                                           |))
                                       ]
                                   ]
@@ -3823,10 +4023,11 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -3859,10 +4060,11 @@ Module str.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::SplitInternal"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::SplitInternal",
                                   "matcher"
+                                |)
                               ]
                             |);
                             Value.StructRecord
@@ -3870,17 +4072,19 @@ Module str.
                               [
                                 ("start",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::iter::SplitInternal"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::iter::SplitInternal",
                                       "start"
+                                    |)
                                   |));
                                 ("end_",
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::iter::SplitInternal"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::iter::SplitInternal",
                                       "end"
+                                    |)
                                   |))
                               ]
                           ]
@@ -3947,7 +4151,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Split" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::Split",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -3987,7 +4195,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Split" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Split",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4027,7 +4241,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Split" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Split",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -4092,7 +4312,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplit" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::RSplit",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -4132,7 +4356,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplit" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplit",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4172,7 +4402,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplit" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::RSplit",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -4231,7 +4467,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Split" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Split",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4265,7 +4507,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplit" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplit",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4299,7 +4547,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Split" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Split",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4329,7 +4583,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplit" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplit",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4390,10 +4650,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitTerminator"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitTerminator",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -4434,7 +4695,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4476,10 +4743,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::SplitTerminator"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::SplitTerminator",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -4546,10 +4814,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::RSplitTerminator"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::RSplitTerminator",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -4590,7 +4859,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4632,10 +4907,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::RSplitTerminator"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::RSplitTerminator",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -4698,7 +4974,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4733,7 +5015,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4768,7 +5056,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4799,7 +5093,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitTerminator" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplitTerminator",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4841,10 +5141,11 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| s |))
-                            "core::str::iter::SplitNInternal"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| s |),
+                            "core::str::iter::SplitNInternal",
                             "iter"
+                          |)
                         ]
                       |))
                   ]
@@ -4926,19 +5227,21 @@ Module str.
                         M.read (| Value.String "iter" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitNInternal"
-                            "iter")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitNInternal",
+                            "iter"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "count" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitNInternal"
-                        "count")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitNInternal",
+                        "count"
+                      |))
                   ]
                 |)
               ]
@@ -4982,10 +5285,11 @@ Module str.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitNInternal"
-                  "count",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitNInternal",
+                  "count"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -5004,10 +5308,11 @@ Module str.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitNInternal"
-                            "count",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitNInternal",
+                            "count"
+                          |),
                           Value.Integer Integer.Usize 0
                         |) in
                       M.alloc (|
@@ -5018,10 +5323,11 @@ Module str.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::iter::SplitNInternal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::iter::SplitNInternal",
                               "iter"
+                            |)
                           ]
                         |)
                       |)));
@@ -5029,10 +5335,11 @@ Module str.
                     ltac:(M.monadic
                       (let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitNInternal"
-                            "count" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitNInternal",
+                            "count"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -5045,10 +5352,11 @@ Module str.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::iter::SplitNInternal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::iter::SplitNInternal",
                               "iter"
+                            |)
                           ]
                         |)
                       |)))
@@ -5088,10 +5396,11 @@ Module str.
             (let self := M.alloc (| self |) in
             M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitNInternal"
-                  "count",
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitNInternal",
+                  "count"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
@@ -5110,10 +5419,11 @@ Module str.
                         |) in
                       let _ :=
                         M.write (|
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitNInternal"
-                            "count",
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitNInternal",
+                            "count"
+                          |),
                           Value.Integer Integer.Usize 0
                         |) in
                       M.alloc (|
@@ -5124,10 +5434,11 @@ Module str.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::iter::SplitNInternal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::iter::SplitNInternal",
                               "iter"
+                            |)
                           ]
                         |)
                       |)));
@@ -5135,10 +5446,11 @@ Module str.
                     ltac:(M.monadic
                       (let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::iter::SplitNInternal"
-                            "count" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::iter::SplitNInternal",
+                            "count"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (| M.read (| β |), Value.Integer Integer.Usize 1 |)
@@ -5151,10 +5463,11 @@ Module str.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::iter::SplitNInternal"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::iter::SplitNInternal",
                               "iter"
+                            |)
                           ]
                         |)
                       |)))
@@ -5186,10 +5499,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitNInternal"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitNInternal",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5250,7 +5564,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitN" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitN",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -5290,7 +5608,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitN" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitN",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5330,7 +5654,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitN" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::SplitN",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -5395,7 +5725,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitN" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::RSplitN",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -5435,7 +5769,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitN" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplitN",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5475,7 +5815,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitN" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::RSplitN",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -5534,7 +5880,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitN" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitN",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5564,7 +5916,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RSplitN" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RSplitN",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5599,10 +5957,11 @@ Module str.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", Ty.associated, [], "clone", [] |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| s |))
-                          "core::str::iter::MatchIndicesInternal"
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| s |),
+                          "core::str::iter::MatchIndicesInternal",
                           0
+                        |)
                       ]
                     |)
                   ]
@@ -5669,10 +6028,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::MatchIndicesInternal"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::MatchIndicesInternal",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -5730,10 +6090,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::MatchIndicesInternal"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::MatchIndicesInternal",
                       0
+                    |)
                   ]
                 |);
                 M.closure
@@ -5746,8 +6107,8 @@ Module str.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let start := M.copy (| γ0_0 |) in
                                 let end_ := M.copy (| γ0_1 |) in
                                 Value.Tuple
@@ -5773,10 +6134,11 @@ Module str.
                                             []
                                           |),
                                           [
-                                            M.get_struct_tuple_field
-                                              (M.read (| self |))
-                                              "core::str::iter::MatchIndicesInternal"
+                                            M.SubPointer.get_struct_tuple_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::MatchIndicesInternal",
                                               0
+                                            |)
                                           ]
                                         |);
                                         Value.StructRecord
@@ -5841,10 +6203,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::MatchIndicesInternal"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::MatchIndicesInternal",
                       0
+                    |)
                   ]
                 |);
                 M.closure
@@ -5857,8 +6220,8 @@ Module str.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let start := M.copy (| γ0_0 |) in
                                 let end_ := M.copy (| γ0_1 |) in
                                 Value.Tuple
@@ -5884,10 +6247,11 @@ Module str.
                                             []
                                           |),
                                           [
-                                            M.get_struct_tuple_field
-                                              (M.read (| self |))
-                                              "core::str::iter::MatchIndicesInternal"
+                                            M.SubPointer.get_struct_tuple_field (|
+                                              M.read (| self |),
+                                              "core::str::iter::MatchIndicesInternal",
                                               0
+                                            |)
                                           ]
                                         |);
                                         Value.StructRecord
@@ -5963,10 +6327,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::MatchIndices"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::MatchIndices",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -6007,7 +6372,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::MatchIndices" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::MatchIndices",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6047,7 +6418,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::MatchIndices" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::MatchIndices",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -6113,10 +6490,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::RMatchIndices"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::RMatchIndices",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -6158,7 +6536,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatchIndices" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RMatchIndices",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6199,7 +6583,12 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatchIndices" 0
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::RMatchIndices",
+                      0
+                    |)
                   ]
                 |)
               ]))
@@ -6260,7 +6649,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::MatchIndices" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::MatchIndices",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6295,7 +6690,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatchIndices" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RMatchIndices",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6334,10 +6735,11 @@ Module str.
                     M.call_closure (|
                       M.get_trait_method (| "core::clone::Clone", Ty.associated, [], "clone", [] |),
                       [
-                        M.get_struct_tuple_field
-                          (M.read (| s |))
-                          "core::str::iter::MatchesInternal"
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| s |),
+                          "core::str::iter::MatchesInternal",
                           0
+                        |)
                       ]
                     |)
                   ]
@@ -6404,10 +6806,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::MatchesInternal"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::MatchesInternal",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -6466,10 +6869,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::MatchesInternal"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::MatchesInternal",
                       0
+                    |)
                   ]
                 |);
                 M.closure
@@ -6482,8 +6886,8 @@ Module str.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let a := M.copy (| γ0_0 |) in
                                 let b := M.copy (| γ0_1 |) in
                                 M.call_closure (|
@@ -6506,10 +6910,11 @@ Module str.
                                         []
                                       |),
                                       [
-                                        M.get_struct_tuple_field
-                                          (M.read (| self |))
-                                          "core::str::iter::MatchesInternal"
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          M.read (| self |),
+                                          "core::str::iter::MatchesInternal",
                                           0
+                                        |)
                                       ]
                                     |);
                                     Value.StructRecord
@@ -6571,10 +6976,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::iter::MatchesInternal"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::MatchesInternal",
                       0
+                    |)
                   ]
                 |);
                 M.closure
@@ -6587,8 +6993,8 @@ Module str.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let a := M.copy (| γ0_0 |) in
                                 let b := M.copy (| γ0_1 |) in
                                 M.call_closure (|
@@ -6611,10 +7017,11 @@ Module str.
                                         []
                                       |),
                                       [
-                                        M.get_struct_tuple_field
-                                          (M.read (| self |))
-                                          "core::str::iter::MatchesInternal"
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          M.read (| self |),
+                                          "core::str::iter::MatchesInternal",
                                           0
+                                        |)
                                       ]
                                     |);
                                     Value.StructRecord
@@ -6686,7 +7093,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Matches" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::Matches",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -6726,7 +7137,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Matches" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Matches",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6766,7 +7183,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Matches" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Matches",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -6831,7 +7254,11 @@ Module str.
                     |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatches" 0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::RMatches",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -6871,7 +7298,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatches" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RMatches",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6911,7 +7344,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatches" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::RMatches",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -6970,7 +7409,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Matches" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Matches",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7004,7 +7449,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::RMatches" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::RMatches",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7058,7 +7509,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Lines" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Lines",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -7094,7 +7551,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Lines" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::Lines",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -7138,7 +7599,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Lines" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Lines",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7166,7 +7633,13 @@ Module str.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Lines" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Lines",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7234,7 +7707,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::Lines" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::Lines",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7285,7 +7764,13 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::LinesAny" 0 ]
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::LinesAny",
+                      0
+                    |)
+                  ]
                 |)
               ]))
         | _, _ => M.impossible
@@ -7321,7 +7806,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::LinesAny" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::LinesAny",
+                      0
+                    |)
                   |))
               ]
             |)))
@@ -7360,7 +7849,13 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::LinesAny" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::LinesAny",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7383,7 +7878,13 @@ Module str.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::LinesAny" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::LinesAny",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7422,7 +7923,13 @@ Module str.
                 "next_back",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::LinesAny" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::LinesAny",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7491,10 +7998,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitWhitespace"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitWhitespace",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -7532,10 +8040,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::SplitWhitespace"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::SplitWhitespace",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -7607,10 +8116,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitAsciiWhitespace"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitAsciiWhitespace",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -7648,10 +8158,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::SplitAsciiWhitespace"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::SplitAsciiWhitespace",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -7705,10 +8216,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -7740,10 +8252,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -7815,10 +8328,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -7863,13 +8377,15 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::iter::SplitWhitespace"
-                    "inner")
-                  "core::iter::adapters::filter::Filter"
+                M.SubPointer.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::iter::SplitWhitespace",
+                    "inner"
+                  |),
+                  "core::iter::adapters::filter::Filter",
                   "iter"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -7915,10 +8431,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitAsciiWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitAsciiWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -7955,10 +8472,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitAsciiWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitAsciiWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -8035,10 +8553,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::SplitAsciiWhitespace"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitAsciiWhitespace",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -8092,19 +8611,23 @@ Module str.
                           ltac:(M.monadic
                             (let γ :=
                               M.use
-                                (M.get_struct_record_field
-                                  (M.get_struct_record_field
-                                    (M.get_struct_record_field
-                                      (M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::SplitAsciiWhitespace"
-                                        "inner")
-                                      "core::iter::adapters::map::Map"
-                                      "iter")
-                                    "core::iter::adapters::filter::Filter"
-                                    "iter")
-                                  "core::slice::iter::Split"
-                                  "finished") in
+                                (M.SubPointer.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::SplitAsciiWhitespace",
+                                        "inner"
+                                      |),
+                                      "core::iter::adapters::map::Map",
+                                      "iter"
+                                    |),
+                                    "core::iter::adapters::filter::Filter",
+                                    "iter"
+                                  |),
+                                  "core::slice::iter::Split",
+                                  "finished"
+                                |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             M.alloc (|
@@ -8125,19 +8648,23 @@ Module str.
                           M.get_function (| "core::str::converts::from_utf8_unchecked", [] |),
                           [
                             M.read (|
-                              M.get_struct_record_field
-                                (M.get_struct_record_field
-                                  (M.get_struct_record_field
-                                    (M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::iter::SplitAsciiWhitespace"
-                                      "inner")
-                                    "core::iter::adapters::map::Map"
-                                    "iter")
-                                  "core::iter::adapters::filter::Filter"
-                                  "iter")
-                                "core::slice::iter::Split"
+                              M.SubPointer.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::iter::SplitAsciiWhitespace",
+                                      "inner"
+                                    |),
+                                    "core::iter::adapters::map::Map",
+                                    "iter"
+                                  |),
+                                  "core::iter::adapters::filter::Filter",
+                                  "iter"
+                                |),
+                                "core::slice::iter::Split",
                                 "v"
+                              |)
                             |)
                           ]
                         |)
@@ -8175,7 +8702,13 @@ Module str.
                 "next_inclusive",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitInclusive" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitInclusive",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8233,10 +8766,11 @@ Module str.
                     M.read (| Value.String "0" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_tuple_field
-                        (M.read (| self |))
-                        "core::str::iter::SplitInclusive"
-                        0)
+                      (M.SubPointer.get_struct_tuple_field (|
+                        M.read (| self |),
+                        "core::str::iter::SplitInclusive",
+                        0
+                      |))
                   ]
                 |)
               ]
@@ -8279,7 +8813,12 @@ Module str.
                     "clone",
                     []
                   |),
-                  [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitInclusive" 0
+                  [
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::iter::SplitInclusive",
+                      0
+                    |)
                   ]
                 |)
               ]))
@@ -8316,7 +8855,13 @@ Module str.
                 "next_back_inclusive",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitInclusive" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitInclusive",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8364,7 +8909,13 @@ Module str.
                 "remainder",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "core::str::iter::SplitInclusive" 0 ]
+              [
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::iter::SplitInclusive",
+                  0
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8403,20 +8954,22 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::EncodeUtf16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::EncodeUtf16",
                         "chars"
+                      |)
                     ]
                   |));
                 ("extra",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "u16", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::EncodeUtf16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::EncodeUtf16",
                         "extra"
+                      |)
                     ]
                   |))
               ]))
@@ -8518,10 +9071,11 @@ Module str.
                                 (M.alloc (|
                                   BinOp.Pure.ne
                                     (M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::EncodeUtf16"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::EncodeUtf16",
                                         "extra"
+                                      |)
                                     |))
                                     (Value.Integer Integer.U16 0)
                                 |)) in
@@ -8532,17 +9086,19 @@ Module str.
                                 M.read (|
                                   let tmp :=
                                     M.copy (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::EncodeUtf16"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::EncodeUtf16",
                                         "extra"
+                                      |)
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::iter::EncodeUtf16"
-                                        "extra",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::iter::EncodeUtf16",
+                                        "extra"
+                                      |),
                                       Value.Integer Integer.U16 0
                                     |) in
                                   M.return_ (|
@@ -8575,10 +9131,11 @@ Module str.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::iter::EncodeUtf16"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::iter::EncodeUtf16",
                               "chars"
+                            |)
                           ]
                         |);
                         M.closure
@@ -8636,12 +9193,13 @@ Module str.
                                                       |) in
                                                     let _ :=
                                                       M.write (|
-                                                        M.get_struct_record_field
-                                                          (M.read (| self |))
-                                                          "core::str::iter::EncodeUtf16"
-                                                          "extra",
+                                                        M.SubPointer.get_struct_record_field (|
+                                                          M.read (| self |),
+                                                          "core::str::iter::EncodeUtf16",
+                                                          "extra"
+                                                        |),
                                                         M.read (|
-                                                          M.get_array_field (|
+                                                          M.SubPointer.get_array_field (|
                                                             buf,
                                                             M.alloc (|
                                                               Value.Integer Integer.Usize 1
@@ -8654,7 +9212,7 @@ Module str.
                                                   ltac:(M.monadic (M.alloc (| Value.Tuple [] |)))
                                               ]
                                             |) in
-                                          M.get_array_field (|
+                                          M.SubPointer.get_array_field (|
                                             buf,
                                             M.alloc (| Value.Integer Integer.Usize 0 |)
                                           |)
@@ -8708,13 +9266,15 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::str::iter::EncodeUtf16"
-                          "chars")
-                        "core::str::iter::Chars"
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::str::iter::EncodeUtf16",
+                          "chars"
+                        |),
+                        "core::str::iter::Chars",
                         "iter"
+                      |)
                     ]
                   |)
                 |) in
@@ -8728,10 +9288,11 @@ Module str.
                           (M.alloc (|
                             BinOp.Pure.eq
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::iter::EncodeUtf16"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::iter::EncodeUtf16",
                                   "extra"
+                                |)
                               |))
                               (Value.Integer Integer.U16 0)
                           |)) in
@@ -8868,10 +9429,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::EscapeDebug"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::EscapeDebug",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -8909,10 +9471,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::EscapeDebug"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::EscapeDebug",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -8972,10 +9535,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::EscapeDefault"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::EscapeDefault",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -9013,10 +9577,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::EscapeDefault"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::EscapeDefault",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -9076,10 +9641,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::iter::EscapeUnicode"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::iter::EscapeUnicode",
                         "inner"
+                      |)
                     ]
                   |))
               ]))
@@ -9117,10 +9683,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::iter::EscapeUnicode"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::iter::EscapeUnicode",
                       "inner"
+                    |)
                   |))
               ]
             |)))
@@ -9254,7 +9821,12 @@ Module str.
                 "next",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::EscapeDebug" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDebug",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9291,7 +9863,12 @@ Module str.
                 "size_hint",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::str::iter::EscapeDebug" "inner"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDebug",
+                  "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9337,10 +9914,11 @@ Module str.
                 [ Acc; Fold; R ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeDebug"
-                  "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDebug",
+                  "inner"
+                |);
                 M.read (| init |);
                 M.read (| fold |)
               ]
@@ -9388,7 +9966,13 @@ Module str.
                 [ Acc; Fold ]
               |),
               [
-                M.read (| M.get_struct_record_field self "core::str::iter::EscapeDebug" "inner" |);
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::str::iter::EscapeDebug",
+                    "inner"
+                  |)
+                |);
                 M.read (| init |);
                 M.read (| fold |)
               ]
@@ -9531,10 +10115,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeDefault"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDefault",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9561,10 +10146,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeDefault"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDefault",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9599,10 +10185,11 @@ Module str.
                 [ Acc; Fold; R ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeDefault"
-                  "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeDefault",
+                  "inner"
+                |);
                 M.read (| init |);
                 M.read (| fold |)
               ]
@@ -9640,7 +10227,11 @@ Module str.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::str::iter::EscapeDefault" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::str::iter::EscapeDefault",
+                    "inner"
+                  |)
                 |);
                 M.read (| init |);
                 M.read (| fold |)
@@ -9784,10 +10375,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeUnicode"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeUnicode",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9814,10 +10406,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeUnicode"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeUnicode",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -9852,10 +10445,11 @@ Module str.
                 [ Acc; Fold; R ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "core::str::iter::EscapeUnicode"
-                  "inner";
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::str::iter::EscapeUnicode",
+                  "inner"
+                |);
                 M.read (| init |);
                 M.read (| fold |)
               ]
@@ -9893,7 +10487,11 @@ Module str.
               |),
               [
                 M.read (|
-                  M.get_struct_record_field self "core::str::iter::EscapeUnicode" "inner"
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::str::iter::EscapeUnicode",
+                    "inner"
+                  |)
                 |);
                 M.read (| init |);
                 M.read (| fold |)

--- a/CoqOfRust/core/str/lossy.v
+++ b/CoqOfRust/core/str/lossy.v
@@ -36,10 +36,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::lossy::Utf8Chunk"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::lossy::Utf8Chunk",
                         "valid"
+                      |)
                     ]
                   |));
                 ("invalid",
@@ -52,10 +53,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::lossy::Utf8Chunk"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::lossy::Utf8Chunk",
                         "invalid"
+                      |)
                     ]
                   |))
               ]))
@@ -92,18 +94,20 @@ Module str.
                 M.read (| Value.String "valid" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::lossy::Utf8Chunk"
-                    "valid");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::lossy::Utf8Chunk",
+                    "valid"
+                  |));
                 M.read (| Value.String "invalid" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::lossy::Utf8Chunk"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::lossy::Utf8Chunk",
                       "invalid"
+                    |)
                   |))
               ]
             |)))
@@ -149,14 +153,16 @@ Module str.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::lossy::Utf8Chunk"
-                    "valid";
-                  M.get_struct_record_field
-                    (M.read (| other |))
-                    "core::str::lossy::Utf8Chunk"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::lossy::Utf8Chunk",
                     "valid"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::str::lossy::Utf8Chunk",
+                    "valid"
+                  |)
                 ]
               |),
               ltac:(M.monadic
@@ -169,14 +175,16 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::lossy::Utf8Chunk"
-                      "invalid";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::str::lossy::Utf8Chunk"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::lossy::Utf8Chunk",
                       "invalid"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::str::lossy::Utf8Chunk",
+                      "invalid"
+                    |)
                   ]
                 |)))
             |)))
@@ -250,7 +258,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::str::lossy::Utf8Chunk" "valid"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::lossy::Utf8Chunk",
+                "valid"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -268,7 +280,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::str::lossy::Utf8Chunk" "invalid"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::lossy::Utf8Chunk",
+                "invalid"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -359,7 +375,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Break",
                                 0
@@ -395,7 +411,7 @@ Module str.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::ops::control_flow::ControlFlow::Continue",
                                 0
@@ -425,10 +441,11 @@ Module str.
                                 |),
                                 [
                                   M.read (|
-                                    M.get_struct_tuple_field
-                                      (M.read (| self |))
-                                      "core::str::lossy::Debug"
+                                    M.SubPointer.get_struct_tuple_field (|
+                                      M.read (| self |),
+                                      "core::str::lossy::Debug",
                                       0
+                                    |)
                                   |)
                                 ]
                               |)
@@ -464,7 +481,7 @@ Module str.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -542,19 +559,21 @@ Module str.
                                                                     fun γ =>
                                                                       ltac:(M.monadic
                                                                         (let γ0_0 :=
-                                                                          M.get_struct_tuple_field_or_break_match (|
+                                                                          M.SubPointer.get_struct_tuple_field (|
                                                                             γ,
                                                                             "core::option::Option::Some",
                                                                             0
                                                                           |) in
                                                                         let γ1_0 :=
-                                                                          M.get_tuple_field
-                                                                            γ0_0
-                                                                            0 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ0_0,
+                                                                            0
+                                                                          |) in
                                                                         let γ1_1 :=
-                                                                          M.get_tuple_field
-                                                                            γ0_0
-                                                                            1 in
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            γ0_0,
+                                                                            1
+                                                                          |) in
                                                                         let i :=
                                                                           M.copy (| γ1_0 |) in
                                                                         let c :=
@@ -677,7 +696,7 @@ Module str.
                                                                                         ltac:(M.monadic
                                                                                           (let
                                                                                                 γ0_0 :=
-                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                               γ,
                                                                                               "core::ops::control_flow::ControlFlow::Break",
                                                                                               0
@@ -731,7 +750,7 @@ Module str.
                                                                                         ltac:(M.monadic
                                                                                           (let
                                                                                                 γ0_0 :=
-                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                               γ,
                                                                                               "core::ops::control_flow::ControlFlow::Continue",
                                                                                               0
@@ -807,7 +826,7 @@ Module str.
                                                                                                         ltac:(M.monadic
                                                                                                           (let
                                                                                                                 γ0_0 :=
-                                                                                                            M.get_struct_tuple_field_or_break_match (|
+                                                                                                            M.SubPointer.get_struct_tuple_field (|
                                                                                                               γ,
                                                                                                               "core::option::Option::Some",
                                                                                                               0
@@ -865,7 +884,7 @@ Module str.
                                                                                                                   ltac:(M.monadic
                                                                                                                     (let
                                                                                                                           γ0_0 :=
-                                                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                                                         γ,
                                                                                                                         "core::ops::control_flow::ControlFlow::Break",
                                                                                                                         0
@@ -920,7 +939,7 @@ Module str.
                                                                                                                   ltac:(M.monadic
                                                                                                                     (let
                                                                                                                           γ0_0 :=
-                                                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                                                         γ,
                                                                                                                         "core::ops::control_flow::ControlFlow::Continue",
                                                                                                                         0
@@ -1036,7 +1055,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Break",
                                                             0
@@ -1078,7 +1097,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::ops::control_flow::ControlFlow::Continue",
                                                             0
@@ -1151,7 +1170,7 @@ Module str.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -1283,7 +1302,7 @@ Module str.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Break",
                                                                                   0
@@ -1333,7 +1352,7 @@ Module str.
                                                                           fun γ =>
                                                                             ltac:(M.monadic
                                                                               (let γ0_0 :=
-                                                                                M.get_struct_tuple_field_or_break_match (|
+                                                                                M.SubPointer.get_struct_tuple_field (|
                                                                                   γ,
                                                                                   "core::ops::control_flow::ControlFlow::Continue",
                                                                                   0
@@ -1411,10 +1430,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::lossy::Utf8Chunks"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::lossy::Utf8Chunks",
                         "source"
+                      |)
                     ]
                   |))
               ]))
@@ -1462,10 +1482,11 @@ Module str.
               "core::str::lossy::Debug"
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::lossy::Utf8Chunks"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::lossy::Utf8Chunks",
                     "source"
+                  |)
                 |)
               ]))
         | _, _ => M.impossible
@@ -1600,10 +1621,11 @@ Module str.
                                     |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::lossy::Utf8Chunks"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::lossy::Utf8Chunks",
                                           "source"
+                                        |)
                                       |)
                                     ]
                                   |)
@@ -1643,10 +1665,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::lossy::Utf8Chunks"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::lossy::Utf8Chunks",
                                                 "source"
+                                              |)
                                             |)
                                           ]
                                         |))
@@ -1666,10 +1689,11 @@ Module str.
                                       |),
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::lossy::Utf8Chunks"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::lossy::Utf8Chunks",
                                             "source"
+                                          |)
                                         |);
                                         M.read (| i |)
                                       ]
@@ -1744,10 +1768,11 @@ Module str.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::lossy::Utf8Chunks"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::lossy::Utf8Chunks",
                                                                               "source"
+                                                                            |)
                                                                           |);
                                                                           M.read (| i |)
                                                                         ]
@@ -1807,10 +1832,11 @@ Module str.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::str::lossy::Utf8Chunks"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::str::lossy::Utf8Chunks",
                                                                     "source"
+                                                                  |)
                                                                 |);
                                                                 M.read (| i |)
                                                               ]
@@ -1820,8 +1846,16 @@ Module str.
                                                       [
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ0_0 |),
@@ -1830,13 +1864,29 @@ Module str.
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ0_0 |),
@@ -1845,8 +1895,16 @@ Module str.
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
@@ -1885,10 +1943,11 @@ Module str.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::lossy::Utf8Chunks"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::lossy::Utf8Chunks",
                                                                               "source"
+                                                                            |)
                                                                           |);
                                                                           M.read (| i |)
                                                                         ]
@@ -1948,10 +2007,11 @@ Module str.
                                                               |),
                                                               [
                                                                 M.read (|
-                                                                  M.get_struct_record_field
-                                                                    (M.read (| self |))
-                                                                    "core::str::lossy::Utf8Chunks"
+                                                                  M.SubPointer.get_struct_record_field (|
+                                                                    M.read (| self |),
+                                                                    "core::str::lossy::Utf8Chunks",
                                                                     "source"
+                                                                  |)
                                                                 |);
                                                                 M.read (| i |)
                                                               ]
@@ -1961,8 +2021,16 @@ Module str.
                                                       [
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ0_0 |),
@@ -1971,13 +2039,29 @@ Module str.
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             M.alloc (| Value.Tuple [] |)));
                                                         fun γ =>
                                                           ltac:(M.monadic
-                                                            (let γ0_0 := M.get_tuple_field γ 0 in
-                                                            let γ0_1 := M.get_tuple_field γ 1 in
+                                                            (let γ0_0 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                0
+                                                              |) in
+                                                            let γ0_1 :=
+                                                              M.SubPointer.get_tuple_field (|
+                                                                γ,
+                                                                1
+                                                              |) in
                                                             let _ :=
                                                               M.is_constant_or_break_match (|
                                                                 M.read (| γ0_0 |),
@@ -2021,10 +2105,11 @@ Module str.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::lossy::Utf8Chunks"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::lossy::Utf8Chunks",
                                                                               "source"
+                                                                            |)
                                                                           |);
                                                                           M.read (| i |)
                                                                         ]
@@ -2081,10 +2166,11 @@ Module str.
                                                                         |),
                                                                         [
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::lossy::Utf8Chunks"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::lossy::Utf8Chunks",
                                                                               "source"
+                                                                            |)
                                                                           |);
                                                                           M.read (| i |)
                                                                         ]
@@ -2160,10 +2246,11 @@ Module str.
                         |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::lossy::Utf8Chunks"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::lossy::Utf8Chunks",
                               "source"
+                            |)
                           |);
                           M.read (| i |)
                         ]
@@ -2172,16 +2259,17 @@ Module str.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let inspected := M.copy (| γ0_0 |) in
                           let remaining := M.copy (| γ0_1 |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::lossy::Utf8Chunks"
-                                "source",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::lossy::Utf8Chunks",
+                                "source"
+                              |),
                               M.read (| remaining |)
                             |) in
                           M.match_operator (|
@@ -2198,8 +2286,8 @@ Module str.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   let valid := M.copy (| γ0_0 |) in
                                   let invalid := M.copy (| γ0_1 |) in
                                   M.alloc (|

--- a/CoqOfRust/core/str/mod.v
+++ b/CoqOfRust/core/str/mod.v
@@ -715,7 +715,7 @@ Module str.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1973,8 +1973,8 @@ Module str.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let i := M.copy (| γ0_0 |) in
                               M.read (| i |)))
                         ]
@@ -2049,8 +2049,8 @@ Module str.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let i := M.copy (| γ0_0 |) in
                               M.read (| i |)))
                         ]
@@ -2181,15 +2181,16 @@ Module str.
             "core::str::iter::RSplit"
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "str", "split", [ P ] |),
                       [ M.read (| self |); M.read (| pat |) ]
                     |)
-                  |))
-                  "core::str::iter::Split"
+                  |),
+                  "core::str::iter::Split",
                   0
+                |)
               |)
             ]))
       | _, _ => M.impossible
@@ -2213,15 +2214,16 @@ Module str.
             [
               M.struct_record_update
                 (M.read (|
-                  M.get_struct_tuple_field
-                    (M.alloc (|
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "str", "split", [ P ] |),
                         [ M.read (| self |); M.read (| pat |) ]
                       |)
-                    |))
-                    "core::str::iter::Split"
+                    |),
+                    "core::str::iter::Split",
                     0
+                  |)
                 |))
                 [ ("allow_trailing_empty", Value.Bool false) ]
             ]))
@@ -2249,15 +2251,16 @@ Module str.
             "core::str::iter::RSplitTerminator"
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "str", "split_terminator", [ P ] |),
                       [ M.read (| self |); M.read (| pat |) ]
                     |)
-                  |))
-                  "core::str::iter::SplitTerminator"
+                  |),
+                  "core::str::iter::SplitTerminator",
                   0
+                |)
               |)
             ]))
       | _, _ => M.impossible
@@ -2286,15 +2289,16 @@ Module str.
                 [
                   ("iter",
                     M.read (|
-                      M.get_struct_tuple_field
-                        (M.alloc (|
+                      M.SubPointer.get_struct_tuple_field (|
+                        M.alloc (|
                           M.call_closure (|
                             M.get_associated_function (| Ty.path "str", "split", [ P ] |),
                             [ M.read (| self |); M.read (| pat |) ]
                           |)
-                        |))
-                        "core::str::iter::Split"
+                        |),
+                        "core::str::iter::Split",
                         0
+                      |)
                     |));
                   ("count", M.read (| n |))
                 ]
@@ -2323,15 +2327,16 @@ Module str.
             "core::str::iter::RSplitN"
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "str", "splitn", [ P ] |),
                       [ M.read (| self |); M.read (| n |); M.read (| pat |) ]
                     |)
-                  |))
-                  "core::str::iter::SplitN"
+                  |),
+                  "core::str::iter::SplitN",
                   0
+                |)
               |)
             ]))
       | _, _ => M.impossible
@@ -2399,7 +2404,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -2438,7 +2443,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -2450,8 +2455,8 @@ Module str.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let start := M.copy (| γ0_0 |) in
                         let end_ := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -2569,7 +2574,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -2608,7 +2613,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -2620,8 +2625,8 @@ Module str.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let start := M.copy (| γ0_0 |) in
                         let end_ := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -2728,15 +2733,16 @@ Module str.
             "core::str::iter::RMatches"
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "str", "matches", [ P ] |),
                       [ M.read (| self |); M.read (| pat |) ]
                     |)
-                  |))
-                  "core::str::iter::Matches"
+                  |),
+                  "core::str::iter::Matches",
                   0
+                |)
               |)
             ]))
       | _, _ => M.impossible
@@ -2797,15 +2803,16 @@ Module str.
             "core::str::iter::RMatchIndices"
             [
               M.read (|
-                M.get_struct_tuple_field
-                  (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (|
+                  M.alloc (|
                     M.call_closure (|
                       M.get_associated_function (| Ty.path "str", "match_indices", [ P ] |),
                       [ M.read (| self |); M.read (| pat |) ]
                     |)
-                  |))
-                  "core::str::iter::MatchIndices"
+                  |),
+                  "core::str::iter::MatchIndices",
                   0
+                |)
               |)
             ]))
       | _, _ => M.impossible
@@ -3046,13 +3053,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let a := M.copy (| γ1_0 |) in
                       let b := M.copy (| γ1_1 |) in
                       let _ := M.write (| i, M.read (| a |) |) in
@@ -3081,13 +3088,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let b := M.copy (| γ1_1 |) in
                       let _ := M.write (| j, M.read (| b |) |) in
                       M.alloc (| Value.Tuple [] |)));
@@ -3173,13 +3180,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let a := M.copy (| γ1_0 |) in
                       let _ := M.write (| i, M.read (| a |) |) in
                       M.alloc (| Value.Tuple [] |)));
@@ -3314,13 +3321,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
                         |) in
-                      let γ1_0 := M.get_tuple_field γ0_0 0 in
-                      let γ1_1 := M.get_tuple_field γ0_0 1 in
+                      let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                      let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                       let b := M.copy (| γ1_1 |) in
                       let _ := M.write (| j, M.read (| b |) |) in
                       M.alloc (| Value.Tuple [] |)));

--- a/CoqOfRust/core/str/pattern.v
+++ b/CoqOfRust/core/str/pattern.v
@@ -89,13 +89,13 @@ Module str.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           0
                         |) in
                       let γ0_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           1
@@ -152,13 +152,13 @@ Module str.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           0
                         |) in
                       let γ0_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           1
@@ -223,13 +223,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           0
                         |) in
                       let γ0_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           1
@@ -257,8 +257,8 @@ Module str.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let left_val := M.copy (| γ0_0 |) in
                                           let right_val := M.copy (| γ0_1 |) in
                                           M.match_operator (|
@@ -412,13 +412,13 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           0
                         |) in
                       let γ0_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           1
@@ -458,8 +458,8 @@ Module str.
                                     [
                                       fun γ =>
                                         ltac:(M.monadic
-                                          (let γ0_0 := M.get_tuple_field γ 0 in
-                                          let γ0_1 := M.get_tuple_field γ 1 in
+                                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                           let left_val := M.copy (| γ0_0 |) in
                                           let right_val := M.copy (| γ0_1 |) in
                                           M.match_operator (|
@@ -725,17 +725,17 @@ Module str.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::str::pattern::SearchStep::Match",
                                   0
                                 |) in
                               let γ2_1 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::str::pattern::SearchStep::Match",
                                   1
@@ -744,13 +744,13 @@ Module str.
                               let __self_1 := M.alloc (| γ2_1 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::str::pattern::SearchStep::Match",
                                   0
                                 |) in
                               let γ2_1 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::str::pattern::SearchStep::Match",
                                   1
@@ -770,17 +770,17 @@ Module str.
                               |)));
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::str::pattern::SearchStep::Reject",
                                   0
                                 |) in
                               let γ2_1 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::str::pattern::SearchStep::Reject",
                                   1
@@ -789,13 +789,13 @@ Module str.
                               let __self_1 := M.alloc (| γ2_1 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::str::pattern::SearchStep::Reject",
                                   0
                                 |) in
                               let γ2_1 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::str::pattern::SearchStep::Reject",
                                   1
@@ -849,13 +849,13 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           0
                         |) in
                       let γ1_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Match",
                           1
@@ -881,13 +881,13 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Reject",
                           0
                         |) in
                       let γ1_1 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::SearchStep::Reject",
                           1
@@ -966,13 +966,13 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Match",
                                     0
                                   |) in
                                 let γ0_1 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Match",
                                     1
@@ -1043,13 +1043,13 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Reject",
                                     0
                                   |) in
                                 let γ0_1 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Reject",
                                     1
@@ -1124,13 +1124,13 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Match",
                                     0
                                   |) in
                                 let γ0_1 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Match",
                                     1
@@ -1201,13 +1201,13 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Reject",
                                     0
                                   |) in
                                 let γ0_1 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::str::pattern::SearchStep::Reject",
                                     1
@@ -1295,50 +1295,55 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "haystack"
+                      |)
                     ]
                   |));
                 ("finger",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "finger"
+                      |)
                     ]
                   |));
                 ("finger_back",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "finger_back"
+                      |)
                     ]
                   |));
                 ("needle",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "char", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "needle"
+                      |)
                     ]
                   |));
                 ("utf8_size",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "utf8_size"
+                      |)
                     ]
                   |));
                 ("utf8_encoded",
@@ -1351,10 +1356,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::CharSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::CharSearcher",
                         "utf8_encoded"
+                      |)
                     ]
                   |))
               ]))
@@ -1403,41 +1409,47 @@ Module str.
                         [
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
-                              "haystack");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
+                              "haystack"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
-                              "finger");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
+                              "finger"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
-                              "finger_back");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
+                              "finger_back"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
-                              "needle");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
+                              "needle"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
-                              "utf8_size");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
+                              "utf8_size"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
                             (M.alloc (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::pattern::CharSearcher"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::pattern::CharSearcher",
                                 "utf8_encoded"
+                              |)
                             |))
                         ]
                     |))
@@ -1483,10 +1495,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::str::pattern::CharSearcher"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::pattern::CharSearcher",
                 "haystack"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -1527,10 +1540,11 @@ Module str.
             M.read (|
               let old_finger :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::CharSearcher"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::CharSearcher",
                     "finger"
+                  |)
                 |) in
               let slice :=
                 M.alloc (|
@@ -1542,10 +1556,11 @@ Module str.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::str::pattern::CharSearcher"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::str::pattern::CharSearcher",
                           "haystack"
+                        |)
                       |);
                       Value.StructRecord
                         "core::ops::range::Range"
@@ -1553,10 +1568,11 @@ Module str.
                           ("start", M.read (| old_finger |));
                           ("end_",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::pattern::CharSearcher"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::pattern::CharSearcher",
                                 "finger_back"
+                              |)
                             |))
                         ]
                     ]
@@ -1579,7 +1595,13 @@ Module str.
                       "len",
                       []
                     |),
-                    [ M.get_struct_record_field iter "core::str::iter::Chars" "iter" ]
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        iter,
+                        "core::str::iter::Chars",
+                        "iter"
+                      |)
+                    ]
                   |)
                 |) in
               M.match_operator (|
@@ -1601,7 +1623,7 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1609,10 +1631,11 @@ Module str.
                       let ch := M.copy (| γ0_0 |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::pattern::CharSearcher"
-                            "finger" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::pattern::CharSearcher",
+                            "finger"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.add (|
@@ -1627,7 +1650,13 @@ Module str.
                                   "len",
                                   []
                                 |),
-                                [ M.get_struct_record_field iter "core::str::iter::Chars" "iter" ]
+                                [
+                                  M.SubPointer.get_struct_record_field (|
+                                    iter,
+                                    "core::str::iter::Chars",
+                                    "iter"
+                                  |)
+                                ]
                               |)
                             |)
                           |)
@@ -1643,10 +1672,11 @@ Module str.
                                     BinOp.Pure.eq
                                       (M.read (| ch |))
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::CharSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::CharSearcher",
                                           "needle"
+                                        |)
                                       |))
                                   |)) in
                               let _ :=
@@ -1660,10 +1690,11 @@ Module str.
                                   [
                                     M.read (| old_finger |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::pattern::CharSearcher"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::pattern::CharSearcher",
                                         "finger"
+                                      |)
                                     |)
                                   ]
                               |)));
@@ -1675,10 +1706,11 @@ Module str.
                                   [
                                     M.read (| old_finger |);
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::pattern::CharSearcher"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::pattern::CharSearcher",
                                         "finger"
+                                      |)
                                     |)
                                   ]
                               |)))
@@ -1785,10 +1817,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::CharSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::CharSearcher",
                                                 "haystack"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -1797,17 +1830,19 @@ Module str.
                                           [
                                             ("start",
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::CharSearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::CharSearcher",
                                                   "finger"
+                                                |)
                                               |));
                                             ("end_",
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::CharSearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::CharSearcher",
                                                   "finger_back"
+                                                |)
                                               |))
                                           ]
                                       ]
@@ -1819,7 +1854,7 @@ Module str.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -1852,7 +1887,7 @@ Module str.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -1873,16 +1908,18 @@ Module str.
                               [
                                 (* Unsize *)
                                 M.pointer_coercion
-                                  (M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::str::pattern::CharSearcher"
-                                    "utf8_encoded");
+                                  (M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::str::pattern::CharSearcher",
+                                    "utf8_encoded"
+                                  |));
                                 BinOp.Panic.sub (|
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::pattern::CharSearcher"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::pattern::CharSearcher",
                                       "utf8_size"
+                                    |)
                                   |),
                                   Value.Integer Integer.Usize 1
                                 |)
@@ -1902,7 +1939,7 @@ Module str.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1910,10 +1947,11 @@ Module str.
                                 let index := M.copy (| γ0_0 |) in
                                 let _ :=
                                   let β :=
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::pattern::CharSearcher"
-                                      "finger" in
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::pattern::CharSearcher",
+                                      "finger"
+                                    |) in
                                   M.write (|
                                     β,
                                     BinOp.Panic.add (|
@@ -1934,16 +1972,18 @@ Module str.
                                             (M.alloc (|
                                               BinOp.Pure.ge
                                                 (M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::str::pattern::CharSearcher"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::str::pattern::CharSearcher",
                                                     "finger"
+                                                  |)
                                                 |))
                                                 (M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::str::pattern::CharSearcher"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::str::pattern::CharSearcher",
                                                     "utf8_size"
+                                                  |)
                                                 |))
                                             |)) in
                                         let _ :=
@@ -1955,16 +1995,18 @@ Module str.
                                           M.alloc (|
                                             BinOp.Panic.sub (|
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::CharSearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::CharSearcher",
                                                   "finger"
+                                                |)
                                               |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::CharSearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::CharSearcher",
                                                   "utf8_size"
+                                                |)
                                               |)
                                             |)
                                           |) in
@@ -1994,10 +2036,11 @@ Module str.
                                                           |),
                                                           [
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::str::pattern::CharSearcher"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::str::pattern::CharSearcher",
                                                                 "haystack"
+                                                              |)
                                                             |)
                                                           ]
                                                         |);
@@ -2007,17 +2050,18 @@ Module str.
                                                             ("start", M.read (| found_char |));
                                                             ("end_",
                                                               M.read (|
-                                                                M.get_struct_record_field
-                                                                  (M.read (| self |))
-                                                                  "core::str::pattern::CharSearcher"
+                                                                M.SubPointer.get_struct_record_field (|
+                                                                  M.read (| self |),
+                                                                  "core::str::pattern::CharSearcher",
                                                                   "finger"
+                                                                |)
                                                               |))
                                                           ]
                                                       ]
                                                     |)
                                                   |) in
                                                 let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::option::Option::Some",
                                                     0
@@ -2072,10 +2116,11 @@ Module str.
                                                                         []
                                                                       |),
                                                                       [
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::CharSearcher"
-                                                                          "utf8_encoded";
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::CharSearcher",
+                                                                          "utf8_encoded"
+                                                                        |);
                                                                         Value.StructRecord
                                                                           "core::ops::range::Range"
                                                                           [
@@ -2085,12 +2130,11 @@ Module str.
                                                                                 0);
                                                                             ("end_",
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::str::pattern::CharSearcher"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::str::pattern::CharSearcher",
                                                                                   "utf8_size"
+                                                                                |)
                                                                               |))
                                                                           ]
                                                                       ]
@@ -2115,10 +2159,11 @@ Module str.
                                                                       [
                                                                         M.read (| found_char |);
                                                                         M.read (|
-                                                                          M.get_struct_record_field
-                                                                            (M.read (| self |))
-                                                                            "core::str::pattern::CharSearcher"
+                                                                          M.SubPointer.get_struct_record_field (|
+                                                                            M.read (| self |),
+                                                                            "core::str::pattern::CharSearcher",
                                                                             "finger"
+                                                                          |)
                                                                         |)
                                                                       ]
                                                                   ]
@@ -2144,15 +2189,17 @@ Module str.
                                     M.read (|
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::pattern::CharSearcher"
-                                            "finger",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::pattern::CharSearcher",
+                                            "finger"
+                                          |),
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::pattern::CharSearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::pattern::CharSearcher",
                                               "finger_back"
+                                            |)
                                           |)
                                         |) in
                                       M.return_ (|
@@ -2215,10 +2262,11 @@ Module str.
             M.read (|
               let old_finger :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::CharSearcher"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::CharSearcher",
                     "finger_back"
+                  |)
                 |) in
               let slice :=
                 M.alloc (|
@@ -2230,20 +2278,22 @@ Module str.
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::str::pattern::CharSearcher"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::str::pattern::CharSearcher",
                           "haystack"
+                        |)
                       |);
                       Value.StructRecord
                         "core::ops::range::Range"
                         [
                           ("start",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::pattern::CharSearcher"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::pattern::CharSearcher",
                                 "finger"
+                              |)
                             |));
                           ("end_", M.read (| old_finger |))
                         ]
@@ -2267,7 +2317,13 @@ Module str.
                       "len",
                       []
                     |),
-                    [ M.get_struct_record_field iter "core::str::iter::Chars" "iter" ]
+                    [
+                      M.SubPointer.get_struct_record_field (|
+                        iter,
+                        "core::str::iter::Chars",
+                        "iter"
+                      |)
+                    ]
                   |)
                 |) in
               M.match_operator (|
@@ -2289,7 +2345,7 @@ Module str.
                           |)
                         |) in
                       let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -2297,10 +2353,11 @@ Module str.
                       let ch := M.copy (| γ0_0 |) in
                       let _ :=
                         let β :=
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::str::pattern::CharSearcher"
-                            "finger_back" in
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::str::pattern::CharSearcher",
+                            "finger_back"
+                          |) in
                         M.write (|
                           β,
                           BinOp.Panic.sub (|
@@ -2315,7 +2372,13 @@ Module str.
                                   "len",
                                   []
                                 |),
-                                [ M.get_struct_record_field iter "core::str::iter::Chars" "iter" ]
+                                [
+                                  M.SubPointer.get_struct_record_field (|
+                                    iter,
+                                    "core::str::iter::Chars",
+                                    "iter"
+                                  |)
+                                ]
                               |)
                             |)
                           |)
@@ -2331,10 +2394,11 @@ Module str.
                                     BinOp.Pure.eq
                                       (M.read (| ch |))
                                       (M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::CharSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::CharSearcher",
                                           "needle"
+                                        |)
                                       |))
                                   |)) in
                               let _ :=
@@ -2347,10 +2411,11 @@ Module str.
                                   "core::str::pattern::SearchStep::Match"
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::pattern::CharSearcher"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::pattern::CharSearcher",
                                         "finger_back"
+                                      |)
                                     |);
                                     M.read (| old_finger |)
                                   ]
@@ -2362,10 +2427,11 @@ Module str.
                                   "core::str::pattern::SearchStep::Reject"
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::pattern::CharSearcher"
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::pattern::CharSearcher",
                                         "finger_back"
+                                      |)
                                     |);
                                     M.read (| old_finger |)
                                   ]
@@ -2445,10 +2511,11 @@ Module str.
                         M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                         [
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharSearcher"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharSearcher",
                               "haystack"
+                            |)
                           |)
                         ]
                       |)
@@ -2494,17 +2561,19 @@ Module str.
                                               [
                                                 ("start",
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::CharSearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::CharSearcher",
                                                       "finger"
+                                                    |)
                                                   |));
                                                 ("end_",
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::CharSearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::CharSearcher",
                                                       "finger_back"
+                                                    |)
                                                   |))
                                               ]
                                           ]
@@ -2516,7 +2585,7 @@ Module str.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Break",
                                             0
@@ -2552,7 +2621,7 @@ Module str.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::ops::control_flow::ControlFlow::Continue",
                                             0
@@ -2573,16 +2642,18 @@ Module str.
                                   [
                                     (* Unsize *)
                                     M.pointer_coercion
-                                      (M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "core::str::pattern::CharSearcher"
-                                        "utf8_encoded");
+                                      (M.SubPointer.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "core::str::pattern::CharSearcher",
+                                        "utf8_encoded"
+                                      |));
                                     BinOp.Panic.sub (|
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::CharSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::CharSearcher",
                                           "utf8_size"
+                                        |)
                                       |),
                                       Value.Integer Integer.Usize 1
                                     |)
@@ -2602,7 +2673,7 @@ Module str.
                                         |)
                                       |) in
                                     let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -2612,10 +2683,11 @@ Module str.
                                       M.alloc (|
                                         BinOp.Panic.add (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::pattern::CharSearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::pattern::CharSearcher",
                                               "finger"
+                                            |)
                                           |),
                                           M.read (| index |)
                                         |)
@@ -2624,10 +2696,11 @@ Module str.
                                       M.alloc (|
                                         BinOp.Panic.sub (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::pattern::CharSearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::pattern::CharSearcher",
                                               "utf8_size"
+                                            |)
                                           |),
                                           Value.Integer Integer.Usize 1
                                         |)
@@ -2688,10 +2761,11 @@ Module str.
                                                                     BinOp.Panic.add (|
                                                                       M.read (| found_char |),
                                                                       M.read (|
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::CharSearcher"
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::CharSearcher",
                                                                           "utf8_size"
+                                                                        |)
                                                                       |)
                                                                     |))
                                                                 ]
@@ -2699,7 +2773,7 @@ Module str.
                                                           |)
                                                         |) in
                                                       let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -2755,10 +2829,11 @@ Module str.
                                                                               []
                                                                             |),
                                                                             [
-                                                                              M.get_struct_record_field
-                                                                                (M.read (| self |))
-                                                                                "core::str::pattern::CharSearcher"
-                                                                                "utf8_encoded";
+                                                                              M.SubPointer.get_struct_record_field (|
+                                                                                M.read (| self |),
+                                                                                "core::str::pattern::CharSearcher",
+                                                                                "utf8_encoded"
+                                                                              |);
                                                                               Value.StructRecord
                                                                                 "core::ops::range::Range"
                                                                                 [
@@ -2768,12 +2843,13 @@ Module str.
                                                                                       0);
                                                                                   ("end_",
                                                                                     M.read (|
-                                                                                      M.get_struct_record_field
-                                                                                        (M.read (|
+                                                                                      M.SubPointer.get_struct_record_field (|
+                                                                                        M.read (|
                                                                                           self
-                                                                                        |))
-                                                                                        "core::str::pattern::CharSearcher"
+                                                                                        |),
+                                                                                        "core::str::pattern::CharSearcher",
                                                                                         "utf8_size"
+                                                                                      |)
                                                                                     |))
                                                                                 ]
                                                                             ]
@@ -2792,10 +2868,11 @@ Module str.
                                                                   M.read (|
                                                                     let _ :=
                                                                       M.write (|
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::CharSearcher"
-                                                                          "finger_back",
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::CharSearcher",
+                                                                          "finger_back"
+                                                                        |),
                                                                         M.read (| found_char |)
                                                                       |) in
                                                                     M.return_ (|
@@ -2805,29 +2882,30 @@ Module str.
                                                                           Value.Tuple
                                                                             [
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::str::pattern::CharSearcher"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::str::pattern::CharSearcher",
                                                                                   "finger_back"
+                                                                                |)
                                                                               |);
                                                                               BinOp.Panic.add (|
                                                                                 M.read (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::CharSearcher"
+                                                                                    |),
+                                                                                    "core::str::pattern::CharSearcher",
                                                                                     "finger_back"
+                                                                                  |)
                                                                                 |),
                                                                                 M.read (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::CharSearcher"
+                                                                                    |),
+                                                                                    "core::str::pattern::CharSearcher",
                                                                                     "utf8_size"
+                                                                                  |)
                                                                                 |)
                                                                               |)
                                                                             ]
@@ -2850,10 +2928,11 @@ Module str.
                                       |) in
                                     let _ :=
                                       M.write (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::CharSearcher"
-                                          "finger_back",
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::CharSearcher",
+                                          "finger_back"
+                                        |),
                                         M.read (| index |)
                                       |) in
                                     M.alloc (| Value.Tuple [] |)));
@@ -2864,15 +2943,17 @@ Module str.
                                         M.read (|
                                           let _ :=
                                             M.write (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::CharSearcher"
-                                                "finger_back",
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::CharSearcher",
+                                                "finger_back"
+                                              |),
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::CharSearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::CharSearcher",
                                                   "finger"
+                                                |)
                                               |)
                                             |) in
                                           M.return_ (|
@@ -3487,10 +3568,11 @@ Module str.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", C, [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::MultiCharEqSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::MultiCharEqSearcher",
                         "char_eq"
+                      |)
                     ]
                   |));
                 ("haystack",
@@ -3503,10 +3585,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::MultiCharEqSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::MultiCharEqSearcher",
                         "haystack"
+                      |)
                     ]
                   |));
                 ("char_indices",
@@ -3519,10 +3602,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::MultiCharEqSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::MultiCharEqSearcher",
                         "char_indices"
+                      |)
                     ]
                   |))
               ]))
@@ -3562,25 +3646,28 @@ Module str.
                 M.read (| Value.String "char_eq" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::MultiCharEqSearcher"
-                    "char_eq");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::MultiCharEqSearcher",
+                    "char_eq"
+                  |));
                 M.read (| Value.String "haystack" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::MultiCharEqSearcher"
-                    "haystack");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::MultiCharEqSearcher",
+                    "haystack"
+                  |));
                 M.read (| Value.String "char_indices" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::MultiCharEqSearcher"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::MultiCharEqSearcher",
                       "char_indices"
+                    |)
                   |))
               ]
             |)))
@@ -3622,7 +3709,11 @@ Module str.
                 ("haystack", M.read (| haystack |));
                 ("char_eq",
                   M.read (|
-                    M.get_struct_tuple_field self "core::str::pattern::MultiCharEqPattern" 0
+                    M.SubPointer.get_struct_tuple_field (|
+                      self,
+                      "core::str::pattern::MultiCharEqPattern",
+                      0
+                    |)
                   |));
                 ("char_indices",
                   M.call_closure (|
@@ -3662,10 +3753,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::str::pattern::MultiCharEqSearcher"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::pattern::MultiCharEqSearcher",
                 "haystack"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -3699,10 +3791,11 @@ Module str.
                 (M.read (|
                   let s :=
                     M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::MultiCharEqSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::MultiCharEqSearcher",
                         "char_indices"
+                      |)
                     |) in
                   let pre_len :=
                     M.alloc (|
@@ -3715,13 +3808,15 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| s |))
-                              "core::str::iter::CharIndices"
-                              "iter")
-                            "core::str::iter::Chars"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| s |),
+                              "core::str::iter::CharIndices",
+                              "iter"
+                            |),
+                            "core::str::iter::Chars",
                             "iter"
+                          |)
                         ]
                       |)
                     |) in
@@ -3745,13 +3840,13 @@ Module str.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let i := M.copy (| γ1_0 |) in
                             let c := M.copy (| γ1_1 |) in
                             let len :=
@@ -3765,13 +3860,15 @@ Module str.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.get_struct_record_field
-                                        (M.read (| s |))
-                                        "core::str::iter::CharIndices"
-                                        "iter")
-                                      "core::str::iter::Chars"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| s |),
+                                        "core::str::iter::CharIndices",
+                                        "iter"
+                                      |),
+                                      "core::str::iter::Chars",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -3796,10 +3893,11 @@ Module str.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::MultiCharEqSearcher"
-                                                "char_eq";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::MultiCharEqSearcher",
+                                                "char_eq"
+                                              |);
                                               M.read (| c |)
                                             ]
                                           |)
@@ -3900,10 +3998,11 @@ Module str.
                 (M.read (|
                   let s :=
                     M.alloc (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::MultiCharEqSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::MultiCharEqSearcher",
                         "char_indices"
+                      |)
                     |) in
                   let pre_len :=
                     M.alloc (|
@@ -3916,13 +4015,15 @@ Module str.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| s |))
-                              "core::str::iter::CharIndices"
-                              "iter")
-                            "core::str::iter::Chars"
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| s |),
+                              "core::str::iter::CharIndices",
+                              "iter"
+                            |),
+                            "core::str::iter::Chars",
                             "iter"
+                          |)
                         ]
                       |)
                     |) in
@@ -3946,13 +4047,13 @@ Module str.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
                               |) in
-                            let γ1_0 := M.get_tuple_field γ0_0 0 in
-                            let γ1_1 := M.get_tuple_field γ0_0 1 in
+                            let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                            let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                             let i := M.copy (| γ1_0 |) in
                             let c := M.copy (| γ1_1 |) in
                             let len :=
@@ -3966,13 +4067,15 @@ Module str.
                                     []
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.get_struct_record_field
-                                        (M.read (| s |))
-                                        "core::str::iter::CharIndices"
-                                        "iter")
-                                      "core::str::iter::Chars"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| s |),
+                                        "core::str::iter::CharIndices",
+                                        "iter"
+                                      |),
+                                      "core::str::iter::Chars",
                                       "iter"
+                                    |)
                                   ]
                                 |)
                               |) in
@@ -3997,10 +4100,11 @@ Module str.
                                               []
                                             |),
                                             [
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::MultiCharEqSearcher"
-                                                "char_eq";
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::MultiCharEqSearcher",
+                                                "char_eq"
+                                              |);
                                               M.read (| c |)
                                             ]
                                           |)
@@ -4109,10 +4213,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharArraySearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharArraySearcher",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -4149,10 +4254,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharArraySearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharArraySearcher",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -4197,10 +4303,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharArrayRefSearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharArrayRefSearcher",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -4237,10 +4344,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharArrayRefSearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharArrayRefSearcher",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -4488,10 +4596,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4518,10 +4627,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4548,10 +4658,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4578,10 +4689,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4625,10 +4737,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4655,10 +4768,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4685,10 +4799,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArraySearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArraySearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4952,10 +5067,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -4982,10 +5098,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5012,10 +5129,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5042,10 +5160,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5089,10 +5208,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5119,10 +5239,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5149,10 +5270,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharArrayRefSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharArrayRefSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5212,10 +5334,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharSliceSearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharSliceSearcher",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -5252,10 +5375,11 @@ Module str.
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharSliceSearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharSliceSearcher",
                       0
+                    |)
                   |))
               ]
             |)))
@@ -5294,10 +5418,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5324,10 +5449,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5354,10 +5480,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5384,10 +5511,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5431,10 +5559,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5461,10 +5590,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5491,10 +5621,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharSliceSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharSliceSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5764,10 +5895,11 @@ Module str.
                     []
                   |),
                   [
-                    M.get_struct_tuple_field
-                      (M.read (| self |))
-                      "core::str::pattern::CharPredicateSearcher"
+                    M.SubPointer.get_struct_tuple_field (|
+                      M.read (| self |),
+                      "core::str::pattern::CharPredicateSearcher",
                       0
+                    |)
                   ]
                 |)
               ]))
@@ -5836,25 +5968,29 @@ Module str.
                         M.read (| Value.String "haystack" |);
                         (* Unsize *)
                         M.pointer_coercion
-                          (M.get_struct_record_field
-                            (M.get_struct_tuple_field
-                              (M.read (| self |))
-                              "core::str::pattern::CharPredicateSearcher"
-                              0)
-                            "core::str::pattern::MultiCharEqSearcher"
-                            "haystack")
+                          (M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_tuple_field (|
+                              M.read (| self |),
+                              "core::str::pattern::CharPredicateSearcher",
+                              0
+                            |),
+                            "core::str::pattern::MultiCharEqSearcher",
+                            "haystack"
+                          |))
                       ]
                     |);
                     M.read (| Value.String "char_indices" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.get_struct_tuple_field
-                          (M.read (| self |))
-                          "core::str::pattern::CharPredicateSearcher"
-                          0)
-                        "core::str::pattern::MultiCharEqSearcher"
-                        "char_indices")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_tuple_field (|
+                          M.read (| self |),
+                          "core::str::pattern::CharPredicateSearcher",
+                          0
+                        |),
+                        "core::str::pattern::MultiCharEqSearcher",
+                        "char_indices"
+                      |))
                   ]
                 |)
               ]
@@ -5895,10 +6031,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5924,10 +6061,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5953,10 +6091,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -5982,10 +6121,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6030,10 +6170,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6059,10 +6200,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6088,10 +6230,11 @@ Module str.
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "core::str::pattern::CharPredicateSearcher"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "core::str::pattern::CharPredicateSearcher",
                   0
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -6970,7 +7113,7 @@ Module str.
                                                   |),
                                                   [ M.read (| haystack |) ]
                                                 |);
-                                                M.get_array_field (|
+                                                M.SubPointer.get_array_field (|
                                                   M.call_closure (|
                                                     M.get_associated_function (|
                                                       Ty.path "str",
@@ -7031,7 +7174,7 @@ Module str.
                                                 |)
                                               |) in
                                             let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -7366,10 +7509,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::StrSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::StrSearcher",
                         "haystack"
+                      |)
                     ]
                   |));
                 ("needle",
@@ -7382,10 +7526,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::StrSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::StrSearcher",
                         "needle"
+                      |)
                     ]
                   |));
                 ("searcher",
@@ -7398,10 +7543,11 @@ Module str.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::StrSearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::StrSearcher",
                         "searcher"
+                      |)
                     ]
                   |))
               ]))
@@ -7438,25 +7584,28 @@ Module str.
                 M.read (| Value.String "haystack" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::StrSearcher"
-                    "haystack");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::StrSearcher",
+                    "haystack"
+                  |));
                 M.read (| Value.String "needle" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::StrSearcher"
-                    "needle");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::StrSearcher",
+                    "needle"
+                  |));
                 M.read (| Value.String "searcher" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::StrSearcher"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::StrSearcher",
                       "searcher"
+                    |)
                   |))
               ]
             |)))
@@ -7508,7 +7657,7 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::StrSearcherImpl::Empty",
                           0
@@ -7534,7 +7683,7 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::StrSearcherImpl::TwoWay",
                           0
@@ -7588,7 +7737,7 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::StrSearcherImpl::Empty",
                           0
@@ -7612,7 +7761,7 @@ Module str.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::str::pattern::StrSearcherImpl::TwoWay",
                           0
@@ -7676,50 +7825,55 @@ Module str.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::EmptyNeedle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::EmptyNeedle",
                         "position"
+                      |)
                     ]
                   |));
                 ("end_",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::EmptyNeedle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::EmptyNeedle",
                         "end"
+                      |)
                     ]
                   |));
                 ("is_match_fw",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::EmptyNeedle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::EmptyNeedle",
                         "is_match_fw"
+                      |)
                     ]
                   |));
                 ("is_match_bw",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::EmptyNeedle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::EmptyNeedle",
                         "is_match_bw"
+                      |)
                     ]
                   |));
                 ("is_finished",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::EmptyNeedle"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::EmptyNeedle",
                         "is_finished"
+                      |)
                     ]
                   |))
               ]))
@@ -7756,39 +7910,44 @@ Module str.
                 M.read (| Value.String "position" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::EmptyNeedle"
-                    "position");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::EmptyNeedle",
+                    "position"
+                  |));
                 M.read (| Value.String "end" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::EmptyNeedle"
-                    "end");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::EmptyNeedle",
+                    "end"
+                  |));
                 M.read (| Value.String "is_match_fw" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::EmptyNeedle"
-                    "is_match_fw");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::EmptyNeedle",
+                    "is_match_fw"
+                  |));
                 M.read (| Value.String "is_match_bw" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::str::pattern::EmptyNeedle"
-                    "is_match_bw");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::str::pattern::EmptyNeedle",
+                    "is_match_bw"
+                  |));
                 M.read (| Value.String "is_finished" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::EmptyNeedle"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::EmptyNeedle",
                       "is_finished"
+                    |)
                   |))
               ]
             |)))
@@ -7938,10 +8097,11 @@ Module str.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::str::pattern::StrSearcher"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::str::pattern::StrSearcher",
                 "haystack"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -8007,15 +8167,16 @@ Module str.
               ltac:(M.monadic
                 (M.read (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::StrSearcher"
-                      "searcher",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::StrSearcher",
+                      "searcher"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::Empty",
                               0
@@ -8029,10 +8190,11 @@ Module str.
                                   ltac:(M.monadic
                                     (let γ :=
                                       M.use
-                                        (M.get_struct_record_field
-                                          (M.read (| searcher |))
-                                          "core::str::pattern::EmptyNeedle"
-                                          "is_finished") in
+                                        (M.SubPointer.get_struct_record_field (|
+                                          M.read (| searcher |),
+                                          "core::str::pattern::EmptyNeedle",
+                                          "is_finished"
+                                        |)) in
                                     let _ :=
                                       M.is_constant_or_break_match (|
                                         M.read (| γ |),
@@ -8054,31 +8216,35 @@ Module str.
                             |) in
                           let is_match :=
                             M.copy (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
                                 "is_match_fw"
+                              |)
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
-                                "is_match_fw",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
+                                "is_match_fw"
+                              |),
                               UnOp.Pure.not
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::EmptyNeedle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::EmptyNeedle",
                                     "is_match_fw"
+                                  |)
                                 |))
                             |) in
                           let pos :=
                             M.copy (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
                                 "position"
+                              |)
                             |) in
                           M.match_operator (|
                             M.alloc (|
@@ -8109,10 +8275,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |);
                                             Value.StructRecord
                                               "core::ops::range::RangeFrom"
@@ -8143,10 +8310,11 @@ Module str.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::EmptyNeedle"
-                                        "is_finished",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::EmptyNeedle",
+                                        "is_finished"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -8155,7 +8323,7 @@ Module str.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -8163,10 +8331,11 @@ Module str.
                                   let ch := M.copy (| γ0_0 |) in
                                   let _ :=
                                     let β :=
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::EmptyNeedle"
-                                        "position" in
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::EmptyNeedle",
+                                        "position"
+                                      |) in
                                     M.write (|
                                       β,
                                       BinOp.Panic.add (|
@@ -8187,10 +8356,11 @@ Module str.
                                       [
                                         M.read (| pos |);
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| searcher |))
-                                            "core::str::pattern::EmptyNeedle"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| searcher |),
+                                            "core::str::pattern::EmptyNeedle",
                                             "position"
+                                          |)
                                         |)
                                       ]
                                   |)))
@@ -8199,7 +8369,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::TwoWay",
                               0
@@ -8216,10 +8386,11 @@ Module str.
                                         (M.alloc (|
                                           BinOp.Pure.eq
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| searcher |))
-                                                "core::str::pattern::TwoWaySearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| searcher |),
+                                                "core::str::pattern::TwoWaySearcher",
                                                 "position"
+                                              |)
                                             |))
                                             (M.call_closure (|
                                               M.get_associated_function (|
@@ -8229,10 +8400,11 @@ Module str.
                                               |),
                                               [
                                                 M.read (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::str::pattern::StrSearcher"
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::str::pattern::StrSearcher",
                                                     "haystack"
+                                                  |)
                                                 |)
                                               ]
                                             |))
@@ -8260,10 +8432,11 @@ Module str.
                             M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::TwoWaySearcher"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::TwoWaySearcher",
                                     "memory"
+                                  |)
                                 |))
                                 (M.read (| M.get_constant (| "core::num::MAX" |) |))
                             |) in
@@ -8281,10 +8454,11 @@ Module str.
                                     M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::StrSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::StrSearcher",
                                           "haystack"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -8292,10 +8466,11 @@ Module str.
                                     M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::StrSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::StrSearcher",
                                           "needle"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -8307,13 +8482,13 @@ Module str.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::str::pattern::SearchStep::Reject",
                                       0
                                     |) in
                                   let γ0_1 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::str::pattern::SearchStep::Reject",
                                       1
@@ -8340,10 +8515,11 @@ Module str.
                                                           |),
                                                           [
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::str::pattern::StrSearcher"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::str::pattern::StrSearcher",
                                                                 "haystack"
+                                                              |)
                                                             |);
                                                             M.read (| b |)
                                                           ]
@@ -8384,19 +8560,21 @@ Module str.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::TwoWaySearcher"
-                                        "position",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::TwoWaySearcher",
+                                        "position"
+                                      |),
                                       M.call_closure (|
                                         M.get_function (| "core::cmp::max", [ Ty.path "usize" ] |),
                                         [
                                           M.read (| b |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| searcher |))
-                                              "core::str::pattern::TwoWaySearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| searcher |),
+                                              "core::str::pattern::TwoWaySearcher",
                                               "position"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -8459,10 +8637,11 @@ Module str.
               ltac:(M.monadic
                 (M.read (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::StrSearcher"
-                      "searcher",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::StrSearcher",
+                      "searcher"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
@@ -8488,13 +8667,13 @@ Module str.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::str::pattern::SearchStep::Match",
                                                 0
                                               |) in
                                             let γ0_1 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::str::pattern::SearchStep::Match",
                                                 1
@@ -8538,7 +8717,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::TwoWay",
                               0
@@ -8548,10 +8727,11 @@ Module str.
                             M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::TwoWaySearcher"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::TwoWaySearcher",
                                     "memory"
+                                  |)
                                 |))
                                 (M.read (| M.get_constant (| "core::num::MAX" |) |))
                             |) in
@@ -8583,10 +8763,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -8598,10 +8779,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "needle"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -8628,10 +8810,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -8643,10 +8826,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "needle"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -8734,15 +8918,16 @@ Module str.
               ltac:(M.monadic
                 (M.read (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::StrSearcher"
-                      "searcher",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::StrSearcher",
+                      "searcher"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::Empty",
                               0
@@ -8756,10 +8941,11 @@ Module str.
                                   ltac:(M.monadic
                                     (let γ :=
                                       M.use
-                                        (M.get_struct_record_field
-                                          (M.read (| searcher |))
-                                          "core::str::pattern::EmptyNeedle"
-                                          "is_finished") in
+                                        (M.SubPointer.get_struct_record_field (|
+                                          M.read (| searcher |),
+                                          "core::str::pattern::EmptyNeedle",
+                                          "is_finished"
+                                        |)) in
                                     let _ :=
                                       M.is_constant_or_break_match (|
                                         M.read (| γ |),
@@ -8781,31 +8967,35 @@ Module str.
                             |) in
                           let is_match :=
                             M.copy (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
                                 "is_match_bw"
+                              |)
                             |) in
                           let _ :=
                             M.write (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
-                                "is_match_bw",
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
+                                "is_match_bw"
+                              |),
                               UnOp.Pure.not
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::EmptyNeedle"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::EmptyNeedle",
                                     "is_match_bw"
+                                  |)
                                 |))
                             |) in
                           let end_ :=
                             M.copy (|
-                              M.get_struct_record_field
-                                (M.read (| searcher |))
-                                "core::str::pattern::EmptyNeedle"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| searcher |),
+                                "core::str::pattern::EmptyNeedle",
                                 "end"
+                              |)
                             |) in
                           M.match_operator (|
                             M.alloc (|
@@ -8836,10 +9026,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |);
                                             Value.StructRecord
                                               "core::ops::range::RangeTo"
@@ -8870,10 +9061,11 @@ Module str.
                                 ltac:(M.monadic
                                   (let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::EmptyNeedle"
-                                        "is_finished",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::EmptyNeedle",
+                                        "is_finished"
+                                      |),
                                       Value.Bool true
                                     |) in
                                   M.alloc (|
@@ -8882,7 +9074,7 @@ Module str.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -8890,10 +9082,11 @@ Module str.
                                   let ch := M.copy (| γ0_0 |) in
                                   let _ :=
                                     let β :=
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::EmptyNeedle"
-                                        "end" in
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::EmptyNeedle",
+                                        "end"
+                                      |) in
                                     M.write (|
                                       β,
                                       BinOp.Panic.sub (|
@@ -8913,10 +9106,11 @@ Module str.
                                       "core::str::pattern::SearchStep::Reject"
                                       [
                                         M.read (|
-                                          M.get_struct_record_field
-                                            (M.read (| searcher |))
-                                            "core::str::pattern::EmptyNeedle"
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| searcher |),
+                                            "core::str::pattern::EmptyNeedle",
                                             "end"
+                                          |)
                                         |);
                                         M.read (| end_ |)
                                       ]
@@ -8926,7 +9120,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::TwoWay",
                               0
@@ -8943,10 +9137,11 @@ Module str.
                                         (M.alloc (|
                                           BinOp.Pure.eq
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| searcher |))
-                                                "core::str::pattern::TwoWaySearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| searcher |),
+                                                "core::str::pattern::TwoWaySearcher",
                                                 "end"
+                                              |)
                                             |))
                                             (Value.Integer Integer.Usize 0)
                                         |)) in
@@ -8973,10 +9168,11 @@ Module str.
                             M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::TwoWaySearcher"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::TwoWaySearcher",
                                     "memory"
+                                  |)
                                 |))
                                 (M.read (| M.get_constant (| "core::num::MAX" |) |))
                             |) in
@@ -8994,10 +9190,11 @@ Module str.
                                     M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::StrSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::StrSearcher",
                                           "haystack"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -9005,10 +9202,11 @@ Module str.
                                     M.get_associated_function (| Ty.path "str", "as_bytes", [] |),
                                     [
                                       M.read (|
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::StrSearcher"
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::StrSearcher",
                                           "needle"
+                                        |)
                                       |)
                                     ]
                                   |);
@@ -9020,13 +9218,13 @@ Module str.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::str::pattern::SearchStep::Reject",
                                       0
                                     |) in
                                   let γ0_1 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::str::pattern::SearchStep::Reject",
                                       1
@@ -9053,10 +9251,11 @@ Module str.
                                                           |),
                                                           [
                                                             M.read (|
-                                                              M.get_struct_record_field
-                                                                (M.read (| self |))
-                                                                "core::str::pattern::StrSearcher"
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| self |),
+                                                                "core::str::pattern::StrSearcher",
                                                                 "haystack"
+                                                              |)
                                                             |);
                                                             M.read (| a |)
                                                           ]
@@ -9097,19 +9296,21 @@ Module str.
                                     |) in
                                   let _ :=
                                     M.write (|
-                                      M.get_struct_record_field
-                                        (M.read (| searcher |))
-                                        "core::str::pattern::TwoWaySearcher"
-                                        "end",
+                                      M.SubPointer.get_struct_record_field (|
+                                        M.read (| searcher |),
+                                        "core::str::pattern::TwoWaySearcher",
+                                        "end"
+                                      |),
                                       M.call_closure (|
                                         M.get_function (| "core::cmp::min", [ Ty.path "usize" ] |),
                                         [
                                           M.read (| a |);
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| searcher |))
-                                              "core::str::pattern::TwoWaySearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| searcher |),
+                                              "core::str::pattern::TwoWaySearcher",
                                               "end"
+                                            |)
                                           |)
                                         ]
                                       |)
@@ -9171,10 +9372,11 @@ Module str.
               ltac:(M.monadic
                 (M.read (|
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::StrSearcher"
-                      "searcher",
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::StrSearcher",
+                      "searcher"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
@@ -9200,13 +9402,13 @@ Module str.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::str::pattern::SearchStep::Match",
                                                 0
                                               |) in
                                             let γ0_1 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::str::pattern::SearchStep::Match",
                                                 1
@@ -9250,7 +9452,7 @@ Module str.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::str::pattern::StrSearcherImpl::TwoWay",
                               0
@@ -9260,10 +9462,11 @@ Module str.
                             M.alloc (|
                               BinOp.Pure.eq
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| searcher |))
-                                    "core::str::pattern::TwoWaySearcher"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| searcher |),
+                                    "core::str::pattern::TwoWaySearcher",
                                     "memory"
+                                  |)
                                 |))
                                 (M.read (| M.get_constant (| "core::num::MAX" |) |))
                             |) in
@@ -9295,10 +9498,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -9310,10 +9514,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "needle"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -9340,10 +9545,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "haystack"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -9355,10 +9561,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::StrSearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::StrSearcher",
                                                 "needle"
+                                              |)
                                             |)
                                           ]
                                         |);
@@ -9420,80 +9627,88 @@ Module str.
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "crit_pos"
+                      |)
                     ]
                   |));
                 ("crit_pos_back",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "crit_pos_back"
+                      |)
                     ]
                   |));
                 ("period",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "period"
+                      |)
                     ]
                   |));
                 ("byteset",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "u64", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "byteset"
+                      |)
                     ]
                   |));
                 ("position",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "position"
+                      |)
                     ]
                   |));
                 ("end_",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "end"
+                      |)
                     ]
                   |));
                 ("memory",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "memory"
+                      |)
                     ]
                   |));
                 ("memory_back",
                   M.call_closure (|
                     M.get_trait_method (| "core::clone::Clone", Ty.path "usize", [], "clone", [] |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "memory_back"
+                      |)
                     ]
                   |))
               ]))
@@ -9544,53 +9759,61 @@ Module str.
                         [
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "crit_pos");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "crit_pos"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "crit_pos_back");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "crit_pos_back"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "period");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "period"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "byteset");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "byteset"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "position");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "position"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "end");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "end"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::str::pattern::TwoWaySearcher"
-                              "memory");
+                            (M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::str::pattern::TwoWaySearcher",
+                              "memory"
+                            |));
                           (* Unsize *)
                           M.pointer_coercion
                             (M.alloc (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::str::pattern::TwoWaySearcher"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::str::pattern::TwoWaySearcher",
                                 "memory_back"
+                              |)
                             |))
                         ]
                     |))
@@ -9715,8 +9938,8 @@ Module str.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let crit_pos_false := M.copy (| γ0_0 |) in
                       let period_false := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -9733,8 +9956,8 @@ Module str.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let crit_pos_true := M.copy (| γ0_0 |) in
                               let period_true := M.copy (| γ0_1 |) in
                               M.match_operator (|
@@ -9771,8 +9994,8 @@ Module str.
                                 [
                                   fun γ =>
                                     ltac:(M.monadic
-                                      (let γ0_0 := M.get_tuple_field γ 0 in
-                                      let γ0_1 := M.get_tuple_field γ 1 in
+                                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                       let crit_pos := M.copy (| γ0_0 |) in
                                       let period := M.copy (| γ0_1 |) in
                                       M.match_operator (|
@@ -10115,10 +10338,11 @@ Module str.
               (BinOp.Pure.bit_and
                 (BinOp.Panic.shr (|
                   M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::str::pattern::TwoWaySearcher"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::str::pattern::TwoWaySearcher",
                       "byteset"
+                    |)
                   |),
                   M.rust_cast (BinOp.Pure.bit_and (M.read (| byte |)) (Value.Integer Integer.U8 63))
                 |))
@@ -10214,10 +10438,11 @@ Module str.
                 (M.read (|
                   let old_pos :=
                     M.copy (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "position"
+                      |)
                     |) in
                   let needle_last :=
                     M.alloc (|
@@ -10252,10 +10477,11 @@ Module str.
                                         M.read (| haystack |);
                                         BinOp.Panic.add (|
                                           M.read (|
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "core::str::pattern::TwoWaySearcher"
+                                            M.SubPointer.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "core::str::pattern::TwoWaySearcher",
                                               "position"
+                                            |)
                                           |),
                                           M.read (| needle_last |)
                                         |)
@@ -10266,7 +10492,7 @@ Module str.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -10281,10 +10507,11 @@ Module str.
                                             M.read (|
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::str::pattern::TwoWaySearcher"
-                                                    "position",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::str::pattern::TwoWaySearcher",
+                                                    "position"
+                                                  |),
                                                   M.call_closure (|
                                                     M.get_associated_function (|
                                                       Ty.apply (Ty.path "slice") [ Ty.path "u8" ],
@@ -10306,10 +10533,11 @@ Module str.
                                                   [
                                                     M.read (| old_pos |);
                                                     M.read (|
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "core::str::pattern::TwoWaySearcher"
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "core::str::pattern::TwoWaySearcher",
                                                         "position"
+                                                      |)
                                                     |)
                                                   ]
                                                 |)
@@ -10344,10 +10572,11 @@ Module str.
                                                 (BinOp.Pure.ne
                                                   (M.read (| old_pos |))
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::TwoWaySearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::TwoWaySearcher",
                                                       "position"
+                                                    |)
                                                   |))))
                                             |)
                                           |)) in
@@ -10371,10 +10600,11 @@ Module str.
                                                 [
                                                   M.read (| old_pos |);
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::TwoWaySearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::TwoWaySearcher",
                                                       "position"
+                                                    |)
                                                   |)
                                                 ]
                                               |)
@@ -10414,10 +10644,11 @@ Module str.
                                           M.read (|
                                             let _ :=
                                               let β :=
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
-                                                  "position" in
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
+                                                  "position"
+                                                |) in
                                               M.write (|
                                                 β,
                                                 BinOp.Panic.add (|
@@ -10450,10 +10681,11 @@ Module str.
                                                         |) in
                                                       let _ :=
                                                         M.write (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::str::pattern::TwoWaySearcher"
-                                                            "memory",
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::str::pattern::TwoWaySearcher",
+                                                            "memory"
+                                                          |),
                                                           Value.Integer Integer.Usize 0
                                                         |) in
                                                       M.alloc (| Value.Tuple [] |)));
@@ -10481,10 +10713,11 @@ Module str.
                                             M.read (| γ |),
                                             Value.Bool true
                                           |) in
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::TwoWaySearcher"
-                                          "crit_pos"));
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::TwoWaySearcher",
+                                          "crit_pos"
+                                        |)));
                                     fun γ =>
                                       ltac:(M.monadic
                                         (M.alloc (|
@@ -10495,16 +10728,18 @@ Module str.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
                                                   "crit_pos"
+                                                |)
                                               |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
                                                   "memory"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -10577,7 +10812,7 @@ Module str.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -10593,23 +10828,22 @@ Module str.
                                                                   (M.alloc (|
                                                                     BinOp.Pure.ne
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| needle |),
                                                                           i
                                                                         |)
                                                                       |))
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| haystack |),
                                                                           M.alloc (|
                                                                             BinOp.Panic.add (|
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::str::pattern::TwoWaySearcher"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::str::pattern::TwoWaySearcher",
                                                                                   "position"
+                                                                                |)
                                                                               |),
                                                                               M.read (| i |)
                                                                             |)
@@ -10627,10 +10861,11 @@ Module str.
                                                                   M.read (|
                                                                     let _ :=
                                                                       let β :=
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::TwoWaySearcher"
-                                                                          "position" in
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::TwoWaySearcher",
+                                                                          "position"
+                                                                        |) in
                                                                       M.write (|
                                                                         β,
                                                                         BinOp.Panic.add (|
@@ -10639,12 +10874,11 @@ Module str.
                                                                             BinOp.Panic.sub (|
                                                                               M.read (| i |),
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::str::pattern::TwoWaySearcher"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::str::pattern::TwoWaySearcher",
                                                                                   "crit_pos"
+                                                                                |)
                                                                               |)
                                                                             |),
                                                                             Value.Integer
@@ -10676,12 +10910,13 @@ Module str.
                                                                                 |) in
                                                                               let _ :=
                                                                                 M.write (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
-                                                                                    "memory",
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
+                                                                                    "memory"
+                                                                                  |),
                                                                                   Value.Integer
                                                                                     Integer.Usize
                                                                                     0
@@ -10727,10 +10962,11 @@ Module str.
                                         M.alloc (| Value.Integer Integer.Usize 0 |)));
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::TwoWaySearcher"
-                                          "memory"))
+                                        (M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::TwoWaySearcher",
+                                          "memory"
+                                        |)))
                                   ]
                                 |)
                               |) in
@@ -10770,10 +11006,11 @@ Module str.
                                                 ("start", M.read (| start |));
                                                 ("end_",
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::TwoWaySearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::TwoWaySearcher",
                                                       "crit_pos"
+                                                    |)
                                                   |))
                                               ]
                                           ]
@@ -10818,7 +11055,7 @@ Module str.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -10834,23 +11071,22 @@ Module str.
                                                                   (M.alloc (|
                                                                     BinOp.Pure.ne
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| needle |),
                                                                           i
                                                                         |)
                                                                       |))
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| haystack |),
                                                                           M.alloc (|
                                                                             BinOp.Panic.add (|
                                                                               M.read (|
-                                                                                M.get_struct_record_field
-                                                                                  (M.read (|
-                                                                                    self
-                                                                                  |))
-                                                                                  "core::str::pattern::TwoWaySearcher"
+                                                                                M.SubPointer.get_struct_record_field (|
+                                                                                  M.read (| self |),
+                                                                                  "core::str::pattern::TwoWaySearcher",
                                                                                   "position"
+                                                                                |)
                                                                               |),
                                                                               M.read (| i |)
                                                                             |)
@@ -10868,19 +11104,21 @@ Module str.
                                                                   M.read (|
                                                                     let _ :=
                                                                       let β :=
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::TwoWaySearcher"
-                                                                          "position" in
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::TwoWaySearcher",
+                                                                          "position"
+                                                                        |) in
                                                                       M.write (|
                                                                         β,
                                                                         BinOp.Panic.add (|
                                                                           M.read (| β |),
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::pattern::TwoWaySearcher"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::pattern::TwoWaySearcher",
                                                                               "period"
+                                                                            |)
                                                                           |)
                                                                         |)
                                                                       |) in
@@ -10907,12 +11145,13 @@ Module str.
                                                                                 |) in
                                                                               let _ :=
                                                                                 M.write (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
-                                                                                    "memory",
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
+                                                                                    "memory"
+                                                                                  |),
                                                                                   BinOp.Panic.sub (|
                                                                                     M.call_closure (|
                                                                                       M.get_associated_function (|
@@ -10933,12 +11172,13 @@ Module str.
                                                                                       ]
                                                                                     |),
                                                                                     M.read (|
-                                                                                      M.get_struct_record_field
-                                                                                        (M.read (|
+                                                                                      M.SubPointer.get_struct_record_field (|
+                                                                                        M.read (|
                                                                                           self
-                                                                                        |))
-                                                                                        "core::str::pattern::TwoWaySearcher"
+                                                                                        |),
+                                                                                        "core::str::pattern::TwoWaySearcher",
                                                                                         "period"
+                                                                                      |)
                                                                                     |)
                                                                                   |)
                                                                                 |) in
@@ -10969,17 +11209,19 @@ Module str.
                                 |)) in
                             let match_pos :=
                               M.copy (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::pattern::TwoWaySearcher"
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::pattern::TwoWaySearcher",
                                   "position"
+                                |)
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::pattern::TwoWaySearcher"
-                                  "position" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::pattern::TwoWaySearcher",
+                                  "position"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.add (|
@@ -11012,10 +11254,11 @@ Module str.
                                         |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::pattern::TwoWaySearcher"
-                                            "memory",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::pattern::TwoWaySearcher",
+                                            "memory"
+                                          |),
                                           Value.Integer Integer.Usize 0
                                         |) in
                                       M.alloc (| Value.Tuple [] |)));
@@ -11145,10 +11388,11 @@ Module str.
                 (M.read (|
                   let old_end :=
                     M.copy (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::str::pattern::TwoWaySearcher"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::str::pattern::TwoWaySearcher",
                         "end"
+                      |)
                     |) in
                   M.alloc (|
                     M.never_to_any (|
@@ -11175,10 +11419,11 @@ Module str.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "core::str::pattern::TwoWaySearcher"
+                                              M.SubPointer.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "core::str::pattern::TwoWaySearcher",
                                                 "end"
+                                              |)
                                             |);
                                             M.call_closure (|
                                               M.get_associated_function (|
@@ -11197,7 +11442,7 @@ Module str.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -11212,10 +11457,11 @@ Module str.
                                             M.read (|
                                               let _ :=
                                                 M.write (|
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::str::pattern::TwoWaySearcher"
-                                                    "end",
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::str::pattern::TwoWaySearcher",
+                                                    "end"
+                                                  |),
                                                   Value.Integer Integer.Usize 0
                                                 |) in
                                               M.return_ (|
@@ -11263,10 +11509,11 @@ Module str.
                                                 (BinOp.Pure.ne
                                                   (M.read (| old_end |))
                                                   (M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::TwoWaySearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::TwoWaySearcher",
                                                       "end"
+                                                    |)
                                                   |))))
                                             |)
                                           |)) in
@@ -11289,10 +11536,11 @@ Module str.
                                                 |),
                                                 [
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "core::str::pattern::TwoWaySearcher"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "core::str::pattern::TwoWaySearcher",
                                                       "end"
+                                                    |)
                                                   |);
                                                   M.read (| old_end |)
                                                 ]
@@ -11333,10 +11581,11 @@ Module str.
                                           M.read (|
                                             let _ :=
                                               let β :=
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
-                                                  "end" in
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
+                                                  "end"
+                                                |) in
                                               M.write (|
                                                 β,
                                                 BinOp.Panic.sub (|
@@ -11369,10 +11618,11 @@ Module str.
                                                         |) in
                                                       let _ :=
                                                         M.write (|
-                                                          M.get_struct_record_field
-                                                            (M.read (| self |))
-                                                            "core::str::pattern::TwoWaySearcher"
-                                                            "memory_back",
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| self |),
+                                                            "core::str::pattern::TwoWaySearcher",
+                                                            "memory_back"
+                                                          |),
                                                           M.call_closure (|
                                                             M.get_associated_function (|
                                                               Ty.apply
@@ -11409,10 +11659,11 @@ Module str.
                                             M.read (| γ |),
                                             Value.Bool true
                                           |) in
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::TwoWaySearcher"
-                                          "crit_pos_back"));
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::TwoWaySearcher",
+                                          "crit_pos_back"
+                                        |)));
                                     fun γ =>
                                       ltac:(M.monadic
                                         (M.alloc (|
@@ -11423,16 +11674,18 @@ Module str.
                                             |),
                                             [
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
                                                   "crit_pos_back"
+                                                |)
                                               |);
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
                                                   "memory_back"
+                                                |)
                                               |)
                                             ]
                                           |)
@@ -11518,7 +11771,7 @@ Module str.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -11534,24 +11787,25 @@ Module str.
                                                                   (M.alloc (|
                                                                     BinOp.Pure.ne
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| needle |),
                                                                           i
                                                                         |)
                                                                       |))
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| haystack |),
                                                                           M.alloc (|
                                                                             BinOp.Panic.add (|
                                                                               BinOp.Panic.sub (|
                                                                                 M.read (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
                                                                                     "end"
+                                                                                  |)
                                                                                 |),
                                                                                 M.call_closure (|
                                                                                   M.get_associated_function (|
@@ -11586,20 +11840,22 @@ Module str.
                                                                   M.read (|
                                                                     let _ :=
                                                                       let β :=
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::TwoWaySearcher"
-                                                                          "end" in
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::TwoWaySearcher",
+                                                                          "end"
+                                                                        |) in
                                                                       M.write (|
                                                                         β,
                                                                         BinOp.Panic.sub (|
                                                                           M.read (| β |),
                                                                           BinOp.Panic.sub (|
                                                                             M.read (|
-                                                                              M.get_struct_record_field
-                                                                                (M.read (| self |))
-                                                                                "core::str::pattern::TwoWaySearcher"
+                                                                              M.SubPointer.get_struct_record_field (|
+                                                                                M.read (| self |),
+                                                                                "core::str::pattern::TwoWaySearcher",
                                                                                 "crit_pos_back"
+                                                                              |)
                                                                             |),
                                                                             M.read (| i |)
                                                                           |)
@@ -11628,12 +11884,13 @@ Module str.
                                                                                 |) in
                                                                               let _ :=
                                                                                 M.write (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
-                                                                                    "memory_back",
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
+                                                                                    "memory_back"
+                                                                                  |),
                                                                                   M.call_closure (|
                                                                                     M.get_associated_function (|
                                                                                       Ty.apply
@@ -11703,10 +11960,11 @@ Module str.
                                         |)));
                                     fun γ =>
                                       ltac:(M.monadic
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::str::pattern::TwoWaySearcher"
-                                          "memory_back"))
+                                        (M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::str::pattern::TwoWaySearcher",
+                                          "memory_back"
+                                        |)))
                                   ]
                                 |)
                               |) in
@@ -11730,10 +11988,11 @@ Module str.
                                           [
                                             ("start",
                                               M.read (|
-                                                M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::str::pattern::TwoWaySearcher"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::str::pattern::TwoWaySearcher",
                                                   "crit_pos_back"
+                                                |)
                                               |));
                                             ("end_", M.read (| needle_end |))
                                           ]
@@ -11773,7 +12032,7 @@ Module str.
                                                   fun γ =>
                                                     ltac:(M.monadic
                                                       (let γ0_0 :=
-                                                        M.get_struct_tuple_field_or_break_match (|
+                                                        M.SubPointer.get_struct_tuple_field (|
                                                           γ,
                                                           "core::option::Option::Some",
                                                           0
@@ -11789,24 +12048,25 @@ Module str.
                                                                   (M.alloc (|
                                                                     BinOp.Pure.ne
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| needle |),
                                                                           i
                                                                         |)
                                                                       |))
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| haystack |),
                                                                           M.alloc (|
                                                                             BinOp.Panic.add (|
                                                                               BinOp.Panic.sub (|
                                                                                 M.read (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
                                                                                     "end"
+                                                                                  |)
                                                                                 |),
                                                                                 M.call_closure (|
                                                                                   M.get_associated_function (|
@@ -11841,19 +12101,21 @@ Module str.
                                                                   M.read (|
                                                                     let _ :=
                                                                       let β :=
-                                                                        M.get_struct_record_field
-                                                                          (M.read (| self |))
-                                                                          "core::str::pattern::TwoWaySearcher"
-                                                                          "end" in
+                                                                        M.SubPointer.get_struct_record_field (|
+                                                                          M.read (| self |),
+                                                                          "core::str::pattern::TwoWaySearcher",
+                                                                          "end"
+                                                                        |) in
                                                                       M.write (|
                                                                         β,
                                                                         BinOp.Panic.sub (|
                                                                           M.read (| β |),
                                                                           M.read (|
-                                                                            M.get_struct_record_field
-                                                                              (M.read (| self |))
-                                                                              "core::str::pattern::TwoWaySearcher"
+                                                                            M.SubPointer.get_struct_record_field (|
+                                                                              M.read (| self |),
+                                                                              "core::str::pattern::TwoWaySearcher",
                                                                               "period"
+                                                                            |)
                                                                           |)
                                                                         |)
                                                                       |) in
@@ -11880,19 +12142,21 @@ Module str.
                                                                                 |) in
                                                                               let _ :=
                                                                                 M.write (|
-                                                                                  M.get_struct_record_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_struct_record_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    "core::str::pattern::TwoWaySearcher"
-                                                                                    "memory_back",
+                                                                                    |),
+                                                                                    "core::str::pattern::TwoWaySearcher",
+                                                                                    "memory_back"
+                                                                                  |),
                                                                                   M.read (|
-                                                                                    M.get_struct_record_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_struct_record_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      "core::str::pattern::TwoWaySearcher"
+                                                                                      |),
+                                                                                      "core::str::pattern::TwoWaySearcher",
                                                                                       "period"
+                                                                                    |)
                                                                                   |)
                                                                                 |) in
                                                                               M.alloc (|
@@ -11924,10 +12188,11 @@ Module str.
                               M.alloc (|
                                 BinOp.Panic.sub (|
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "core::str::pattern::TwoWaySearcher"
+                                    M.SubPointer.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "core::str::pattern::TwoWaySearcher",
                                       "end"
+                                    |)
                                   |),
                                   M.call_closure (|
                                     M.get_associated_function (|
@@ -11941,10 +12206,11 @@ Module str.
                               |) in
                             let _ :=
                               let β :=
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::str::pattern::TwoWaySearcher"
-                                  "end" in
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::str::pattern::TwoWaySearcher",
+                                  "end"
+                                |) in
                               M.write (|
                                 β,
                                 BinOp.Panic.sub (|
@@ -11977,10 +12243,11 @@ Module str.
                                         |) in
                                       let _ :=
                                         M.write (|
-                                          M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::str::pattern::TwoWaySearcher"
-                                            "memory_back",
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::str::pattern::TwoWaySearcher",
+                                            "memory_back"
+                                          |),
                                           M.call_closure (|
                                             M.get_associated_function (|
                                               Ty.apply (Ty.path "slice") [ Ty.path "u8" ],
@@ -12099,7 +12366,7 @@ Module str.
                                 |)
                               |) in
                             let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -12108,7 +12375,7 @@ Module str.
                             let a := M.copy (| γ0_0 |) in
                             let b :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| arr |),
                                   M.alloc (|
                                     BinOp.Panic.add (| M.read (| left |), M.read (| offset |) |)
@@ -12354,7 +12621,7 @@ Module str.
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                             let a :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| arr |),
                                   M.alloc (|
                                     BinOp.Panic.sub (|
@@ -12372,7 +12639,7 @@ Module str.
                               |) in
                             let b :=
                               M.copy (|
-                                M.get_array_field (|
+                                M.SubPointer.get_array_field (|
                                   M.read (| arr |),
                                   M.alloc (|
                                     BinOp.Panic.sub (|
@@ -12970,7 +13237,7 @@ Module str.
                   |) in
                 let first_probe :=
                   M.copy (|
-                    M.get_array_field (|
+                    M.SubPointer.get_array_field (|
                       M.read (| needle |),
                       M.alloc (| Value.Integer Integer.Usize 0 |)
                     |)
@@ -13080,7 +13347,7 @@ Module str.
                                                     let idx := M.copy (| γ |) in
                                                     BinOp.Pure.ne
                                                       (M.read (|
-                                                        M.get_array_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (| needle |),
                                                           idx
                                                         |)
@@ -13097,7 +13364,7 @@ Module str.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -13256,7 +13523,10 @@ Module str.
                       |),
                       [
                         M.read (|
-                          M.get_array_field (| M.read (| needle |), second_probe_offset |)
+                          M.SubPointer.get_array_field (|
+                            M.read (| needle |),
+                            second_probe_offset
+                          |)
                         |)
                       ]
                     |)
@@ -13873,7 +14143,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -13881,7 +14151,10 @@ Module str.
                                                         let j := M.copy (| γ0_0 |) in
                                                         let _ :=
                                                           M.write (|
-                                                            M.get_array_field (| masks, j |),
+                                                            M.SubPointer.get_array_field (|
+                                                              masks,
+                                                              j
+                                                            |),
                                                             M.call_closure (|
                                                               M.get_trait_method (|
                                                                 "core::ops::function::Fn",
@@ -13980,7 +14253,7 @@ Module str.
                                                     fun γ =>
                                                       ltac:(M.monadic
                                                         (let γ0_0 :=
-                                                          M.get_struct_tuple_field_or_break_match (|
+                                                          M.SubPointer.get_struct_tuple_field (|
                                                             γ,
                                                             "core::option::Option::Some",
                                                             0
@@ -13988,7 +14261,10 @@ Module str.
                                                         let j := M.copy (| γ0_0 |) in
                                                         let mask :=
                                                           M.copy (|
-                                                            M.get_array_field (| masks, j |)
+                                                            M.SubPointer.get_array_field (|
+                                                              masks,
+                                                              j
+                                                            |)
                                                           |) in
                                                         M.match_operator (|
                                                           M.alloc (| Value.Tuple [] |),
@@ -14437,8 +14713,8 @@ Module str.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let left_val := M.copy (| γ0_0 |) in
                                     let right_val := M.copy (| γ0_1 |) in
                                     M.match_operator (|
@@ -14613,13 +14889,21 @@ Module str.
                                                       fun γ =>
                                                         ltac:(M.monadic
                                                           (let γ0_0 :=
-                                                            M.get_struct_tuple_field_or_break_match (|
+                                                            M.SubPointer.get_struct_tuple_field (|
                                                               γ,
                                                               "core::option::Option::Some",
                                                               0
                                                             |) in
-                                                          let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                                          let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                                          let γ1_0 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ0_0,
+                                                              0
+                                                            |) in
+                                                          let γ1_1 :=
+                                                            M.SubPointer.get_tuple_field (|
+                                                              γ0_0,
+                                                              1
+                                                            |) in
                                                           let γ1_0 := M.read (| γ1_0 |) in
                                                           let b1 := M.copy (| γ1_0 |) in
                                                           let γ1_1 := M.read (| γ1_1 |) in
@@ -14693,8 +14977,8 @@ Module str.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let px := M.copy (| γ0_0 |) in
                         let py := M.copy (| γ0_1 |) in
                         M.match_operator (|
@@ -14748,8 +15032,8 @@ Module str.
                           [
                             fun γ =>
                               ltac:(M.monadic
-                                (let γ0_0 := M.get_tuple_field γ 0 in
-                                let γ0_1 := M.get_tuple_field γ 1 in
+                                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                 let pxend := M.copy (| γ0_0 |) in
                                 let pyend := M.copy (| γ0_1 |) in
                                 let _ :=

--- a/CoqOfRust/core/str/traits.v
+++ b/CoqOfRust/core/str/traits.v
@@ -394,10 +394,18 @@ Module str.
                               LogicalOp.and (|
                                 BinOp.Pure.le
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "start"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "end"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "end"
+                                    |)
                                   |)),
                                 ltac:(M.monadic
                                   (M.call_closure (|
@@ -409,10 +417,11 @@ Module str.
                                     [
                                       M.read (| slice |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::ops::range::Range"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::ops::range::Range",
                                           "start"
+                                        |)
                                       |)
                                     ]
                                   |)))
@@ -427,7 +436,11 @@ Module str.
                                   [
                                     M.read (| slice |);
                                     M.read (|
-                                      M.get_struct_record_field self "core::ops::range::Range" "end"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::ops::range::Range",
+                                        "end"
+                                      |)
                                     |)
                                   ]
                                 |)))
@@ -492,10 +505,18 @@ Module str.
                               LogicalOp.and (|
                                 BinOp.Pure.le
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "start"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "end"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "end"
+                                    |)
                                   |)),
                                 ltac:(M.monadic
                                   (M.call_closure (|
@@ -507,10 +528,11 @@ Module str.
                                     [
                                       M.read (| slice |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::ops::range::Range"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::ops::range::Range",
                                           "start"
+                                        |)
                                       |)
                                     ]
                                   |)))
@@ -525,7 +547,11 @@ Module str.
                                   [
                                     M.read (| slice |);
                                     M.read (|
-                                      M.get_struct_record_field self "core::ops::range::Range" "end"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::ops::range::Range",
+                                        "end"
+                                      |)
                                     |)
                                   ]
                                 |)))
@@ -608,24 +634,27 @@ Module str.
                                         (LogicalOp.and (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |)),
                                           ltac:(M.monadic
                                             (BinOp.Pure.le
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::ops::range::Range"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::ops::range::Range",
                                                   "end"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -702,15 +731,33 @@ Module str.
                         |),
                         [ M.read (| slice |) ]
                       |);
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
+                      |)
                     ]
                   |)
                 |) in
               let len :=
                 M.alloc (|
                   BinOp.Panic.sub (|
-                    M.read (| M.get_struct_record_field self "core::ops::range::Range" "end" |),
-                    M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::Range",
+                        "end"
+                      |)
+                    |),
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::Range",
+                        "start"
+                      |)
+                    |)
                   |)
                 |) in
               M.alloc (|
@@ -768,24 +815,27 @@ Module str.
                                         (LogicalOp.and (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "end"
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_record_field
-                                                self
-                                                "core::ops::range::Range"
+                                              M.SubPointer.get_struct_record_field (|
+                                                self,
+                                                "core::ops::range::Range",
                                                 "start"
+                                              |)
                                             |)),
                                           ltac:(M.monadic
                                             (BinOp.Pure.le
                                               (M.read (|
-                                                M.get_struct_record_field
-                                                  self
-                                                  "core::ops::range::Range"
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::ops::range::Range",
                                                   "end"
+                                                |)
                                               |))
                                               (M.call_closure (|
                                                 M.get_associated_function (|
@@ -860,15 +910,33 @@ Module str.
                         |),
                         [ M.read (| slice |) ]
                       |);
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
+                      |)
                     ]
                   |)
                 |) in
               let len :=
                 M.alloc (|
                   BinOp.Panic.sub (|
-                    M.read (| M.get_struct_record_field self "core::ops::range::Range" "end" |),
-                    M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |)
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::Range",
+                        "end"
+                      |)
+                    |),
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::Range",
+                        "start"
+                      |)
+                    |)
                   |)
                 |) in
               M.alloc (|
@@ -902,15 +970,27 @@ Module str.
                 M.alloc (|
                   Value.Tuple
                     [
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "start" |);
-                      M.read (| M.get_struct_record_field self "core::ops::range::Range" "end" |)
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "start"
+                        |)
+                      |);
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::Range",
+                          "end"
+                        |)
+                      |)
                     ]
                 |),
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let end_ := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -930,7 +1010,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -990,10 +1070,18 @@ Module str.
                               LogicalOp.and (|
                                 BinOp.Pure.le
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "start"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "start"
+                                    |)
                                   |))
                                   (M.read (|
-                                    M.get_struct_record_field self "core::ops::range::Range" "end"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::ops::range::Range",
+                                      "end"
+                                    |)
                                   |)),
                                 ltac:(M.monadic
                                   (M.call_closure (|
@@ -1005,10 +1093,11 @@ Module str.
                                     [
                                       M.read (| slice |);
                                       M.read (|
-                                        M.get_struct_record_field
-                                          self
-                                          "core::ops::range::Range"
+                                        M.SubPointer.get_struct_record_field (|
+                                          self,
+                                          "core::ops::range::Range",
                                           "start"
+                                        |)
                                       |)
                                     ]
                                   |)))
@@ -1023,7 +1112,11 @@ Module str.
                                   [
                                     M.read (| slice |);
                                     M.read (|
-                                      M.get_struct_record_field self "core::ops::range::Range" "end"
+                                      M.SubPointer.get_struct_record_field (|
+                                        self,
+                                        "core::ops::range::Range",
+                                        "end"
+                                      |)
                                     |)
                                   ]
                                 |)))
@@ -1051,10 +1144,18 @@ Module str.
                             [
                               M.read (| slice |);
                               M.read (|
-                                M.get_struct_record_field self "core::ops::range::Range" "start"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "start"
+                                |)
                               |);
                               M.read (|
-                                M.get_struct_record_field self "core::ops::range::Range" "end"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::Range",
+                                  "end"
+                                |)
                               |)
                             ]
                           |)
@@ -1148,7 +1249,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1181,7 +1282,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1252,7 +1353,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -1285,7 +1386,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -1522,7 +1623,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::RangeTo" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeTo",
+                                    "end"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1584,7 +1689,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::RangeTo" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeTo",
+                                    "end"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1641,7 +1750,13 @@ Module str.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -1675,7 +1790,13 @@ Module str.
                   [
                     ("start", Value.Integer Integer.Usize 0);
                     ("end_",
-                      M.read (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |))
+                      M.read (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeTo",
+                          "end"
+                        |)
+                      |))
                   ];
                 M.read (| slice |)
               ]
@@ -1700,7 +1821,13 @@ Module str.
             let slice := M.alloc (| slice |) in
             M.read (|
               let end_ :=
-                M.copy (| M.get_struct_record_field self "core::ops::range::RangeTo" "end" |) in
+                M.copy (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::ops::range::RangeTo",
+                    "end"
+                  |)
+                |) in
               M.match_operator (|
                 M.alloc (|
                   M.call_closure (|
@@ -1718,7 +1845,7 @@ Module str.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::option::Option::Some",
                           0
@@ -1772,7 +1899,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field self "core::ops::range::RangeTo" "end"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeTo",
+                                    "end"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1800,7 +1931,11 @@ Module str.
                               M.read (| slice |);
                               Value.Integer Integer.Usize 0;
                               M.read (|
-                                M.get_struct_record_field self "core::ops::range::RangeTo" "end"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::RangeTo",
+                                  "end"
+                                |)
                               |)
                             ]
                           |)
@@ -1867,10 +2002,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |)
                               ]
                             |)
@@ -1934,10 +2070,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2010,7 +2147,11 @@ Module str.
                       [
                         ("start",
                           M.read (|
-                            M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::ops::range::RangeFrom",
+                              "start"
+                            |)
                           |));
                         ("end_", M.read (| len |))
                       ];
@@ -2062,7 +2203,11 @@ Module str.
                       [
                         ("start",
                           M.read (|
-                            M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::ops::range::RangeFrom",
+                              "start"
+                            |)
                           |));
                         ("end_", M.read (| len |))
                       ];
@@ -2095,7 +2240,11 @@ Module str.
                   Value.Tuple
                     [
                       M.read (|
-                        M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::ops::range::RangeFrom",
+                          "start"
+                        |)
                       |);
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "str", "len", [] |),
@@ -2106,8 +2255,8 @@ Module str.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let start := M.copy (| γ0_0 |) in
                       let end_ := M.copy (| γ0_1 |) in
                       M.match_operator (|
@@ -2127,7 +2276,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0
@@ -2183,10 +2332,11 @@ Module str.
                               [
                                 M.read (| slice |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    self
-                                    "core::ops::range::RangeFrom"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::ops::range::RangeFrom",
                                     "start"
+                                  |)
                                 |)
                               ]
                             |)
@@ -2213,7 +2363,11 @@ Module str.
                             [
                               M.read (| slice |);
                               M.read (|
-                                M.get_struct_record_field self "core::ops::range::RangeFrom" "start"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::ops::range::RangeFrom",
+                                  "start"
+                                |)
                               |);
                               M.call_closure (|
                                 M.get_associated_function (| Ty.path "str", "len", [] |),
@@ -2670,7 +2824,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -2709,7 +2867,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -2749,7 +2911,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -2789,7 +2955,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -2828,7 +2998,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);
@@ -2867,7 +3041,11 @@ Module str.
                   [
                     Value.Integer Integer.Usize 0;
                     M.read (|
-                      M.get_struct_record_field self "core::ops::range::RangeToInclusive" "end"
+                      M.SubPointer.get_struct_record_field (|
+                        self,
+                        "core::ops::range::RangeToInclusive",
+                        "end"
+                      |)
                     |)
                   ]
                 |);

--- a/CoqOfRust/core/str/validations.v
+++ b/CoqOfRust/core/str/validations.v
@@ -133,7 +133,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Break",
                                   0
@@ -166,7 +166,7 @@ Module str.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::ops::control_flow::ControlFlow::Continue",
                                   0
@@ -458,7 +458,7 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Break",
                                     0
@@ -491,7 +491,7 @@ Module str.
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::ops::control_flow::ControlFlow::Continue",
                                     0
@@ -961,7 +961,9 @@ Module str.
                                 |) in
                               let old_offset := M.copy (| index |) in
                               let first :=
-                                M.copy (| M.get_array_field (| M.read (| v |), index |) |) in
+                                M.copy (|
+                                  M.SubPointer.get_array_field (| M.read (| v |), index |)
+                                |) in
                               M.match_operator (|
                                 M.alloc (| Value.Tuple [] |),
                                 [
@@ -1077,7 +1079,7 @@ Module str.
                                                                               |)))
                                                                         ]
                                                                       |) in
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       M.read (| v |),
                                                                       index
                                                                     |)
@@ -1192,7 +1194,7 @@ Module str.
                                                                       |)))
                                                                 ]
                                                               |) in
-                                                            M.get_array_field (|
+                                                            M.SubPointer.get_array_field (|
                                                               M.read (| v |),
                                                               index
                                                             |)
@@ -1208,9 +1210,15 @@ Module str.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let _ :=
                                                                     M.is_constant_or_break_match (|
                                                                       M.read (| γ0_0 |),
@@ -1220,16 +1228,28 @@ Module str.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   Value.Tuple []));
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let _ :=
                                                                     M.is_constant_or_break_match (|
                                                                       M.read (| γ0_0 |),
@@ -1239,9 +1259,15 @@ Module str.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   Value.Tuple []))
                                                             ],
                                                             M.closure
@@ -1362,7 +1388,7 @@ Module str.
                                                                               |)))
                                                                         ]
                                                                       |) in
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       M.read (| v |),
                                                                       index
                                                                     |)
@@ -1477,7 +1503,7 @@ Module str.
                                                                       |)))
                                                                 ]
                                                               |) in
-                                                            M.get_array_field (|
+                                                            M.SubPointer.get_array_field (|
                                                               M.read (| v |),
                                                               index
                                                             |)
@@ -1493,9 +1519,15 @@ Module str.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let _ :=
                                                                     M.is_constant_or_break_match (|
                                                                       M.read (| γ0_0 |),
@@ -1505,16 +1537,28 @@ Module str.
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   Value.Tuple []));
                                                               fun γ =>
                                                                 ltac:(M.monadic
                                                                   (let γ0_0 :=
-                                                                    M.get_tuple_field γ 0 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      0
+                                                                    |) in
                                                                   let γ0_1 :=
-                                                                    M.get_tuple_field γ 1 in
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      γ,
+                                                                      1
+                                                                    |) in
                                                                   let _ :=
                                                                     M.is_constant_or_break_match (|
                                                                       M.read (| γ0_0 |),
@@ -1641,7 +1685,7 @@ Module str.
                                                                                 |)))
                                                                           ]
                                                                         |) in
-                                                                      M.get_array_field (|
+                                                                      M.SubPointer.get_array_field (|
                                                                         M.read (| v |),
                                                                         index
                                                                       |)
@@ -1763,7 +1807,7 @@ Module str.
                                                                               |)))
                                                                         ]
                                                                       |) in
-                                                                    M.get_array_field (|
+                                                                    M.SubPointer.get_array_field (|
                                                                       M.read (| v |),
                                                                       index
                                                                     |)
@@ -2049,7 +2093,7 @@ Module str.
                                                                   ltac:(M.monadic
                                                                     (BinOp.Pure.lt
                                                                       (M.read (|
-                                                                        M.get_array_field (|
+                                                                        M.SubPointer.get_array_field (|
                                                                           M.read (| v |),
                                                                           index
                                                                         |)
@@ -2409,7 +2453,7 @@ Module str.
           (let b := M.alloc (| b |) in
           M.rust_cast
             (M.read (|
-              M.get_array_field (|
+              M.SubPointer.get_array_field (|
                 M.read (| M.get_constant (| "core::str::validations::UTF8_CHAR_WIDTH" |) |),
                 M.alloc (| M.rust_cast (M.read (| b |)) |)
               |)

--- a/CoqOfRust/core/sync/atomic.v
+++ b/CoqOfRust/core/sync/atomic.v
@@ -448,7 +448,12 @@ Module sync.
                   "get",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicBool" "v"
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::sync::atomic::AtomicBool",
+                    "v"
+                  |)
                 ]
               |))))
         | _, _ => M.impossible
@@ -528,7 +533,15 @@ Module sync.
                   "into_inner",
                   []
                 |),
-                [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicBool" "v" |) ]
+                [
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::sync::atomic::AtomicBool",
+                      "v"
+                    |)
+                  |)
+                ]
               |))
               (Value.Integer Integer.U8 0)))
         | _, _ => M.impossible
@@ -562,10 +575,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicBool"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicBool",
                           "v"
+                        |)
                       ]
                     |));
                   M.read (| order |)
@@ -606,10 +620,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicBool"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicBool",
                             "v"
+                          |)
                         ]
                       |);
                       M.rust_cast (M.read (| val |));
@@ -702,10 +717,11 @@ Module sync.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::sync::atomic::AtomicBool"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::sync::atomic::AtomicBool",
                                     "v"
+                                  |)
                                 ]
                               |);
                               M.rust_cast (M.read (| val |));
@@ -763,7 +779,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -773,7 +789,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -860,29 +876,29 @@ Module sync.
                             [
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::SeqCst" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::SeqCst" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::AcqRel" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     M.never_to_any (|
                                       M.call_closure (|
@@ -914,36 +930,36 @@ Module sync.
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::AcqRel" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::Acquire" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::Acquire" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::Release" []
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     M.never_to_any (|
                                       M.call_closure (|
@@ -975,8 +991,8 @@ Module sync.
                                   |)));
                               fun γ =>
                                 ltac:(M.monadic
-                                  (let γ0_0 := M.get_tuple_field γ 0 in
-                                  let γ0_1 := M.get_tuple_field γ 1 in
+                                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                   M.alloc (|
                                     Value.StructTuple "core::sync::atomic::Ordering::Relaxed" []
                                   |)))
@@ -1067,10 +1083,11 @@ Module sync.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "core::sync::atomic::AtomicBool"
+                                  M.SubPointer.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "core::sync::atomic::AtomicBool",
                                     "v"
+                                  |)
                                 ]
                               |);
                               M.rust_cast (M.read (| current |));
@@ -1084,7 +1101,7 @@ Module sync.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::result::Result::Ok",
                                   0
@@ -1098,7 +1115,7 @@ Module sync.
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::result::Result::Err",
                                   0
@@ -1204,10 +1221,11 @@ Module sync.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::sync::atomic::AtomicBool"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::sync::atomic::AtomicBool",
                                 "v"
+                              |)
                             ]
                           |);
                           M.rust_cast (M.read (| current |));
@@ -1221,7 +1239,7 @@ Module sync.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::result::Result::Ok",
                               0
@@ -1235,7 +1253,7 @@ Module sync.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::result::Result::Err",
                               0
@@ -1280,10 +1298,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicBool"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicBool",
                         "v"
+                      |)
                     ]
                   |);
                   M.rust_cast (M.read (| val |));
@@ -1382,10 +1401,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicBool"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicBool",
                         "v"
+                      |)
                     ]
                   |);
                   M.rust_cast (M.read (| val |));
@@ -1422,10 +1442,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicBool"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicBool",
                         "v"
+                      |)
                     ]
                   |);
                   M.rust_cast (M.read (| val |));
@@ -1486,10 +1507,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicBool"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicBool",
                       "v"
+                    |)
                   ]
                 |)
               ]
@@ -1563,7 +1585,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -1591,7 +1613,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -1604,7 +1626,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -1719,7 +1741,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicPtr" "p" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicPtr",
+                  "p"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1824,7 +1852,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicPtr" "p" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicPtr",
+                    "p"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -1863,10 +1899,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicPtr"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicPtr",
                         "p"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -1913,10 +1950,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicPtr"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicPtr",
                             "p"
+                          |)
                         ]
                       |);
                       M.read (| ptr |);
@@ -1960,10 +1998,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicPtr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicPtr",
                       "p"
+                    |)
                   ]
                 |);
                 M.read (| ptr |);
@@ -2019,7 +2058,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -2029,7 +2068,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -2081,10 +2120,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicPtr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicPtr",
                       "p"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -2138,10 +2178,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicPtr"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicPtr",
                       "p"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -2222,7 +2263,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -2250,7 +2291,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -2263,7 +2304,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -2406,10 +2447,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicPtr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicPtr",
                           "p"
+                        |)
                       ]
                     |);
                     M.call_closure (|
@@ -2460,10 +2502,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicPtr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicPtr",
                           "p"
+                        |)
                       ]
                     |);
                     M.call_closure (|
@@ -2514,10 +2557,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicPtr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicPtr",
                           "p"
+                        |)
                       ]
                     |);
                     M.call_closure (|
@@ -2568,10 +2612,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicPtr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicPtr",
                           "p"
+                        |)
                       ]
                     |);
                     M.call_closure (|
@@ -2622,10 +2667,11 @@ Module sync.
                         []
                       |),
                       [
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::sync::atomic::AtomicPtr"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::sync::atomic::AtomicPtr",
                           "p"
+                        |)
                       ]
                     |);
                     M.call_closure (|
@@ -2661,7 +2707,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicPtr" "p" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicPtr",
+                  "p"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -2928,7 +2980,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI8",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -3036,7 +3094,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicI8" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicI8",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -3067,10 +3133,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicI8"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicI8",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -3107,10 +3174,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicI8"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicI8",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -3147,7 +3215,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3206,7 +3279,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -3216,7 +3289,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -3260,7 +3333,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -3308,7 +3386,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -3345,7 +3428,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3379,7 +3467,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3413,7 +3506,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3447,7 +3545,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3481,7 +3584,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3515,7 +3623,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3587,7 +3700,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -3615,7 +3728,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -3628,7 +3741,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -3684,7 +3797,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3718,7 +3836,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -3746,7 +3869,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI8" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI8",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -3949,7 +4078,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU8",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4057,7 +4192,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicU8" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicU8",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4088,10 +4231,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicU8"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicU8",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -4128,10 +4272,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicU8"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicU8",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -4168,7 +4313,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4227,7 +4377,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -4237,7 +4387,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -4281,7 +4431,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -4329,7 +4484,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -4366,7 +4526,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4400,7 +4565,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4434,7 +4604,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4468,7 +4643,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4502,7 +4682,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4536,7 +4721,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4608,7 +4798,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -4636,7 +4826,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -4649,7 +4839,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -4705,7 +4895,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4739,7 +4934,12 @@ Module sync.
                     "get",
                     []
                   |),
-                  [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v"
+                  [
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU8",
+                      "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -4767,7 +4967,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU8" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU8",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -4970,7 +5176,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI16" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI16",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5078,7 +5290,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicI16" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicI16",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -5109,10 +5329,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicI16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicI16",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -5149,10 +5370,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicI16"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicI16",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -5190,10 +5412,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5252,7 +5475,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -5262,7 +5485,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -5307,10 +5530,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -5359,10 +5583,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -5400,10 +5625,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5438,10 +5664,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5476,10 +5703,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5514,10 +5742,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5552,10 +5781,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5590,10 +5820,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5665,7 +5896,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -5693,7 +5924,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -5706,7 +5937,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -5763,10 +5994,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5801,10 +6033,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -5832,7 +6065,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI16" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI16",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6035,7 +6274,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU16" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU16",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6143,7 +6388,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicU16" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicU16",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -6174,10 +6427,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicU16"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicU16",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -6214,10 +6468,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicU16"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicU16",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -6255,10 +6510,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6317,7 +6573,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -6327,7 +6583,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -6372,10 +6628,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -6424,10 +6681,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -6465,10 +6723,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6503,10 +6762,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6541,10 +6801,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6579,10 +6840,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6617,10 +6879,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6655,10 +6918,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6730,7 +6994,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -6758,7 +7022,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -6771,7 +7035,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -6828,10 +7092,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6866,10 +7131,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU16"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU16",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -6897,7 +7163,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU16" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU16",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7100,7 +7372,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI32" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI32",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7208,7 +7486,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicI32" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicI32",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -7239,10 +7525,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicI32"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicI32",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -7279,10 +7566,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicI32"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicI32",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -7320,10 +7608,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7382,7 +7671,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -7392,7 +7681,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -7437,10 +7726,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -7489,10 +7779,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -7530,10 +7821,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7568,10 +7860,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7606,10 +7899,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7644,10 +7938,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7682,10 +7977,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7720,10 +8016,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7795,7 +8092,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -7823,7 +8120,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -7836,7 +8133,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -7893,10 +8190,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7931,10 +8229,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -7962,7 +8261,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI32" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI32",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8165,7 +8470,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU32" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU32",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8273,7 +8584,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicU32" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicU32",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -8304,10 +8623,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicU32"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicU32",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -8344,10 +8664,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicU32"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicU32",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -8385,10 +8706,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8447,7 +8769,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -8457,7 +8779,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -8502,10 +8824,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -8554,10 +8877,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -8595,10 +8919,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8633,10 +8958,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8671,10 +8997,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8709,10 +9036,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8747,10 +9075,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8785,10 +9114,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8860,7 +9190,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -8888,7 +9218,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -8901,7 +9231,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -8958,10 +9288,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -8996,10 +9327,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU32"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU32",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9027,7 +9359,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU32" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU32",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -9230,7 +9568,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI64" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI64",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -9338,7 +9682,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicI64" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicI64",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -9369,10 +9721,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicI64"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicI64",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -9409,10 +9762,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicI64"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicI64",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -9450,10 +9804,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9512,7 +9867,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -9522,7 +9877,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -9567,10 +9922,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -9619,10 +9975,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -9660,10 +10017,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9698,10 +10056,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9736,10 +10095,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9774,10 +10134,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9812,10 +10173,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9850,10 +10212,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -9925,7 +10288,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -9953,7 +10316,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -9966,7 +10329,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -10023,10 +10386,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10061,10 +10425,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicI64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicI64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10092,7 +10457,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicI64" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicI64",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -10295,7 +10666,13 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU64" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU64",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -10403,7 +10780,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicU64" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicU64",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -10434,10 +10819,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicU64"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicU64",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -10474,10 +10860,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicU64"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicU64",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -10515,10 +10902,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10577,7 +10965,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -10587,7 +10975,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -10632,10 +11020,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -10684,10 +11073,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -10725,10 +11115,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10763,10 +11154,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10801,10 +11193,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10839,10 +11232,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10877,10 +11271,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10915,10 +11310,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -10990,7 +11386,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -11018,7 +11414,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -11031,7 +11427,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -11088,10 +11484,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11126,10 +11523,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicU64"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicU64",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11157,7 +11555,13 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicU64" "v" ]
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicU64",
+                  "v"
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -11360,7 +11764,12 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicIsize" "v"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicIsize",
+                  "v"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -11469,7 +11878,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicIsize" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicIsize",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -11500,10 +11917,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicIsize"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicIsize",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -11540,10 +11958,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicIsize"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicIsize",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -11581,10 +12000,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11643,7 +12063,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -11653,7 +12073,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -11701,10 +12121,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -11753,10 +12174,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -11794,10 +12216,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11832,10 +12255,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11870,10 +12294,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11908,10 +12333,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11946,10 +12372,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -11984,10 +12411,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12059,7 +12487,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -12087,7 +12515,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -12100,7 +12528,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -12157,10 +12585,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12195,10 +12624,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicIsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicIsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12226,7 +12656,12 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicIsize" "v"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicIsize",
+                  "v"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12430,7 +12865,12 @@ Module sync.
                 "get_mut",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicUsize" "v"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicUsize",
+                  "v"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -12539,7 +12979,15 @@ Module sync.
                 "into_inner",
                 []
               |),
-              [ M.read (| M.get_struct_record_field self "core::sync::atomic::AtomicUsize" "v" |) ]
+              [
+                M.read (|
+                  M.SubPointer.get_struct_record_field (|
+                    self,
+                    "core::sync::atomic::AtomicUsize",
+                    "v"
+                  |)
+                |)
+              ]
             |)))
         | _, _ => M.impossible
         end.
@@ -12570,10 +13018,11 @@ Module sync.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::sync::atomic::AtomicUsize"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::sync::atomic::AtomicUsize",
                         "v"
+                      |)
                     ]
                   |));
                 M.read (| order |)
@@ -12610,10 +13059,11 @@ Module sync.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::sync::atomic::AtomicUsize"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::sync::atomic::AtomicUsize",
                             "v"
+                          |)
                         ]
                       |);
                       M.read (| val |);
@@ -12651,10 +13101,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12713,7 +13164,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Ok",
                           0
@@ -12723,7 +13174,7 @@ Module sync.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -12771,10 +13222,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -12823,10 +13275,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| current |);
@@ -12864,10 +13317,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12902,10 +13356,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12940,10 +13395,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -12978,10 +13434,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -13016,10 +13473,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -13054,10 +13512,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -13129,7 +13588,7 @@ Module sync.
                                     |)
                                   |) in
                                 let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -13157,7 +13616,7 @@ Module sync.
                                       ltac:(M.monadic
                                         (let x := M.copy (| γ |) in
                                         let γ1_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Ok",
                                             0
@@ -13170,7 +13629,7 @@ Module sync.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::result::Result::Err",
                                             0
@@ -13227,10 +13686,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -13265,10 +13725,11 @@ Module sync.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::sync::atomic::AtomicUsize"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::sync::atomic::AtomicUsize",
                       "v"
+                    |)
                   ]
                 |);
                 M.read (| val |);
@@ -13296,7 +13757,12 @@ Module sync.
                 "get",
                 []
               |),
-              [ M.get_struct_record_field (M.read (| self |)) "core::sync::atomic::AtomicUsize" "v"
+              [
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::sync::atomic::AtomicUsize",
+                  "v"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -13859,8 +14325,8 @@ Module sync.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13872,8 +14338,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13885,8 +14351,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13898,8 +14364,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13911,8 +14377,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13924,8 +14390,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13937,8 +14403,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13950,8 +14416,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13963,8 +14429,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13976,8 +14442,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -13989,8 +14455,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14002,8 +14468,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14015,8 +14481,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14028,8 +14494,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14041,8 +14507,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14054,8 +14520,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.never_to_any (|
                           M.call_closure (|
@@ -14087,8 +14553,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.never_to_any (|
                           M.call_closure (|
@@ -14123,8 +14589,8 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let val := M.copy (| γ0_0 |) in
                     let ok := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -14200,8 +14666,8 @@ Module sync.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14213,8 +14679,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14226,8 +14692,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14239,8 +14705,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14252,8 +14718,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14265,8 +14731,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14278,8 +14744,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14291,8 +14757,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14304,8 +14770,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14317,8 +14783,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14330,8 +14796,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14343,8 +14809,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14356,8 +14822,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14369,8 +14835,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14382,8 +14848,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.call_closure (|
                           M.get_function (|
@@ -14395,8 +14861,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.never_to_any (|
                           M.call_closure (|
@@ -14428,8 +14894,8 @@ Module sync.
                       |)));
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       M.alloc (|
                         M.never_to_any (|
                           M.call_closure (|
@@ -14464,8 +14930,8 @@ Module sync.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let val := M.copy (| γ0_0 |) in
                     let ok := M.copy (| γ0_1 |) in
                     M.match_operator (|

--- a/CoqOfRust/core/sync/exclusive.v
+++ b/CoqOfRust/core/sync/exclusive.v
@@ -135,7 +135,13 @@ Module sync.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.read (| M.get_struct_record_field self "core::sync::exclusive::Exclusive" "inner" |)))
+            M.read (|
+              M.SubPointer.get_struct_record_field (|
+                self,
+                "core::sync::exclusive::Exclusive",
+                "inner"
+              |)
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -153,10 +159,11 @@ Module sync.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field
-              (M.read (| self |))
-              "core::sync::exclusive::Exclusive"
-              "inner"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::sync::exclusive::Exclusive",
+              "inner"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -184,8 +191,8 @@ Module sync.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.call_closure (|
+                M.SubPointer.get_struct_record_field (|
+                  M.call_closure (|
                     M.get_associated_function (|
                       Ty.apply
                         (Ty.path "core::pin::Pin")
@@ -198,9 +205,10 @@ Module sync.
                       []
                     |),
                     [ M.read (| self |) ]
-                  |))
-                  "core::sync::exclusive::Exclusive"
+                  |),
+                  "core::sync::exclusive::Exclusive",
                   "inner"
+                |)
               ]
             |)))
         | _, _ => M.impossible

--- a/CoqOfRust/core/task/poll.v
+++ b/CoqOfRust/core/task/poll.v
@@ -53,7 +53,7 @@ Module task.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -107,7 +107,7 @@ Module task.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -250,11 +250,11 @@ Module task.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::task::poll::Poll::Ready",
                                   0
@@ -262,7 +262,7 @@ Module task.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::task::poll::Poll::Ready",
                                   0
@@ -346,11 +346,11 @@ Module task.
                         [
                           fun γ =>
                             ltac:(M.monadic
-                              (let γ0_0 := M.get_tuple_field γ 0 in
-                              let γ0_1 := M.get_tuple_field γ 1 in
+                              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                               let γ0_0 := M.read (| γ0_0 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_0,
                                   "core::task::poll::Poll::Ready",
                                   0
@@ -358,7 +358,7 @@ Module task.
                               let __self_0 := M.alloc (| γ2_0 |) in
                               let γ0_1 := M.read (| γ0_1 |) in
                               let γ2_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ0_1,
                                   "core::task::poll::Poll::Ready",
                                   0
@@ -431,11 +431,11 @@ Module task.
                 [
                   fun γ =>
                     ltac:(M.monadic
-                      (let γ0_0 := M.get_tuple_field γ 0 in
-                      let γ0_1 := M.get_tuple_field γ 1 in
+                      (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                      let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                       let γ0_0 := M.read (| γ0_0 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::task::poll::Poll::Ready",
                           0
@@ -443,7 +443,7 @@ Module task.
                       let __self_0 := M.alloc (| γ2_0 |) in
                       let γ0_1 := M.read (| γ0_1 |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_1,
                           "core::task::poll::Poll::Ready",
                           0
@@ -532,7 +532,7 @@ Module task.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -588,7 +588,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -641,7 +641,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -718,13 +718,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Ok",
                           0
@@ -753,13 +753,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Err",
                           0
@@ -809,13 +809,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Ok",
                           0
@@ -829,13 +829,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Err",
                           0
@@ -912,19 +912,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Ok",
                           0
@@ -957,19 +957,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Err",
                           0
@@ -987,7 +987,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -1037,19 +1037,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Ok",
                           0
@@ -1067,19 +1067,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Err",
                           0
@@ -1112,7 +1112,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -1223,13 +1223,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Ok",
                           0
@@ -1243,13 +1243,13 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::result::Result::Err",
                           0
@@ -1314,7 +1314,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0
@@ -1468,19 +1468,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Ok",
                           0
@@ -1498,19 +1498,19 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
                         |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ0_0,
                           "core::option::Option::Some",
                           0
                         |) in
                       let γ2_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ1_0,
                           "core::result::Result::Err",
                           0
@@ -1524,7 +1524,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::task::poll::Poll::Ready",
                           0
@@ -1596,7 +1596,7 @@ Module task.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
+                        M.SubPointer.get_struct_tuple_field (|
                           γ,
                           "core::result::Result::Err",
                           0

--- a/CoqOfRust/core/task/wake.v
+++ b/CoqOfRust/core/task/wake.v
@@ -38,10 +38,18 @@ Module task.
             LogicalOp.and (|
               BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::task::wake::RawWaker" "data"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::task::wake::RawWaker",
+                    "data"
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field (M.read (| other |)) "core::task::wake::RawWaker" "data"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::task::wake::RawWaker",
+                    "data"
+                  |)
                 |)),
               ltac:(M.monadic
                 (M.call_closure (|
@@ -53,14 +61,16 @@ Module task.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::RawWaker"
-                      "vtable";
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::task::wake::RawWaker"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::RawWaker",
                       "vtable"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::task::wake::RawWaker",
+                      "vtable"
+                    |)
                   ]
                 |)))
             |)))
@@ -97,18 +107,20 @@ Module task.
                 M.read (| Value.String "data" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::task::wake::RawWaker"
-                    "data");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::task::wake::RawWaker",
+                    "data"
+                  |));
                 M.read (| Value.String "vtable" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::RawWaker"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::RawWaker",
                       "vtable"
+                    |)
                   |))
               ]
             |)))
@@ -156,7 +168,11 @@ Module task.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::task::wake::RawWaker" "data"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::task::wake::RawWaker",
+                "data"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -174,7 +190,11 @@ Module task.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::task::wake::RawWaker" "vtable"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::task::wake::RawWaker",
+                "vtable"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -225,60 +245,68 @@ Module task.
                 LogicalOp.and (|
                   BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::task::wake::RawWakerVTable"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::task::wake::RawWakerVTable",
                         "clone"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::task::wake::RawWakerVTable"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::task::wake::RawWakerVTable",
                         "clone"
+                      |)
                     |)),
                   ltac:(M.monadic
                     (BinOp.Pure.eq
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "core::task::wake::RawWakerVTable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| self |),
+                          "core::task::wake::RawWakerVTable",
                           "wake"
+                        |)
                       |))
                       (M.read (|
-                        M.get_struct_record_field
-                          (M.read (| other |))
-                          "core::task::wake::RawWakerVTable"
+                        M.SubPointer.get_struct_record_field (|
+                          M.read (| other |),
+                          "core::task::wake::RawWakerVTable",
                           "wake"
+                        |)
                       |))))
                 |),
                 ltac:(M.monadic
                   (BinOp.Pure.eq
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::task::wake::RawWakerVTable"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::task::wake::RawWakerVTable",
                         "wake_by_ref"
+                      |)
                     |))
                     (M.read (|
-                      M.get_struct_record_field
-                        (M.read (| other |))
-                        "core::task::wake::RawWakerVTable"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "core::task::wake::RawWakerVTable",
                         "wake_by_ref"
+                      |)
                     |))))
               |),
               ltac:(M.monadic
                 (BinOp.Pure.eq
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::RawWakerVTable"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::RawWakerVTable",
                       "drop"
+                    |)
                   |))
                   (M.read (|
-                    M.get_struct_record_field
-                      (M.read (| other |))
-                      "core::task::wake::RawWakerVTable"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::task::wake::RawWakerVTable",
                       "drop"
+                    |)
                   |))))
             |)))
         | _, _ => M.impossible
@@ -372,32 +400,36 @@ Module task.
                 M.read (| Value.String "clone" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::task::wake::RawWakerVTable"
-                    "clone");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::task::wake::RawWakerVTable",
+                    "clone"
+                  |));
                 M.read (| Value.String "wake" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::task::wake::RawWakerVTable"
-                    "wake");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::task::wake::RawWakerVTable",
+                    "wake"
+                  |));
                 M.read (| Value.String "wake_by_ref" |);
                 (* Unsize *)
                 M.pointer_coercion
-                  (M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::task::wake::RawWakerVTable"
-                    "wake_by_ref");
+                  (M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::task::wake::RawWakerVTable",
+                    "wake_by_ref"
+                  |));
                 M.read (| Value.String "drop" |);
                 (* Unsize *)
                 M.pointer_coercion
                   (M.alloc (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::RawWakerVTable"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::RawWakerVTable",
                       "drop"
+                    |)
                   |))
               ]
             |)))
@@ -505,7 +537,11 @@ Module task.
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
             M.read (|
-              M.get_struct_record_field (M.read (| self |)) "core::task::wake::Context" "waker"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::task::wake::Context",
+                "waker"
+              |)
             |)))
         | _, _ => M.impossible
         end.
@@ -554,10 +590,11 @@ Module task.
                     M.read (| Value.String "waker" |);
                     (* Unsize *)
                     M.pointer_coercion
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::task::wake::Context"
-                        "waker")
+                      (M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::task::wake::Context",
+                        "waker"
+                      |))
                   ]
                 |)
               ]
@@ -640,22 +677,33 @@ Module task.
             M.read (|
               let wake :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.read (|
-                      M.get_struct_record_field
-                        (M.get_struct_record_field self "core::task::wake::Waker" "waker")
-                        "core::task::wake::RawWaker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "core::task::wake::Waker",
+                          "waker"
+                        |),
+                        "core::task::wake::RawWaker",
                         "vtable"
-                    |))
-                    "core::task::wake::RawWakerVTable"
+                      |)
+                    |),
+                    "core::task::wake::RawWakerVTable",
                     "wake"
+                  |)
                 |) in
               let data :=
                 M.copy (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field self "core::task::wake::Waker" "waker")
-                    "core::task::wake::RawWaker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      self,
+                      "core::task::wake::Waker",
+                      "waker"
+                    |),
+                    "core::task::wake::RawWaker",
                     "data"
+                  |)
                 |) in
               let _ :=
                 M.alloc (|
@@ -689,28 +737,33 @@ Module task.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.read (|
-                M.get_struct_record_field
-                  (M.read (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::task::wake::Waker"
-                        "waker")
-                      "core::task::wake::RawWaker"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::task::wake::Waker",
+                        "waker"
+                      |),
+                      "core::task::wake::RawWaker",
                       "vtable"
-                  |))
-                  "core::task::wake::RawWakerVTable"
+                    |)
+                  |),
+                  "core::task::wake::RawWakerVTable",
                   "wake_by_ref"
+                |)
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::Waker"
-                      "waker")
-                    "core::task::wake::RawWaker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::Waker",
+                      "waker"
+                    |),
+                    "core::task::wake::RawWaker",
                     "data"
+                  |)
                 |)
               ]
             |)))
@@ -739,8 +792,16 @@ Module task.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "core::task::wake::Waker" "waker";
-                M.get_struct_record_field (M.read (| other |)) "core::task::wake::Waker" "waker"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::task::wake::Waker",
+                  "waker"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::task::wake::Waker",
+                  "waker"
+                |)
               ]
             |)))
         | _, _ => M.impossible
@@ -803,7 +864,11 @@ Module task.
         | [], [ self ] =>
           ltac:(M.monadic
             (let self := M.alloc (| self |) in
-            M.get_struct_record_field (M.read (| self |)) "core::task::wake::Waker" "waker"))
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::task::wake::Waker",
+              "waker"
+            |)))
         | _, _ => M.impossible
         end.
       
@@ -834,28 +899,33 @@ Module task.
                 ("waker",
                   M.call_closure (|
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (|
-                          M.get_struct_record_field
-                            (M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::task::wake::Waker"
-                              "waker")
-                            "core::task::wake::RawWaker"
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::task::wake::Waker",
+                              "waker"
+                            |),
+                            "core::task::wake::RawWaker",
                             "vtable"
-                        |))
-                        "core::task::wake::RawWakerVTable"
+                          |)
+                        |),
+                        "core::task::wake::RawWakerVTable",
                         "clone"
+                      |)
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::task::wake::Waker"
-                            "waker")
-                          "core::task::wake::RawWaker"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::task::wake::Waker",
+                            "waker"
+                          |),
+                          "core::task::wake::RawWaker",
                           "data"
+                        |)
                       |)
                     ]
                   |))
@@ -946,28 +1016,33 @@ Module task.
             (let self := M.alloc (| self |) in
             M.call_closure (|
               M.read (|
-                M.get_struct_record_field
-                  (M.read (|
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "core::task::wake::Waker"
-                        "waker")
-                      "core::task::wake::RawWaker"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "core::task::wake::Waker",
+                        "waker"
+                      |),
+                      "core::task::wake::RawWaker",
                       "vtable"
-                  |))
-                  "core::task::wake::RawWakerVTable"
+                    |)
+                  |),
+                  "core::task::wake::RawWakerVTable",
                   "drop"
+                |)
               |),
               [
                 M.read (|
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::task::wake::Waker"
-                      "waker")
-                    "core::task::wake::RawWaker"
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::task::wake::Waker",
+                      "waker"
+                    |),
+                    "core::task::wake::RawWaker",
                     "data"
+                  |)
                 |)
               ]
             |)))
@@ -1006,13 +1081,15 @@ Module task.
                   M.use
                     (M.alloc (|
                       M.read (|
-                        M.get_struct_record_field
-                          (M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::task::wake::Waker"
-                            "waker")
-                          "core::task::wake::RawWaker"
+                        M.SubPointer.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::task::wake::Waker",
+                            "waker"
+                          |),
+                          "core::task::wake::RawWaker",
                           "vtable"
+                        |)
                       |)
                     |))
                 |) in
@@ -1051,13 +1128,15 @@ Module task.
                             M.read (| Value.String "data" |);
                             (* Unsize *)
                             M.pointer_coercion
-                              (M.get_struct_record_field
-                                (M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "core::task::wake::Waker"
-                                  "waker")
-                                "core::task::wake::RawWaker"
-                                "data")
+                              (M.SubPointer.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "core::task::wake::Waker",
+                                  "waker"
+                                |),
+                                "core::task::wake::RawWaker",
+                                "data"
+                              |))
                           ]
                         |);
                         M.read (| Value.String "vtable" |);

--- a/CoqOfRust/core/time.v
+++ b/CoqOfRust/core/time.v
@@ -83,9 +83,19 @@ Module time.
           (let self := M.alloc (| self |) in
           let other := M.alloc (| other |) in
           BinOp.Pure.eq
-            (M.read (| M.get_struct_tuple_field (M.read (| self |)) "core::time::Nanoseconds" 0 |))
             (M.read (|
-              M.get_struct_tuple_field (M.read (| other |)) "core::time::Nanoseconds" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::time::Nanoseconds",
+                0
+              |)
+            |))
+            (M.read (|
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| other |),
+                "core::time::Nanoseconds",
+                0
+              |)
             |))))
       | _, _ => M.impossible
       end.
@@ -155,8 +165,16 @@ Module time.
               []
             |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::time::Nanoseconds" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "core::time::Nanoseconds" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::time::Nanoseconds",
+                0
+              |);
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| other |),
+                "core::time::Nanoseconds",
+                0
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -183,8 +201,16 @@ Module time.
           M.call_closure (|
             M.get_trait_method (| "core::cmp::Ord", Ty.path "u32", [], "cmp", [] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::time::Nanoseconds" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "core::time::Nanoseconds" 0
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::time::Nanoseconds",
+                0
+              |);
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| other |),
+                "core::time::Nanoseconds",
+                0
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -211,7 +237,11 @@ Module time.
           M.call_closure (|
             M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "core::time::Nanoseconds" 0;
+              M.SubPointer.get_struct_tuple_field (|
+                M.read (| self |),
+                "core::time::Nanoseconds",
+                0
+              |);
               M.read (| state |)
             ]
           |)))
@@ -326,10 +356,18 @@ Module time.
           LogicalOp.and (|
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "secs"
+                |)
               |))
               (M.read (|
-                M.get_struct_record_field (M.read (| other |)) "core::time::Duration" "secs"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "core::time::Duration",
+                  "secs"
+                |)
               |)),
             ltac:(M.monadic
               (M.call_closure (|
@@ -341,8 +379,16 @@ Module time.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos";
-                  M.get_struct_record_field (M.read (| other |)) "core::time::Duration" "nanos"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "nanos"
+                  |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "core::time::Duration",
+                    "nanos"
+                  |)
                 ]
               |)))
           |)))
@@ -424,8 +470,16 @@ Module time.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs";
-                    M.get_struct_record_field (M.read (| other |)) "core::time::Duration" "secs"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "secs"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::time::Duration",
+                      "secs"
+                    |)
                   ]
                 |)
               |),
@@ -433,7 +487,7 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -448,14 +502,16 @@ Module time.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::time::Duration"
-                            "nanos";
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::time::Duration"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::time::Duration",
                             "nanos"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::time::Duration",
+                            "nanos"
+                          |)
                         ]
                       |)
                     |)));
@@ -493,8 +549,16 @@ Module time.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", Ty.path "u64", [], "cmp", [] |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs";
-                    M.get_struct_record_field (M.read (| other |)) "core::time::Duration" "secs"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "secs"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "core::time::Duration",
+                      "secs"
+                    |)
                   ]
                 |)
               |),
@@ -511,14 +575,16 @@ Module time.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "core::time::Duration"
-                            "nanos";
-                          M.get_struct_record_field
-                            (M.read (| other |))
-                            "core::time::Duration"
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| self |),
+                            "core::time::Duration",
                             "nanos"
+                          |);
+                          M.SubPointer.get_struct_record_field (|
+                            M.read (| other |),
+                            "core::time::Duration",
+                            "nanos"
+                          |)
                         ]
                       |)
                     |)));
@@ -556,7 +622,11 @@ Module time.
                 M.call_closure (|
                   M.get_trait_method (| "core::hash::Hash", Ty.path "u64", [], "hash", [ __H ] |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs";
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "secs"
+                    |);
                     M.read (| state |)
                   ]
                 |)
@@ -571,7 +641,11 @@ Module time.
                   [ __H ]
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos";
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "nanos"
+                  |);
                   M.read (| state |)
                 ]
               |)
@@ -767,7 +841,7 @@ Module time.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -949,16 +1023,25 @@ Module time.
           LogicalOp.and (|
             BinOp.Pure.eq
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "secs"
+                |)
               |))
               (Value.Integer Integer.U64 0),
             ltac:(M.monadic
               (BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_tuple_field
-                    (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                    "core::time::Nanoseconds"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "nanos"
+                    |),
+                    "core::time::Nanoseconds",
                     0
+                  |)
                 |))
                 (Value.Integer Integer.U32 0)))
           |)))
@@ -977,7 +1060,13 @@ Module time.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs" |)))
+          M.read (|
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "core::time::Duration",
+              "secs"
+            |)
+          |)))
       | _, _ => M.impossible
       end.
     
@@ -995,10 +1084,15 @@ Module time.
           (let self := M.alloc (| self |) in
           BinOp.Panic.div (|
             M.read (|
-              M.get_struct_tuple_field
-                (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                "core::time::Nanoseconds"
+              M.SubPointer.get_struct_tuple_field (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "nanos"
+                |),
+                "core::time::Nanoseconds",
                 0
+              |)
             |),
             M.read (| M.get_constant (| "core::time::NANOS_PER_MILLI" |) |)
           |)))
@@ -1020,10 +1114,15 @@ Module time.
           (let self := M.alloc (| self |) in
           BinOp.Panic.div (|
             M.read (|
-              M.get_struct_tuple_field
-                (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                "core::time::Nanoseconds"
+              M.SubPointer.get_struct_tuple_field (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "nanos"
+                |),
+                "core::time::Nanoseconds",
                 0
+              |)
             |),
             M.read (| M.get_constant (| "core::time::NANOS_PER_MICRO" |) |)
           |)))
@@ -1044,10 +1143,15 @@ Module time.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_tuple_field
-              (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-              "core::time::Nanoseconds"
+            M.SubPointer.get_struct_tuple_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::time::Duration",
+                "nanos"
+              |),
+              "core::time::Nanoseconds",
               0
+            |)
           |)))
       | _, _ => M.impossible
       end.
@@ -1068,17 +1172,26 @@ Module time.
             BinOp.Panic.mul (|
               M.rust_cast
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "secs"
+                  |)
                 |)),
               M.rust_cast (M.read (| M.get_constant (| "core::time::MILLIS_PER_SEC" |) |))
             |),
             M.rust_cast
               (BinOp.Panic.div (|
                 M.read (|
-                  M.get_struct_tuple_field
-                    (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                    "core::time::Nanoseconds"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "nanos"
+                    |),
+                    "core::time::Nanoseconds",
                     0
+                  |)
                 |),
                 M.read (| M.get_constant (| "core::time::NANOS_PER_MILLI" |) |)
               |))
@@ -1102,17 +1215,26 @@ Module time.
             BinOp.Panic.mul (|
               M.rust_cast
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "secs"
+                  |)
                 |)),
               M.rust_cast (M.read (| M.get_constant (| "core::time::MICROS_PER_SEC" |) |))
             |),
             M.rust_cast
               (BinOp.Panic.div (|
                 M.read (|
-                  M.get_struct_tuple_field
-                    (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                    "core::time::Nanoseconds"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "nanos"
+                    |),
+                    "core::time::Nanoseconds",
                     0
+                  |)
                 |),
                 M.read (| M.get_constant (| "core::time::NANOS_PER_MICRO" |) |)
               |))
@@ -1136,16 +1258,25 @@ Module time.
             BinOp.Panic.mul (|
               M.rust_cast
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "secs"
+                  |)
                 |)),
               M.rust_cast (M.read (| M.get_constant (| "core::time::NANOS_PER_SEC" |) |))
             |),
             M.rust_cast
               (M.read (|
-                M.get_struct_tuple_field
-                  (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                  "core::time::Nanoseconds"
+                M.SubPointer.get_struct_tuple_field (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::Duration",
+                    "nanos"
+                  |),
+                  "core::time::Nanoseconds",
                   0
+                |)
               |))
           |)))
       | _, _ => M.impossible
@@ -1182,7 +1313,7 @@ Module time.
                         |)
                       |) in
                     let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1259,16 +1390,24 @@ Module time.
                               M.get_associated_function (| Ty.path "u64", "checked_add", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::time::Duration" "secs"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::time::Duration",
+                                    "secs"
+                                  |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field rhs "core::time::Duration" "secs"
+                                  M.SubPointer.get_struct_record_field (|
+                                    rhs,
+                                    "core::time::Duration",
+                                    "secs"
+                                  |)
                                 |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1278,16 +1417,26 @@ Module time.
                           M.alloc (|
                             BinOp.Panic.add (|
                               M.read (|
-                                M.get_struct_tuple_field
-                                  (M.get_struct_record_field self "core::time::Duration" "nanos")
-                                  "core::time::Nanoseconds"
+                                M.SubPointer.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::time::Duration",
+                                    "nanos"
+                                  |),
+                                  "core::time::Nanoseconds",
                                   0
+                                |)
                               |),
                               M.read (|
-                                M.get_struct_tuple_field
-                                  (M.get_struct_record_field rhs "core::time::Duration" "nanos")
-                                  "core::time::Nanoseconds"
+                                M.SubPointer.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_record_field (|
+                                    rhs,
+                                    "core::time::Duration",
+                                    "nanos"
+                                  |),
+                                  "core::time::Nanoseconds",
                                   0
+                                |)
                               |)
                             |)
                           |) in
@@ -1339,7 +1488,7 @@ Module time.
                                               |)
                                             |) in
                                           let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -1470,7 +1619,7 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1525,16 +1674,24 @@ Module time.
                               M.get_associated_function (| Ty.path "u64", "checked_sub", [] |),
                               [
                                 M.read (|
-                                  M.get_struct_record_field self "core::time::Duration" "secs"
+                                  M.SubPointer.get_struct_record_field (|
+                                    self,
+                                    "core::time::Duration",
+                                    "secs"
+                                  |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field rhs "core::time::Duration" "secs"
+                                  M.SubPointer.get_struct_record_field (|
+                                    rhs,
+                                    "core::time::Duration",
+                                    "secs"
+                                  |)
                                 |)
                               ]
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -1552,22 +1709,26 @@ Module time.
                                         (M.alloc (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_tuple_field
-                                                (M.get_struct_record_field
-                                                  self
-                                                  "core::time::Duration"
-                                                  "nanos")
-                                                "core::time::Nanoseconds"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  self,
+                                                  "core::time::Duration",
+                                                  "nanos"
+                                                |),
+                                                "core::time::Nanoseconds",
                                                 0
+                                              |)
                                             |))
                                             (M.read (|
-                                              M.get_struct_tuple_field
-                                                (M.get_struct_record_field
-                                                  rhs
-                                                  "core::time::Duration"
-                                                  "nanos")
-                                                "core::time::Nanoseconds"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  rhs,
+                                                  "core::time::Duration",
+                                                  "nanos"
+                                                |),
+                                                "core::time::Nanoseconds",
                                                 0
+                                              |)
                                             |))
                                         |)) in
                                     let _ :=
@@ -1578,22 +1739,26 @@ Module time.
                                     M.alloc (|
                                       BinOp.Panic.sub (|
                                         M.read (|
-                                          M.get_struct_tuple_field
-                                            (M.get_struct_record_field
-                                              self
-                                              "core::time::Duration"
-                                              "nanos")
-                                            "core::time::Nanoseconds"
+                                          M.SubPointer.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              self,
+                                              "core::time::Duration",
+                                              "nanos"
+                                            |),
+                                            "core::time::Nanoseconds",
                                             0
+                                          |)
                                         |),
                                         M.read (|
-                                          M.get_struct_tuple_field
-                                            (M.get_struct_record_field
-                                              rhs
-                                              "core::time::Duration"
-                                              "nanos")
-                                            "core::time::Nanoseconds"
+                                          M.SubPointer.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_record_field (|
+                                              rhs,
+                                              "core::time::Duration",
+                                              "nanos"
+                                            |),
+                                            "core::time::Nanoseconds",
                                             0
+                                          |)
                                         |)
                                       |)
                                     |)));
@@ -1616,7 +1781,7 @@ Module time.
                                                 |)
                                               |) in
                                             let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -1627,26 +1792,30 @@ Module time.
                                               BinOp.Panic.sub (|
                                                 BinOp.Panic.add (|
                                                   M.read (|
-                                                    M.get_struct_tuple_field
-                                                      (M.get_struct_record_field
-                                                        self
-                                                        "core::time::Duration"
-                                                        "nanos")
-                                                      "core::time::Nanoseconds"
+                                                    M.SubPointer.get_struct_tuple_field (|
+                                                      M.SubPointer.get_struct_record_field (|
+                                                        self,
+                                                        "core::time::Duration",
+                                                        "nanos"
+                                                      |),
+                                                      "core::time::Nanoseconds",
                                                       0
+                                                    |)
                                                   |),
                                                   M.read (|
                                                     M.get_constant (| "core::time::NANOS_PER_SEC" |)
                                                   |)
                                                 |),
                                                 M.read (|
-                                                  M.get_struct_tuple_field
-                                                    (M.get_struct_record_field
-                                                      rhs
-                                                      "core::time::Duration"
-                                                      "nanos")
-                                                    "core::time::Nanoseconds"
+                                                  M.SubPointer.get_struct_tuple_field (|
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      rhs,
+                                                      "core::time::Duration",
+                                                      "nanos"
+                                                    |),
+                                                    "core::time::Nanoseconds",
                                                     0
+                                                  |)
                                                 |)
                                               |)
                                             |)));
@@ -1775,7 +1944,7 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1821,10 +1990,15 @@ Module time.
                     BinOp.Panic.mul (|
                       M.rust_cast
                         (M.read (|
-                          M.get_struct_tuple_field
-                            (M.get_struct_record_field self "core::time::Duration" "nanos")
-                            "core::time::Nanoseconds"
+                          M.SubPointer.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "core::time::Duration",
+                              "nanos"
+                            |),
+                            "core::time::Nanoseconds",
                             0
+                          |)
                         |)),
                       M.rust_cast (M.read (| rhs |))
                     |)
@@ -1856,14 +2030,18 @@ Module time.
                                 M.get_associated_function (| Ty.path "u64", "checked_mul", [] |),
                                 [
                                   M.read (|
-                                    M.get_struct_record_field self "core::time::Duration" "secs"
+                                    M.SubPointer.get_struct_record_field (|
+                                      self,
+                                      "core::time::Duration",
+                                      "secs"
+                                    |)
                                   |);
                                   M.rust_cast (M.read (| rhs |))
                                 ]
                               |)
                             |) in
                           let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::option::Option::Some",
                               0
@@ -1886,7 +2064,7 @@ Module time.
                                       |)
                                     |) in
                                   let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -2013,7 +2191,7 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2068,13 +2246,21 @@ Module time.
                           [
                             BinOp.Panic.div (|
                               M.read (|
-                                M.get_struct_record_field self "core::time::Duration" "secs"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::time::Duration",
+                                  "secs"
+                                |)
                               |),
                               M.rust_cast (M.read (| rhs |))
                             |);
                             BinOp.Panic.rem (|
                               M.read (|
-                                M.get_struct_record_field self "core::time::Duration" "secs"
+                                M.SubPointer.get_struct_record_field (|
+                                  self,
+                                  "core::time::Duration",
+                                  "secs"
+                                |)
                               |),
                               M.rust_cast (M.read (| rhs |))
                             |)
@@ -2083,8 +2269,8 @@ Module time.
                       [
                         fun γ =>
                           ltac:(M.monadic
-                            (let γ0_0 := M.get_tuple_field γ 0 in
-                            let γ0_1 := M.get_tuple_field γ 1 in
+                            (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                            let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                             let secs := M.copy (| γ0_0 |) in
                             let extra_secs := M.copy (| γ0_1 |) in
                             M.match_operator (|
@@ -2093,25 +2279,29 @@ Module time.
                                   [
                                     BinOp.Panic.div (|
                                       M.read (|
-                                        M.get_struct_tuple_field
-                                          (M.get_struct_record_field
-                                            self
-                                            "core::time::Duration"
-                                            "nanos")
-                                          "core::time::Nanoseconds"
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::time::Duration",
+                                            "nanos"
+                                          |),
+                                          "core::time::Nanoseconds",
                                           0
+                                        |)
                                       |),
                                       M.read (| rhs |)
                                     |);
                                     BinOp.Panic.rem (|
                                       M.read (|
-                                        M.get_struct_tuple_field
-                                          (M.get_struct_record_field
-                                            self
-                                            "core::time::Duration"
-                                            "nanos")
-                                          "core::time::Nanoseconds"
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            self,
+                                            "core::time::Duration",
+                                            "nanos"
+                                          |),
+                                          "core::time::Nanoseconds",
                                           0
+                                        |)
                                       |),
                                       M.read (| rhs |)
                                     |)
@@ -2120,8 +2310,8 @@ Module time.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let nanos := M.copy (| γ0_0 |) in
                                     let extra_nanos := M.copy (| γ0_1 |) in
                                     let _ :=
@@ -2249,15 +2439,24 @@ Module time.
           BinOp.Panic.add (|
             M.rust_cast
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "secs"
+                |)
               |)),
             BinOp.Panic.div (|
               M.rust_cast
                 (M.read (|
-                  M.get_struct_tuple_field
-                    (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                    "core::time::Nanoseconds"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "nanos"
+                    |),
+                    "core::time::Nanoseconds",
                     0
+                  |)
                 |)),
               M.rust_cast (M.read (| M.get_constant (| "core::time::NANOS_PER_SEC" |) |))
             |)
@@ -2280,15 +2479,24 @@ Module time.
           BinOp.Panic.add (|
             M.rust_cast
               (M.read (|
-                M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "secs"
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "core::time::Duration",
+                  "secs"
+                |)
               |)),
             BinOp.Panic.div (|
               M.rust_cast
                 (M.read (|
-                  M.get_struct_tuple_field
-                    (M.get_struct_record_field (M.read (| self |)) "core::time::Duration" "nanos")
-                    "core::time::Nanoseconds"
+                  M.SubPointer.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::Duration",
+                      "nanos"
+                    |),
+                    "core::time::Nanoseconds",
                     0
+                  |)
                 |)),
               M.rust_cast (M.read (| M.get_constant (| "core::time::NANOS_PER_SEC" |) |))
             |)
@@ -2327,21 +2535,13 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let v := M.copy (| γ0_0 |) in
                     v));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -2404,21 +2604,13 @@ Module time.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let v := M.copy (| γ0_0 |) in
                     v));
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -3198,8 +3390,8 @@ Module time.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let secs := M.copy (| γ0_0 |) in
                         let nanos := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -3807,8 +3999,8 @@ Module time.
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_tuple_field γ 0 in
-                        let γ0_1 := M.get_tuple_field γ 1 in
+                        (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                        let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                         let secs := M.copy (| γ0_0 |) in
                         let nanos := M.copy (| γ0_1 |) in
                         M.alloc (|
@@ -4270,7 +4462,7 @@ Module time.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -4297,10 +4489,11 @@ Module time.
                                                 [
                                                   M.read (| total_secs |);
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      entry
-                                                      "core::time::Duration"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      entry,
+                                                      "core::time::Duration",
                                                       "secs"
+                                                    |)
                                                   |)
                                                 ]
                                               |);
@@ -4326,13 +4519,15 @@ Module time.
                                                     M.read (| total_nanos |);
                                                     M.rust_cast
                                                       (M.read (|
-                                                        M.get_struct_tuple_field
-                                                          (M.get_struct_record_field
-                                                            entry
-                                                            "core::time::Duration"
-                                                            "nanos")
-                                                          "core::time::Nanoseconds"
+                                                        M.SubPointer.get_struct_tuple_field (|
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            entry,
+                                                            "core::time::Duration",
+                                                            "nanos"
+                                                          |),
+                                                          "core::time::Nanoseconds",
                                                           0
+                                                        |)
                                                       |))
                                                   ]
                                                 |)
@@ -4341,7 +4536,7 @@ Module time.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -4401,13 +4596,15 @@ Module time.
                                                         |),
                                                         M.rust_cast
                                                           (M.read (|
-                                                            M.get_struct_tuple_field
-                                                              (M.get_struct_record_field
-                                                                entry
-                                                                "core::time::Duration"
-                                                                "nanos")
-                                                              "core::time::Nanoseconds"
+                                                            M.SubPointer.get_struct_tuple_field (|
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                entry,
+                                                                "core::time::Duration",
+                                                                "nanos"
+                                                              |),
+                                                              "core::time::Nanoseconds",
                                                               0
+                                                            |)
                                                           |))
                                                       |)
                                                     |)))
@@ -4533,7 +4730,7 @@ Module time.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
@@ -4560,10 +4757,11 @@ Module time.
                                                 [
                                                   M.read (| total_secs |);
                                                   M.read (|
-                                                    M.get_struct_record_field
-                                                      (M.read (| entry |))
-                                                      "core::time::Duration"
+                                                    M.SubPointer.get_struct_record_field (|
+                                                      M.read (| entry |),
+                                                      "core::time::Duration",
                                                       "secs"
+                                                    |)
                                                   |)
                                                 ]
                                               |);
@@ -4589,13 +4787,15 @@ Module time.
                                                     M.read (| total_nanos |);
                                                     M.rust_cast
                                                       (M.read (|
-                                                        M.get_struct_tuple_field
-                                                          (M.get_struct_record_field
-                                                            (M.read (| entry |))
-                                                            "core::time::Duration"
-                                                            "nanos")
-                                                          "core::time::Nanoseconds"
+                                                        M.SubPointer.get_struct_tuple_field (|
+                                                          M.SubPointer.get_struct_record_field (|
+                                                            M.read (| entry |),
+                                                            "core::time::Duration",
+                                                            "nanos"
+                                                          |),
+                                                          "core::time::Nanoseconds",
                                                           0
+                                                        |)
                                                       |))
                                                   ]
                                                 |)
@@ -4604,7 +4804,7 @@ Module time.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -4664,13 +4864,15 @@ Module time.
                                                         |),
                                                         M.rust_cast
                                                           (M.read (|
-                                                            M.get_struct_tuple_field
-                                                              (M.get_struct_record_field
-                                                                (M.read (| entry |))
-                                                                "core::time::Duration"
-                                                                "nanos")
-                                                              "core::time::Nanoseconds"
+                                                            M.SubPointer.get_struct_tuple_field (|
+                                                              M.SubPointer.get_struct_record_field (|
+                                                                M.read (| entry |),
+                                                                "core::time::Duration",
+                                                                "nanos"
+                                                              |),
+                                                              "core::time::Nanoseconds",
                                                               0
+                                                            |)
                                                           |))
                                                       |)
                                                     |)))
@@ -4972,10 +5174,11 @@ Module time.
                         (M.alloc (|
                           BinOp.Pure.gt
                             (M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::time::Duration"
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::time::Duration",
                                 "secs"
+                              |)
                             |))
                             (Value.Integer Integer.U64 0)
                         |)) in
@@ -4986,19 +5189,22 @@ Module time.
                         [
                           M.read (| f |);
                           M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "core::time::Duration"
+                            M.SubPointer.get_struct_record_field (|
+                              M.read (| self |),
+                              "core::time::Duration",
                               "secs"
+                            |)
                           |);
                           M.read (|
-                            M.get_struct_tuple_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "core::time::Duration"
-                                "nanos")
-                              "core::time::Nanoseconds"
+                            M.SubPointer.get_struct_tuple_field (|
+                              M.SubPointer.get_struct_record_field (|
+                                M.read (| self |),
+                                "core::time::Duration",
+                                "nanos"
+                              |),
+                              "core::time::Nanoseconds",
                               0
+                            |)
                           |);
                           BinOp.Panic.div (|
                             M.read (| M.get_constant (| "core::time::NANOS_PER_SEC" |) |),
@@ -5021,13 +5227,15 @@ Module time.
                                 (M.alloc (|
                                   BinOp.Pure.ge
                                     (M.read (|
-                                      M.get_struct_tuple_field
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::time::Duration"
-                                          "nanos")
-                                        "core::time::Nanoseconds"
+                                      M.SubPointer.get_struct_tuple_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::time::Duration",
+                                          "nanos"
+                                        |),
+                                        "core::time::Nanoseconds",
                                         0
+                                      |)
                                     |))
                                     (M.read (|
                                       M.get_constant (| "core::time::NANOS_PER_MILLI" |)
@@ -5043,13 +5251,15 @@ Module time.
                                   M.rust_cast
                                     (BinOp.Panic.div (|
                                       M.read (|
-                                        M.get_struct_tuple_field
-                                          (M.get_struct_record_field
-                                            (M.read (| self |))
-                                            "core::time::Duration"
-                                            "nanos")
-                                          "core::time::Nanoseconds"
+                                        M.SubPointer.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.read (| self |),
+                                            "core::time::Duration",
+                                            "nanos"
+                                          |),
+                                          "core::time::Nanoseconds",
                                           0
+                                        |)
                                       |),
                                       M.read (|
                                         M.get_constant (| "core::time::NANOS_PER_MILLI" |)
@@ -5057,13 +5267,15 @@ Module time.
                                     |));
                                   BinOp.Panic.rem (|
                                     M.read (|
-                                      M.get_struct_tuple_field
-                                        (M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "core::time::Duration"
-                                          "nanos")
-                                        "core::time::Nanoseconds"
+                                      M.SubPointer.get_struct_tuple_field (|
+                                        M.SubPointer.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "core::time::Duration",
+                                          "nanos"
+                                        |),
+                                        "core::time::Nanoseconds",
                                         0
+                                      |)
                                     |),
                                     M.read (| M.get_constant (| "core::time::NANOS_PER_MILLI" |) |)
                                   |);
@@ -5088,13 +5300,15 @@ Module time.
                                         (M.alloc (|
                                           BinOp.Pure.ge
                                             (M.read (|
-                                              M.get_struct_tuple_field
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::time::Duration"
-                                                  "nanos")
-                                                "core::time::Nanoseconds"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::time::Duration",
+                                                  "nanos"
+                                                |),
+                                                "core::time::Nanoseconds",
                                                 0
+                                              |)
                                             |))
                                             (M.read (|
                                               M.get_constant (| "core::time::NANOS_PER_MICRO" |)
@@ -5113,13 +5327,15 @@ Module time.
                                           M.rust_cast
                                             (BinOp.Panic.div (|
                                               M.read (|
-                                                M.get_struct_tuple_field
-                                                  (M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "core::time::Duration"
-                                                    "nanos")
-                                                  "core::time::Nanoseconds"
+                                                M.SubPointer.get_struct_tuple_field (|
+                                                  M.SubPointer.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "core::time::Duration",
+                                                    "nanos"
+                                                  |),
+                                                  "core::time::Nanoseconds",
                                                   0
+                                                |)
                                               |),
                                               M.read (|
                                                 M.get_constant (| "core::time::NANOS_PER_MICRO" |)
@@ -5127,13 +5343,15 @@ Module time.
                                             |));
                                           BinOp.Panic.rem (|
                                             M.read (|
-                                              M.get_struct_tuple_field
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::time::Duration"
-                                                  "nanos")
-                                                "core::time::Nanoseconds"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::time::Duration",
+                                                  "nanos"
+                                                |),
+                                                "core::time::Nanoseconds",
                                                 0
+                                              |)
                                             |),
                                             M.read (|
                                               M.get_constant (| "core::time::NANOS_PER_MICRO" |)
@@ -5159,13 +5377,15 @@ Module time.
                                           M.read (| f |);
                                           M.rust_cast
                                             (M.read (|
-                                              M.get_struct_tuple_field
-                                                (M.get_struct_record_field
-                                                  (M.read (| self |))
-                                                  "core::time::Duration"
-                                                  "nanos")
-                                                "core::time::Nanoseconds"
+                                              M.SubPointer.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_record_field (|
+                                                  M.read (| self |),
+                                                  "core::time::Duration",
+                                                  "nanos"
+                                                |),
+                                                "core::time::Nanoseconds",
                                                 0
+                                              |)
                                             |));
                                           Value.Integer Integer.U32 0;
                                           Value.Integer Integer.U32 1;
@@ -5222,10 +5442,11 @@ Module time.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "core::time::TryFromFloatSecsError"
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "core::time::TryFromFloatSecsError",
                     "kind"
+                  |)
                 |))
             ]
           |)))
@@ -5262,10 +5483,11 @@ Module time.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "core::time::TryFromFloatSecsError"
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "core::time::TryFromFloatSecsError",
                       "kind"
+                    |)
                   ]
                 |))
             ]))
@@ -5310,14 +5532,16 @@ Module time.
               []
             |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::time::TryFromFloatSecsError"
-                "kind";
-              M.get_struct_record_field
-                (M.read (| other |))
-                "core::time::TryFromFloatSecsError"
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::time::TryFromFloatSecsError",
                 "kind"
+              |);
+              M.SubPointer.get_struct_record_field (|
+                M.read (| other |),
+                "core::time::TryFromFloatSecsError",
+                "kind"
+              |)
             ]
           |)))
       | _, _ => M.impossible
@@ -5391,10 +5615,11 @@ Module time.
           (let self := M.alloc (| self |) in
           M.read (|
             M.match_operator (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "core::time::TryFromFloatSecsError"
-                "kind",
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "core::time::TryFromFloatSecsError",
+                "kind"
+              |),
               [
                 fun γ =>
                   ltac:(M.monadic

--- a/CoqOfRust/core/tuple.v
+++ b/CoqOfRust/core/tuple.v
@@ -29,7 +29,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -60,7 +60,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -79,7 +82,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -154,7 +160,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "partial_cmp", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -173,7 +182,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -192,7 +204,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "le", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -211,7 +226,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "ge", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -230,7 +248,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "gt", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -268,7 +289,10 @@ Module tuple.
           let other := M.alloc (| other |) in
           M.call_closure (|
             M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
-            [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+            [
+              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+            ]
           |)))
       | _, _ => M.impossible
       end.
@@ -341,7 +365,7 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
                     let value_T := M.copy (| γ0_0 |) in
                     M.alloc (| Value.Tuple [ M.read (| value_T |) ] |)))
               ]
@@ -380,7 +404,7 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
                     let value_T := M.copy (| γ0_0 |) in
                     M.alloc (| Value.Array [ M.read (| value_T |) ] |)))
               ]
@@ -416,12 +440,17 @@ Module tuple.
           LogicalOp.and (|
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
-              [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+              [
+                M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+              ]
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 1; M.get_tuple_field (M.read (| other |)) 1
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                 ]
               |)))
           |)))
@@ -443,12 +472,17 @@ Module tuple.
           LogicalOp.or (|
             M.call_closure (|
               M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
-              [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0 ]
+              [
+                M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
+              ]
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 1; M.get_tuple_field (M.read (| other |)) 1
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                 ]
               |)))
           |)))
@@ -534,8 +568,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", U, [ U ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -543,7 +577,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -558,8 +592,8 @@ Module tuple.
                           []
                         |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)));
@@ -591,8 +625,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", U, [ U ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -623,8 +657,8 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "lt", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)))
@@ -652,8 +686,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", U, [ U ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -684,8 +718,8 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "le", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)))
@@ -713,8 +747,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", U, [ U ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -745,8 +779,8 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "ge", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)))
@@ -774,8 +808,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", U, [ U ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -806,8 +840,8 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialOrd", T, [ T ], "gt", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)))
@@ -854,8 +888,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", U, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -866,8 +900,8 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)
                     |)));
@@ -959,8 +993,8 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
                     let value_U := M.copy (| γ0_0 |) in
                     let value_T := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Tuple [ M.read (| value_U |); M.read (| value_T |) ] |)))
@@ -1000,8 +1034,8 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let value_U := M.copy (| γ0_0 |) in
                     let value_T := M.copy (| γ0_1 |) in
                     M.alloc (| Value.Array [ M.read (| value_U |); M.read (| value_T |) ] |)))
@@ -1039,22 +1073,26 @@ Module tuple.
             LogicalOp.and (|
               M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                 ]
               |),
               ltac:(M.monadic
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 1;
-                    M.get_tuple_field (M.read (| other |)) 1
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 2; M.get_tuple_field (M.read (| other |)) 2
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                 ]
               |)))
           |)))
@@ -1077,22 +1115,26 @@ Module tuple.
             LogicalOp.or (|
               M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 0; M.get_tuple_field (M.read (| other |)) 0
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                 ]
               |),
               ltac:(M.monadic
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 1;
-                    M.get_tuple_field (M.read (| other |)) 1
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 2; M.get_tuple_field (M.read (| other |)) 2
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                 ]
               |)))
           |)))
@@ -1178,8 +1220,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", V, [ V ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -1187,7 +1229,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -1203,8 +1245,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -1212,7 +1254,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -1227,8 +1269,8 @@ Module tuple.
                                   []
                                 |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)));
@@ -1266,8 +1308,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", V, [ V ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -1305,8 +1347,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -1347,8 +1389,8 @@ Module tuple.
                                   []
                                 |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)))
@@ -1378,8 +1420,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", V, [ V ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -1417,8 +1459,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -1459,8 +1501,8 @@ Module tuple.
                                   []
                                 |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)))
@@ -1490,8 +1532,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", V, [ V ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -1529,8 +1571,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -1574,8 +1616,8 @@ Module tuple.
                                   []
                                 |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)))
@@ -1605,8 +1647,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", V, [ V ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -1644,8 +1686,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -1689,8 +1731,8 @@ Module tuple.
                                   []
                                 |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)))
@@ -1739,8 +1781,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", V, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -1752,8 +1794,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", U, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -1764,8 +1806,8 @@ Module tuple.
                               M.call_closure (|
                                 M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)
                             |)));
@@ -1873,9 +1915,9 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                     let value_V := M.copy (| γ0_0 |) in
                     let value_U := M.copy (| γ0_1 |) in
                     let value_T := M.copy (| γ0_2 |) in
@@ -1919,9 +1961,9 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                     let value_V := M.copy (| γ0_0 |) in
                     let value_U := M.copy (| γ0_1 |) in
                     let value_T := M.copy (| γ0_2 |) in
@@ -1965,16 +2007,16 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |),
                 ltac:(M.monadic
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 1;
-                      M.get_tuple_field (M.read (| other |)) 1
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                     ]
                   |)))
               |),
@@ -1982,15 +2024,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 2;
-                    M.get_tuple_field (M.read (| other |)) 2
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 3; M.get_tuple_field (M.read (| other |)) 3
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                 ]
               |)))
           |)))
@@ -2015,16 +2059,16 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |),
                 ltac:(M.monadic
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 1;
-                      M.get_tuple_field (M.read (| other |)) 1
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                     ]
                   |)))
               |),
@@ -2032,15 +2076,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 2;
-                    M.get_tuple_field (M.read (| other |)) 2
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 3; M.get_tuple_field (M.read (| other |)) 3
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                 ]
               |)))
           |)))
@@ -2126,8 +2172,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", W, [ W ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -2135,7 +2181,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -2151,8 +2197,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -2160,7 +2206,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -2176,8 +2222,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -2185,7 +2231,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -2200,8 +2246,8 @@ Module tuple.
                                           []
                                         |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)));
@@ -2245,8 +2291,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", W, [ W ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -2284,8 +2330,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -2327,8 +2373,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -2378,8 +2424,8 @@ Module tuple.
                                           []
                                         |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)))
@@ -2411,8 +2457,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", W, [ W ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -2450,8 +2496,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -2493,8 +2539,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -2544,8 +2590,8 @@ Module tuple.
                                           []
                                         |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)))
@@ -2577,8 +2623,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", W, [ W ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -2616,8 +2662,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -2662,8 +2708,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -2713,8 +2759,8 @@ Module tuple.
                                           []
                                         |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)))
@@ -2746,8 +2792,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", W, [ W ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -2785,8 +2831,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -2831,8 +2877,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -2882,8 +2928,8 @@ Module tuple.
                                           []
                                         |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)))
@@ -2934,8 +2980,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", W, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -2947,8 +2993,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", V, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -2960,8 +3006,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", U, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -2972,8 +3018,8 @@ Module tuple.
                                       M.call_closure (|
                                         M.get_trait_method (| "core::cmp::Ord", T, [], "cmp", [] |),
                                         [
-                                          M.get_tuple_field (M.read (| self |)) 3;
-                                          M.get_tuple_field (M.read (| other |)) 3
+                                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                         ]
                                       |)
                                     |)));
@@ -3097,10 +3143,10 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
                     let value_W := M.copy (| γ0_0 |) in
                     let value_V := M.copy (| γ0_1 |) in
                     let value_U := M.copy (| γ0_2 |) in
@@ -3150,10 +3196,10 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                     let value_W := M.copy (| γ0_0 |) in
                     let value_V := M.copy (| γ0_1 |) in
                     let value_U := M.copy (| γ0_2 |) in
@@ -3204,16 +3250,16 @@ Module tuple.
                   M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 0;
-                      M.get_tuple_field (M.read (| other |)) 0
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                     ]
                   |),
                   ltac:(M.monadic
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 1;
-                        M.get_tuple_field (M.read (| other |)) 1
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                       ]
                     |)))
                 |),
@@ -3221,8 +3267,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 2;
-                      M.get_tuple_field (M.read (| other |)) 2
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                     ]
                   |)))
               |),
@@ -3230,15 +3276,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 3;
-                    M.get_tuple_field (M.read (| other |)) 3
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 4; M.get_tuple_field (M.read (| other |)) 4
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                 ]
               |)))
           |)))
@@ -3264,16 +3312,16 @@ Module tuple.
                   M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 0;
-                      M.get_tuple_field (M.read (| other |)) 0
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                     ]
                   |),
                   ltac:(M.monadic
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 1;
-                        M.get_tuple_field (M.read (| other |)) 1
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                       ]
                     |)))
                 |),
@@ -3281,8 +3329,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 2;
-                      M.get_tuple_field (M.read (| other |)) 2
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                     ]
                   |)))
               |),
@@ -3290,15 +3338,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 3;
-                    M.get_tuple_field (M.read (| other |)) 3
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 4; M.get_tuple_field (M.read (| other |)) 4
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                 ]
               |)))
           |)))
@@ -3385,8 +3435,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", X, [ X ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -3394,7 +3444,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -3410,8 +3460,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -3419,7 +3469,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -3435,8 +3485,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -3444,7 +3494,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -3460,8 +3510,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -3469,7 +3519,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -3484,8 +3534,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)));
@@ -3535,8 +3591,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", X, [ X ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -3574,8 +3630,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -3617,8 +3673,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -3669,8 +3725,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -3725,8 +3781,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)))
@@ -3760,8 +3822,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", X, [ X ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -3799,8 +3861,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -3842,8 +3904,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -3894,8 +3956,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -3950,8 +4012,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)))
@@ -3985,8 +4053,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", X, [ X ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -4024,8 +4092,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -4070,8 +4138,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -4122,8 +4190,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -4180,8 +4248,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)))
@@ -4215,8 +4289,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", X, [ X ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -4254,8 +4328,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -4300,8 +4374,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -4352,8 +4426,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -4410,8 +4484,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)))
@@ -4464,8 +4544,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", X, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -4477,8 +4557,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", W, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -4490,8 +4570,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", V, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -4509,8 +4589,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -4527,8 +4607,14 @@ Module tuple.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_tuple_field (M.read (| self |)) 4;
-                                                  M.get_tuple_field (M.read (| other |)) 4
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| self |),
+                                                    4
+                                                  |);
+                                                  M.SubPointer.get_tuple_field (|
+                                                    M.read (| other |),
+                                                    4
+                                                  |)
                                                 ]
                                               |)
                                             |)));
@@ -4668,11 +4754,11 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
                     let value_X := M.copy (| γ0_0 |) in
                     let value_W := M.copy (| γ0_1 |) in
                     let value_V := M.copy (| γ0_2 |) in
@@ -4724,11 +4810,11 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
                     let value_X := M.copy (| γ0_0 |) in
                     let value_W := M.copy (| γ0_1 |) in
                     let value_V := M.copy (| γ0_2 |) in
@@ -4782,16 +4868,16 @@ Module tuple.
                     M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 0;
-                        M.get_tuple_field (M.read (| other |)) 0
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                       ]
                     |),
                     ltac:(M.monadic
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)))
                   |),
@@ -4799,8 +4885,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 2;
-                        M.get_tuple_field (M.read (| other |)) 2
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                       ]
                     |)))
                 |),
@@ -4808,8 +4894,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 3;
-                      M.get_tuple_field (M.read (| other |)) 3
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                     ]
                   |)))
               |),
@@ -4817,15 +4903,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 4;
-                    M.get_tuple_field (M.read (| other |)) 4
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 5; M.get_tuple_field (M.read (| other |)) 5
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                 ]
               |)))
           |)))
@@ -4852,16 +4940,16 @@ Module tuple.
                     M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 0;
-                        M.get_tuple_field (M.read (| other |)) 0
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                       ]
                     |),
                     ltac:(M.monadic
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 1;
-                          M.get_tuple_field (M.read (| other |)) 1
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                         ]
                       |)))
                   |),
@@ -4869,8 +4957,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 2;
-                        M.get_tuple_field (M.read (| other |)) 2
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                       ]
                     |)))
                 |),
@@ -4878,8 +4966,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 3;
-                      M.get_tuple_field (M.read (| other |)) 3
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                     ]
                   |)))
               |),
@@ -4887,15 +4975,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 4;
-                    M.get_tuple_field (M.read (| other |)) 4
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 5; M.get_tuple_field (M.read (| other |)) 5
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                 ]
               |)))
           |)))
@@ -4984,8 +5074,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Y, [ Y ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -4993,7 +5083,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -5009,8 +5099,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -5018,7 +5108,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -5034,8 +5124,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -5043,7 +5133,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -5059,8 +5149,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -5068,7 +5158,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -5084,8 +5174,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -5093,7 +5189,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -5108,8 +5204,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)));
@@ -5165,8 +5267,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Y, [ Y ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -5204,8 +5306,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -5247,8 +5349,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -5299,8 +5401,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -5356,8 +5458,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -5414,8 +5522,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)))
@@ -5451,8 +5565,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Y, [ Y ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -5490,8 +5604,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -5533,8 +5647,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -5585,8 +5699,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -5642,8 +5756,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -5700,8 +5820,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)))
@@ -5737,8 +5863,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Y, [ Y ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -5776,8 +5902,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -5822,8 +5948,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -5874,8 +6000,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -5933,8 +6059,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -5991,8 +6123,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)))
@@ -6028,8 +6166,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Y, [ Y ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -6067,8 +6205,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -6113,8 +6251,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -6165,8 +6303,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -6224,8 +6362,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -6282,8 +6426,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)))
@@ -6338,8 +6488,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", Y, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -6351,8 +6501,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", X, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -6364,8 +6514,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", W, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -6383,8 +6533,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -6402,8 +6552,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -6420,8 +6576,14 @@ Module tuple.
                                                           []
                                                         |),
                                                         [
-                                                          M.get_tuple_field (M.read (| self |)) 5;
-                                                          M.get_tuple_field (M.read (| other |)) 5
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| self |),
+                                                            5
+                                                          |);
+                                                          M.SubPointer.get_tuple_field (|
+                                                            M.read (| other |),
+                                                            5
+                                                          |)
                                                         ]
                                                       |)
                                                     |)));
@@ -6577,12 +6739,12 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
                     let value_Y := M.copy (| γ0_0 |) in
                     let value_X := M.copy (| γ0_1 |) in
                     let value_W := M.copy (| γ0_2 |) in
@@ -6636,12 +6798,12 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
                     let value_Y := M.copy (| γ0_0 |) in
                     let value_X := M.copy (| γ0_1 |) in
                     let value_W := M.copy (| γ0_2 |) in
@@ -6698,16 +6860,16 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 0;
-                          M.get_tuple_field (M.read (| other |)) 0
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                         ]
                       |),
                       ltac:(M.monadic
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)))
                     |),
@@ -6715,8 +6877,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 2;
-                          M.get_tuple_field (M.read (| other |)) 2
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                         ]
                       |)))
                   |),
@@ -6724,8 +6886,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 3;
-                        M.get_tuple_field (M.read (| other |)) 3
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                       ]
                     |)))
                 |),
@@ -6733,8 +6895,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 4;
-                      M.get_tuple_field (M.read (| other |)) 4
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                     ]
                   |)))
               |),
@@ -6742,15 +6904,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 5;
-                    M.get_tuple_field (M.read (| other |)) 5
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 6; M.get_tuple_field (M.read (| other |)) 6
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                 ]
               |)))
           |)))
@@ -6778,16 +6942,16 @@ Module tuple.
                       M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 0;
-                          M.get_tuple_field (M.read (| other |)) 0
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                         ]
                       |),
                       ltac:(M.monadic
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)))
                     |),
@@ -6795,8 +6959,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 2;
-                          M.get_tuple_field (M.read (| other |)) 2
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                         ]
                       |)))
                   |),
@@ -6804,8 +6968,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 3;
-                        M.get_tuple_field (M.read (| other |)) 3
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                       ]
                     |)))
                 |),
@@ -6813,8 +6977,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 4;
-                      M.get_tuple_field (M.read (| other |)) 4
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                     ]
                   |)))
               |),
@@ -6822,15 +6986,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 5;
-                    M.get_tuple_field (M.read (| other |)) 5
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 6; M.get_tuple_field (M.read (| other |)) 6
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                 ]
               |)))
           |)))
@@ -6919,8 +7085,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Z, [ Z ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -6928,7 +7094,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -6944,8 +7110,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -6953,7 +7119,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -6969,8 +7135,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -6978,7 +7144,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -6994,8 +7160,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -7003,7 +7169,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -7019,8 +7185,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -7028,7 +7200,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -7044,8 +7216,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -7053,7 +7231,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -7068,12 +7246,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)));
@@ -7135,8 +7315,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Z, [ Z ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -7174,8 +7354,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -7217,8 +7397,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -7269,8 +7449,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -7326,8 +7506,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -7385,8 +7571,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -7443,12 +7635,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)))
@@ -7486,8 +7680,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Z, [ Z ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -7525,8 +7719,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -7568,8 +7762,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -7620,8 +7814,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -7677,8 +7871,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -7736,8 +7936,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -7794,12 +8000,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)))
@@ -7837,8 +8045,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Z, [ Z ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -7876,8 +8084,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -7922,8 +8130,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -7974,8 +8182,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -8033,8 +8241,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -8092,8 +8306,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -8150,12 +8370,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)))
@@ -8193,8 +8415,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", Z, [ Z ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -8232,8 +8454,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -8278,8 +8500,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -8330,8 +8552,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -8389,8 +8611,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -8448,8 +8676,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -8506,12 +8740,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)))
@@ -8568,8 +8804,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", Z, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -8581,8 +8817,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", Y, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -8594,8 +8830,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", X, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -8613,8 +8849,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -8632,8 +8868,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -8651,8 +8893,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -8669,12 +8917,14 @@ Module tuple.
                                                                   []
                                                                 |),
                                                                 [
-                                                                  M.get_tuple_field
-                                                                    (M.read (| self |))
-                                                                    6;
-                                                                  M.get_tuple_field
-                                                                    (M.read (| other |))
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| self |),
                                                                     6
+                                                                  |);
+                                                                  M.SubPointer.get_tuple_field (|
+                                                                    M.read (| other |),
+                                                                    6
+                                                                  |)
                                                                 ]
                                                               |)
                                                             |)));
@@ -8846,13 +9096,13 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
                     let value_Z := M.copy (| γ0_0 |) in
                     let value_Y := M.copy (| γ0_1 |) in
                     let value_X := M.copy (| γ0_2 |) in
@@ -8908,13 +9158,13 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
                     let value_Z := M.copy (| γ0_0 |) in
                     let value_Y := M.copy (| γ0_1 |) in
                     let value_X := M.copy (| γ0_2 |) in
@@ -8974,16 +9224,16 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 0;
-                            M.get_tuple_field (M.read (| other |)) 0
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                           ]
                         |),
                         ltac:(M.monadic
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 1;
-                              M.get_tuple_field (M.read (| other |)) 1
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                             ]
                           |)))
                       |),
@@ -8991,8 +9241,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 2;
-                            M.get_tuple_field (M.read (| other |)) 2
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                           ]
                         |)))
                     |),
@@ -9000,8 +9250,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 3;
-                          M.get_tuple_field (M.read (| other |)) 3
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                         ]
                       |)))
                   |),
@@ -9009,8 +9259,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 4;
-                        M.get_tuple_field (M.read (| other |)) 4
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                       ]
                     |)))
                 |),
@@ -9018,8 +9268,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 5;
-                      M.get_tuple_field (M.read (| other |)) 5
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                     ]
                   |)))
               |),
@@ -9027,15 +9277,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 6;
-                    M.get_tuple_field (M.read (| other |)) 6
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 7; M.get_tuple_field (M.read (| other |)) 7
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                 ]
               |)))
           |)))
@@ -9064,16 +9316,16 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 0;
-                            M.get_tuple_field (M.read (| other |)) 0
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                           ]
                         |),
                         ltac:(M.monadic
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 1;
-                              M.get_tuple_field (M.read (| other |)) 1
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                             ]
                           |)))
                       |),
@@ -9081,8 +9333,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 2;
-                            M.get_tuple_field (M.read (| other |)) 2
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                           ]
                         |)))
                     |),
@@ -9090,8 +9342,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 3;
-                          M.get_tuple_field (M.read (| other |)) 3
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                         ]
                       |)))
                   |),
@@ -9099,8 +9351,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 4;
-                        M.get_tuple_field (M.read (| other |)) 4
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                       ]
                     |)))
                 |),
@@ -9108,8 +9360,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 5;
-                      M.get_tuple_field (M.read (| other |)) 5
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                     ]
                   |)))
               |),
@@ -9117,15 +9369,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 6;
-                    M.get_tuple_field (M.read (| other |)) 6
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 7; M.get_tuple_field (M.read (| other |)) 7
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                 ]
               |)))
           |)))
@@ -9214,8 +9468,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -9223,7 +9477,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -9239,8 +9493,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -9248,7 +9502,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -9264,8 +9518,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -9273,7 +9527,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -9289,8 +9543,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -9298,7 +9552,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -9314,8 +9568,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -9323,7 +9583,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -9339,8 +9599,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -9348,7 +9614,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -9364,12 +9630,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -9377,7 +9645,7 @@ Module tuple.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -9392,12 +9660,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)));
@@ -9466,8 +9736,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -9505,8 +9775,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -9548,8 +9818,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -9600,8 +9870,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -9657,8 +9927,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -9716,8 +9992,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -9775,12 +10057,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -9837,12 +10121,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)))
@@ -9882,8 +10168,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -9921,8 +10207,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -9964,8 +10250,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -10016,8 +10302,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -10073,8 +10359,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -10132,8 +10424,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -10191,12 +10489,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -10253,12 +10553,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)))
@@ -10298,8 +10600,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -10337,8 +10639,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -10383,8 +10685,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -10435,8 +10737,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -10494,8 +10796,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -10553,8 +10861,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -10612,12 +10926,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -10674,12 +10990,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)))
@@ -10719,8 +11037,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", A, [ A ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -10758,8 +11076,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -10804,8 +11122,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -10856,8 +11174,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -10915,8 +11233,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -10974,8 +11298,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -11033,12 +11363,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -11095,12 +11427,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)))
@@ -11159,8 +11493,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", A, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -11172,8 +11506,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", Z, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -11185,8 +11519,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", Y, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -11204,8 +11538,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -11223,8 +11557,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -11242,8 +11582,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -11261,12 +11607,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -11283,12 +11631,14 @@ Module tuple.
                                                                           []
                                                                         |),
                                                                         [
-                                                                          M.get_tuple_field
-                                                                            (M.read (| self |))
-                                                                            7;
-                                                                          M.get_tuple_field
-                                                                            (M.read (| other |))
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| self |),
                                                                             7
+                                                                          |);
+                                                                          M.SubPointer.get_tuple_field (|
+                                                                            M.read (| other |),
+                                                                            7
+                                                                          |)
                                                                         ]
                                                                       |)
                                                                     |)));
@@ -11477,14 +11827,14 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
                     let value_A := M.copy (| γ0_0 |) in
                     let value_Z := M.copy (| γ0_1 |) in
                     let value_Y := M.copy (| γ0_2 |) in
@@ -11542,14 +11892,14 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
                     let value_A := M.copy (| γ0_0 |) in
                     let value_Z := M.copy (| γ0_1 |) in
                     let value_Y := M.copy (| γ0_2 |) in
@@ -11612,16 +11962,16 @@ Module tuple.
                           M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 0;
-                              M.get_tuple_field (M.read (| other |)) 0
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                             ]
                           |),
                           ltac:(M.monadic
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 1;
-                                M.get_tuple_field (M.read (| other |)) 1
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                               ]
                             |)))
                         |),
@@ -11629,8 +11979,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 2;
-                              M.get_tuple_field (M.read (| other |)) 2
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                             ]
                           |)))
                       |),
@@ -11638,8 +11988,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 3;
-                            M.get_tuple_field (M.read (| other |)) 3
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                           ]
                         |)))
                     |),
@@ -11647,8 +11997,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 4;
-                          M.get_tuple_field (M.read (| other |)) 4
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                         ]
                       |)))
                   |),
@@ -11656,8 +12006,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 5;
-                        M.get_tuple_field (M.read (| other |)) 5
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                       ]
                     |)))
                 |),
@@ -11665,8 +12015,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 6;
-                      M.get_tuple_field (M.read (| other |)) 6
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                     ]
                   |)))
               |),
@@ -11674,15 +12024,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 7;
-                    M.get_tuple_field (M.read (| other |)) 7
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 8; M.get_tuple_field (M.read (| other |)) 8
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                 ]
               |)))
           |)))
@@ -11712,16 +12064,16 @@ Module tuple.
                           M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 0;
-                              M.get_tuple_field (M.read (| other |)) 0
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                             ]
                           |),
                           ltac:(M.monadic
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "ne", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 1;
-                                M.get_tuple_field (M.read (| other |)) 1
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                               ]
                             |)))
                         |),
@@ -11729,8 +12081,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 2;
-                              M.get_tuple_field (M.read (| other |)) 2
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                             ]
                           |)))
                       |),
@@ -11738,8 +12090,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 3;
-                            M.get_tuple_field (M.read (| other |)) 3
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                           ]
                         |)))
                     |),
@@ -11747,8 +12099,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 4;
-                          M.get_tuple_field (M.read (| other |)) 4
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                         ]
                       |)))
                   |),
@@ -11756,8 +12108,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 5;
-                        M.get_tuple_field (M.read (| other |)) 5
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                       ]
                     |)))
                 |),
@@ -11765,8 +12117,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 6;
-                      M.get_tuple_field (M.read (| other |)) 6
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                     ]
                   |)))
               |),
@@ -11774,15 +12126,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 7;
-                    M.get_tuple_field (M.read (| other |)) 7
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 8; M.get_tuple_field (M.read (| other |)) 8
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                 ]
               |)))
           |)))
@@ -11871,8 +12225,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", B, [ B ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -11880,7 +12234,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -11896,8 +12250,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -11905,7 +12259,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -11921,8 +12275,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -11930,7 +12284,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -11946,8 +12300,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -11955,7 +12309,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -11971,8 +12325,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -11980,7 +12340,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -11996,8 +12356,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -12005,7 +12371,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -12021,12 +12387,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -12034,7 +12402,7 @@ Module tuple.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -12050,12 +12418,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -12063,7 +12433,7 @@ Module tuple.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -12078,16 +12448,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)));
@@ -12163,8 +12535,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", B, [ B ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -12202,8 +12574,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -12245,8 +12617,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -12297,8 +12669,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -12354,8 +12726,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -12413,8 +12791,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -12472,12 +12856,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -12535,12 +12921,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -12599,16 +12987,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)))
@@ -12650,8 +13040,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", B, [ B ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -12689,8 +13079,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -12732,8 +13122,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -12784,8 +13174,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -12841,8 +13231,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -12900,8 +13296,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -12959,12 +13361,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -13022,12 +13426,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -13086,16 +13492,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)))
@@ -13137,8 +13545,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", B, [ B ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -13176,8 +13584,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -13222,8 +13630,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -13274,8 +13682,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -13333,8 +13741,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -13392,8 +13806,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -13451,12 +13871,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -13514,12 +13936,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -13578,16 +14002,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)))
@@ -13629,8 +14055,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", B, [ B ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -13668,8 +14094,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -13714,8 +14140,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -13766,8 +14192,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -13825,8 +14251,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -13884,8 +14316,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -13943,12 +14381,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -14006,12 +14446,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -14070,16 +14512,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)))
@@ -14140,8 +14584,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", B, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -14153,8 +14597,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", A, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -14166,8 +14610,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", Z, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -14185,8 +14629,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -14204,8 +14648,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -14223,8 +14673,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -14242,12 +14698,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -14265,12 +14723,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -14287,16 +14747,18 @@ Module tuple.
                                                                                   []
                                                                                 |),
                                                                                 [
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
                                                                                       self
-                                                                                    |))
-                                                                                    8;
-                                                                                  M.get_tuple_field
-                                                                                    (M.read (|
-                                                                                      other
-                                                                                    |))
+                                                                                    |),
                                                                                     8
+                                                                                  |);
+                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                    M.read (|
+                                                                                      other
+                                                                                    |),
+                                                                                    8
+                                                                                  |)
                                                                                 ]
                                                                               |)
                                                                             |)));
@@ -14502,15 +14964,15 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
-                    let γ0_8 := M.get_slice_index_or_break_match (| γ, 8 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_slice_index (| γ, 8 |) in
                     let value_B := M.copy (| γ0_0 |) in
                     let value_A := M.copy (| γ0_1 |) in
                     let value_Z := M.copy (| γ0_2 |) in
@@ -14570,15 +15032,15 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
                     let value_B := M.copy (| γ0_0 |) in
                     let value_A := M.copy (| γ0_1 |) in
                     let value_Z := M.copy (| γ0_2 |) in
@@ -14645,16 +15107,16 @@ Module tuple.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", C, [ C ], "eq", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 0;
-                                M.get_tuple_field (M.read (| other |)) 0
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                               ]
                             |),
                             ltac:(M.monadic
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "eq", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 1;
-                                  M.get_tuple_field (M.read (| other |)) 1
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                 ]
                               |)))
                           |),
@@ -14662,8 +15124,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 2;
-                                M.get_tuple_field (M.read (| other |)) 2
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                               ]
                             |)))
                         |),
@@ -14671,8 +15133,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 3;
-                              M.get_tuple_field (M.read (| other |)) 3
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                             ]
                           |)))
                       |),
@@ -14680,8 +15142,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 4;
-                            M.get_tuple_field (M.read (| other |)) 4
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                           ]
                         |)))
                     |),
@@ -14689,8 +15151,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 5;
-                          M.get_tuple_field (M.read (| other |)) 5
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                         ]
                       |)))
                   |),
@@ -14698,8 +15160,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 6;
-                        M.get_tuple_field (M.read (| other |)) 6
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                       ]
                     |)))
                 |),
@@ -14707,8 +15169,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 7;
-                      M.get_tuple_field (M.read (| other |)) 7
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                     ]
                   |)))
               |),
@@ -14716,15 +15178,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 8;
-                    M.get_tuple_field (M.read (| other |)) 8
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 9; M.get_tuple_field (M.read (| other |)) 9
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                 ]
               |)))
           |)))
@@ -14755,16 +15219,16 @@ Module tuple.
                             M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", C, [ C ], "ne", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 0;
-                                M.get_tuple_field (M.read (| other |)) 0
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                               ]
                             |),
                             ltac:(M.monadic
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "ne", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 1;
-                                  M.get_tuple_field (M.read (| other |)) 1
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                 ]
                               |)))
                           |),
@@ -14772,8 +15236,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "ne", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 2;
-                                M.get_tuple_field (M.read (| other |)) 2
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                               ]
                             |)))
                         |),
@@ -14781,8 +15245,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 3;
-                              M.get_tuple_field (M.read (| other |)) 3
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                             ]
                           |)))
                       |),
@@ -14790,8 +15254,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 4;
-                            M.get_tuple_field (M.read (| other |)) 4
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                           ]
                         |)))
                     |),
@@ -14799,8 +15263,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 5;
-                          M.get_tuple_field (M.read (| other |)) 5
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                         ]
                       |)))
                   |),
@@ -14808,8 +15272,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 6;
-                        M.get_tuple_field (M.read (| other |)) 6
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                       ]
                     |)))
                 |),
@@ -14817,8 +15281,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 7;
-                      M.get_tuple_field (M.read (| other |)) 7
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                     ]
                   |)))
               |),
@@ -14826,15 +15290,17 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 8;
-                    M.get_tuple_field (M.read (| other |)) 8
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
-                [ M.get_tuple_field (M.read (| self |)) 9; M.get_tuple_field (M.read (| other |)) 9
+                [
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                 ]
               |)))
           |)))
@@ -14928,8 +15394,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", C, [ C ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -14937,7 +15403,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -14953,8 +15419,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -14962,7 +15428,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -14978,8 +15444,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -14987,7 +15453,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -15003,8 +15469,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -15012,7 +15478,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -15028,8 +15494,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -15037,7 +15509,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -15053,8 +15525,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -15062,7 +15540,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -15078,12 +15556,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -15091,7 +15571,7 @@ Module tuple.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -15107,12 +15587,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -15120,7 +15602,7 @@ Module tuple.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -15136,16 +15618,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -15153,7 +15637,7 @@ Module tuple.
                                                                                 fun γ =>
                                                                                   ltac:(M.monadic
                                                                                     (let γ0_0 :=
-                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                         γ,
                                                                                         "core::option::Option::Some",
                                                                                         0
@@ -15168,16 +15652,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)));
@@ -15262,8 +15748,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", C, [ C ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -15301,8 +15787,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -15344,8 +15830,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -15396,8 +15882,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -15453,8 +15939,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -15512,8 +16004,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -15571,12 +16069,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -15634,12 +16134,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -15699,16 +16201,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -15774,16 +16278,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)))
@@ -15827,8 +16333,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", C, [ C ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -15866,8 +16372,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -15909,8 +16415,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -15961,8 +16467,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -16018,8 +16524,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -16077,8 +16589,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -16136,12 +16654,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -16199,12 +16719,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -16264,16 +16786,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -16339,16 +16863,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)))
@@ -16392,8 +16918,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", C, [ C ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -16431,8 +16957,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -16477,8 +17003,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -16529,8 +17055,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -16588,8 +17114,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -16647,8 +17179,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -16706,12 +17244,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -16769,12 +17309,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -16834,16 +17376,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -16909,16 +17453,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)))
@@ -16962,8 +17508,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", C, [ C ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -17001,8 +17547,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -17047,8 +17593,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -17099,8 +17645,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -17158,8 +17704,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -17217,8 +17769,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -17276,12 +17834,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -17339,12 +17899,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -17404,16 +17966,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -17479,16 +18043,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)))
@@ -17552,8 +18118,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", C, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -17565,8 +18131,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", B, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -17578,8 +18144,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", A, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -17597,8 +18163,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -17616,8 +18182,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -17635,8 +18207,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -17654,12 +18232,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -17677,12 +18257,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -17700,16 +18282,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -17726,16 +18310,18 @@ Module tuple.
                                                                                           []
                                                                                         |),
                                                                                         [
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
                                                                                               self
-                                                                                            |))
-                                                                                            9;
-                                                                                          M.get_tuple_field
-                                                                                            (M.read (|
-                                                                                              other
-                                                                                            |))
+                                                                                            |),
                                                                                             9
+                                                                                          |);
+                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                            M.read (|
+                                                                                              other
+                                                                                            |),
+                                                                                            9
+                                                                                          |)
                                                                                         ]
                                                                                       |)
                                                                                     |)));
@@ -17961,16 +18547,16 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
-                    let γ0_8 := M.get_slice_index_or_break_match (| γ, 8 |) in
-                    let γ0_9 := M.get_slice_index_or_break_match (| γ, 9 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_slice_index (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_slice_index (| γ, 9 |) in
                     let value_C := M.copy (| γ0_0 |) in
                     let value_B := M.copy (| γ0_1 |) in
                     let value_A := M.copy (| γ0_2 |) in
@@ -18032,16 +18618,16 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
                     let value_C := M.copy (| γ0_0 |) in
                     let value_B := M.copy (| γ0_1 |) in
                     let value_A := M.copy (| γ0_2 |) in
@@ -18111,8 +18697,8 @@ Module tuple.
                               M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", D, [ D ], "eq", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 0;
-                                  M.get_tuple_field (M.read (| other |)) 0
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                                 ]
                               |),
                               ltac:(M.monadic
@@ -18125,8 +18711,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 1;
-                                    M.get_tuple_field (M.read (| other |)) 1
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                   ]
                                 |)))
                             |),
@@ -18134,8 +18720,8 @@ Module tuple.
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "eq", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)))
                           |),
@@ -18143,8 +18729,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 3;
-                                M.get_tuple_field (M.read (| other |)) 3
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                               ]
                             |)))
                         |),
@@ -18152,8 +18738,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 4;
-                              M.get_tuple_field (M.read (| other |)) 4
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                             ]
                           |)))
                       |),
@@ -18161,8 +18747,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 5;
-                            M.get_tuple_field (M.read (| other |)) 5
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                           ]
                         |)))
                     |),
@@ -18170,8 +18756,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 6;
-                          M.get_tuple_field (M.read (| other |)) 6
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                         ]
                       |)))
                   |),
@@ -18179,8 +18765,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 7;
-                        M.get_tuple_field (M.read (| other |)) 7
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                       ]
                     |)))
                 |),
@@ -18188,8 +18774,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 8;
-                      M.get_tuple_field (M.read (| other |)) 8
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                     ]
                   |)))
               |),
@@ -18197,8 +18783,8 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 9;
-                    M.get_tuple_field (M.read (| other |)) 9
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                   ]
                 |)))
             |),
@@ -18206,8 +18792,8 @@ Module tuple.
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
                 [
-                  M.get_tuple_field (M.read (| self |)) 10;
-                  M.get_tuple_field (M.read (| other |)) 10
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 10 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 10 |)
                 ]
               |)))
           |)))
@@ -18239,8 +18825,8 @@ Module tuple.
                               M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", D, [ D ], "ne", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 0;
-                                  M.get_tuple_field (M.read (| other |)) 0
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                                 ]
                               |),
                               ltac:(M.monadic
@@ -18253,8 +18839,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 1;
-                                    M.get_tuple_field (M.read (| other |)) 1
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                   ]
                                 |)))
                             |),
@@ -18262,8 +18848,8 @@ Module tuple.
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "ne", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 2;
-                                  M.get_tuple_field (M.read (| other |)) 2
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                 ]
                               |)))
                           |),
@@ -18271,8 +18857,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "ne", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 3;
-                                M.get_tuple_field (M.read (| other |)) 3
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                               ]
                             |)))
                         |),
@@ -18280,8 +18866,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 4;
-                              M.get_tuple_field (M.read (| other |)) 4
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                             ]
                           |)))
                       |),
@@ -18289,8 +18875,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 5;
-                            M.get_tuple_field (M.read (| other |)) 5
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                           ]
                         |)))
                     |),
@@ -18298,8 +18884,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 6;
-                          M.get_tuple_field (M.read (| other |)) 6
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                         ]
                       |)))
                   |),
@@ -18307,8 +18893,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 7;
-                        M.get_tuple_field (M.read (| other |)) 7
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                       ]
                     |)))
                 |),
@@ -18316,8 +18902,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 8;
-                      M.get_tuple_field (M.read (| other |)) 8
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                     ]
                   |)))
               |),
@@ -18325,8 +18911,8 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 9;
-                    M.get_tuple_field (M.read (| other |)) 9
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                   ]
                 |)))
             |),
@@ -18334,8 +18920,8 @@ Module tuple.
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
                 [
-                  M.get_tuple_field (M.read (| self |)) 10;
-                  M.get_tuple_field (M.read (| other |)) 10
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 10 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 10 |)
                 ]
               |)))
           |)))
@@ -18429,8 +19015,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", D, [ D ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -18438,7 +19024,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -18454,8 +19040,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -18463,7 +19049,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -18479,8 +19065,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -18488,7 +19074,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -18504,8 +19090,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -18513,7 +19099,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -18529,8 +19115,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -18538,7 +19130,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -18554,8 +19146,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -18563,7 +19161,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -18579,12 +19177,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -18592,7 +19192,7 @@ Module tuple.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -18608,12 +19208,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -18621,7 +19223,7 @@ Module tuple.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -18637,16 +19239,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -18654,7 +19258,7 @@ Module tuple.
                                                                                 fun γ =>
                                                                                   ltac:(M.monadic
                                                                                     (let γ0_0 :=
-                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                         γ,
                                                                                         "core::option::Option::Some",
                                                                                         0
@@ -18670,16 +19274,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |),
@@ -18688,7 +19294,7 @@ Module tuple.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::option::Option::Some",
                                                                                                 0
@@ -18705,16 +19311,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)));
@@ -18809,8 +19417,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", D, [ D ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -18848,8 +19456,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -18891,8 +19499,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -18943,8 +19551,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -19000,8 +19608,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -19059,8 +19673,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -19118,12 +19738,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -19181,12 +19803,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -19246,16 +19870,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -19322,16 +19948,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -19401,16 +20029,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)))
@@ -19456,8 +20086,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", D, [ D ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -19495,8 +20125,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -19538,8 +20168,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -19590,8 +20220,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -19647,8 +20277,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -19706,8 +20342,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -19765,12 +20407,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -19828,12 +20472,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -19893,16 +20539,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -19969,16 +20617,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -20048,16 +20698,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)))
@@ -20103,8 +20755,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", D, [ D ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -20142,8 +20794,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -20188,8 +20840,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -20240,8 +20892,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -20299,8 +20951,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -20358,8 +21016,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -20417,12 +21081,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -20480,12 +21146,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -20545,16 +21213,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -20621,16 +21291,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -20700,16 +21372,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)))
@@ -20755,8 +21429,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", D, [ D ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -20794,8 +21468,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -20840,8 +21514,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -20892,8 +21566,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -20951,8 +21625,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -21010,8 +21690,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -21069,12 +21755,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -21132,12 +21820,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -21197,16 +21887,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -21273,16 +21965,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -21352,16 +22046,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)))
@@ -21427,8 +22123,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", D, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -21440,8 +22136,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", C, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -21453,8 +22149,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", B, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -21472,8 +22168,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -21491,8 +22187,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -21510,8 +22212,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -21529,12 +22237,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -21552,12 +22262,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -21575,16 +22287,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -21602,16 +22316,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |),
@@ -21628,16 +22344,18 @@ Module tuple.
                                                                                                   []
                                                                                                 |),
                                                                                                 [
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
                                                                                                       self
-                                                                                                    |))
-                                                                                                    10;
-                                                                                                  M.get_tuple_field
-                                                                                                    (M.read (|
-                                                                                                      other
-                                                                                                    |))
+                                                                                                    |),
                                                                                                     10
+                                                                                                  |);
+                                                                                                  M.SubPointer.get_tuple_field (|
+                                                                                                    M.read (|
+                                                                                                      other
+                                                                                                    |),
+                                                                                                    10
+                                                                                                  |)
                                                                                                 ]
                                                                                               |)
                                                                                             |)));
@@ -21883,17 +22601,17 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
-                    let γ0_8 := M.get_slice_index_or_break_match (| γ, 8 |) in
-                    let γ0_9 := M.get_slice_index_or_break_match (| γ, 9 |) in
-                    let γ0_10 := M.get_slice_index_or_break_match (| γ, 10 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_slice_index (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_slice_index (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_slice_index (| γ, 10 |) in
                     let value_D := M.copy (| γ0_0 |) in
                     let value_C := M.copy (| γ0_1 |) in
                     let value_B := M.copy (| γ0_2 |) in
@@ -21957,17 +22675,17 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
-                    let γ0_10 := M.get_tuple_field γ 10 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
                     let value_D := M.copy (| γ0_0 |) in
                     let value_C := M.copy (| γ0_1 |) in
                     let value_B := M.copy (| γ0_2 |) in
@@ -22046,8 +22764,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 0;
-                                    M.get_tuple_field (M.read (| other |)) 0
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                                   ]
                                 |),
                                 ltac:(M.monadic
@@ -22060,8 +22778,8 @@ Module tuple.
                                       []
                                     |),
                                     [
-                                      M.get_tuple_field (M.read (| self |)) 1;
-                                      M.get_tuple_field (M.read (| other |)) 1
+                                      M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                      M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                     ]
                                   |)))
                               |),
@@ -22075,8 +22793,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)))
                             |),
@@ -22084,8 +22802,8 @@ Module tuple.
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "eq", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 3;
-                                  M.get_tuple_field (M.read (| other |)) 3
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                 ]
                               |)))
                           |),
@@ -22093,8 +22811,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 4;
-                                M.get_tuple_field (M.read (| other |)) 4
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                               ]
                             |)))
                         |),
@@ -22102,8 +22820,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "eq", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 5;
-                              M.get_tuple_field (M.read (| other |)) 5
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                             ]
                           |)))
                       |),
@@ -22111,8 +22829,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "eq", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 6;
-                            M.get_tuple_field (M.read (| other |)) 6
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                           ]
                         |)))
                     |),
@@ -22120,8 +22838,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "eq", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 7;
-                          M.get_tuple_field (M.read (| other |)) 7
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                         ]
                       |)))
                   |),
@@ -22129,8 +22847,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "eq", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 8;
-                        M.get_tuple_field (M.read (| other |)) 8
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                       ]
                     |)))
                 |),
@@ -22138,8 +22856,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "eq", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 9;
-                      M.get_tuple_field (M.read (| other |)) 9
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                     ]
                   |)))
               |),
@@ -22147,8 +22865,8 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "eq", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 10;
-                    M.get_tuple_field (M.read (| other |)) 10
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 10 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 10 |)
                   ]
                 |)))
             |),
@@ -22156,8 +22874,8 @@ Module tuple.
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "eq", [] |),
                 [
-                  M.get_tuple_field (M.read (| self |)) 11;
-                  M.get_tuple_field (M.read (| other |)) 11
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 11 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 11 |)
                 ]
               |)))
           |)))
@@ -22196,8 +22914,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 0;
-                                    M.get_tuple_field (M.read (| other |)) 0
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                                   ]
                                 |),
                                 ltac:(M.monadic
@@ -22210,8 +22928,8 @@ Module tuple.
                                       []
                                     |),
                                     [
-                                      M.get_tuple_field (M.read (| self |)) 1;
-                                      M.get_tuple_field (M.read (| other |)) 1
+                                      M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                                      M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                                     ]
                                   |)))
                               |),
@@ -22225,8 +22943,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)))
                             |),
@@ -22234,8 +22952,8 @@ Module tuple.
                               (M.call_closure (|
                                 M.get_trait_method (| "core::cmp::PartialEq", B, [ B ], "ne", [] |),
                                 [
-                                  M.get_tuple_field (M.read (| self |)) 3;
-                                  M.get_tuple_field (M.read (| other |)) 3
+                                  M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                  M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                 ]
                               |)))
                           |),
@@ -22243,8 +22961,8 @@ Module tuple.
                             (M.call_closure (|
                               M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "ne", [] |),
                               [
-                                M.get_tuple_field (M.read (| self |)) 4;
-                                M.get_tuple_field (M.read (| other |)) 4
+                                M.SubPointer.get_tuple_field (| M.read (| self |), 4 |);
+                                M.SubPointer.get_tuple_field (| M.read (| other |), 4 |)
                               ]
                             |)))
                         |),
@@ -22252,8 +22970,8 @@ Module tuple.
                           (M.call_closure (|
                             M.get_trait_method (| "core::cmp::PartialEq", Z, [ Z ], "ne", [] |),
                             [
-                              M.get_tuple_field (M.read (| self |)) 5;
-                              M.get_tuple_field (M.read (| other |)) 5
+                              M.SubPointer.get_tuple_field (| M.read (| self |), 5 |);
+                              M.SubPointer.get_tuple_field (| M.read (| other |), 5 |)
                             ]
                           |)))
                       |),
@@ -22261,8 +22979,8 @@ Module tuple.
                         (M.call_closure (|
                           M.get_trait_method (| "core::cmp::PartialEq", Y, [ Y ], "ne", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 6;
-                            M.get_tuple_field (M.read (| other |)) 6
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 6 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 6 |)
                           ]
                         |)))
                     |),
@@ -22270,8 +22988,8 @@ Module tuple.
                       (M.call_closure (|
                         M.get_trait_method (| "core::cmp::PartialEq", X, [ X ], "ne", [] |),
                         [
-                          M.get_tuple_field (M.read (| self |)) 7;
-                          M.get_tuple_field (M.read (| other |)) 7
+                          M.SubPointer.get_tuple_field (| M.read (| self |), 7 |);
+                          M.SubPointer.get_tuple_field (| M.read (| other |), 7 |)
                         ]
                       |)))
                   |),
@@ -22279,8 +22997,8 @@ Module tuple.
                     (M.call_closure (|
                       M.get_trait_method (| "core::cmp::PartialEq", W, [ W ], "ne", [] |),
                       [
-                        M.get_tuple_field (M.read (| self |)) 8;
-                        M.get_tuple_field (M.read (| other |)) 8
+                        M.SubPointer.get_tuple_field (| M.read (| self |), 8 |);
+                        M.SubPointer.get_tuple_field (| M.read (| other |), 8 |)
                       ]
                     |)))
                 |),
@@ -22288,8 +23006,8 @@ Module tuple.
                   (M.call_closure (|
                     M.get_trait_method (| "core::cmp::PartialEq", V, [ V ], "ne", [] |),
                     [
-                      M.get_tuple_field (M.read (| self |)) 9;
-                      M.get_tuple_field (M.read (| other |)) 9
+                      M.SubPointer.get_tuple_field (| M.read (| self |), 9 |);
+                      M.SubPointer.get_tuple_field (| M.read (| other |), 9 |)
                     ]
                   |)))
               |),
@@ -22297,8 +23015,8 @@ Module tuple.
                 (M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialEq", U, [ U ], "ne", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 10;
-                    M.get_tuple_field (M.read (| other |)) 10
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 10 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 10 |)
                   ]
                 |)))
             |),
@@ -22306,8 +23024,8 @@ Module tuple.
               (M.call_closure (|
                 M.get_trait_method (| "core::cmp::PartialEq", T, [ T ], "ne", [] |),
                 [
-                  M.get_tuple_field (M.read (| self |)) 11;
-                  M.get_tuple_field (M.read (| other |)) 11
+                  M.SubPointer.get_tuple_field (| M.read (| self |), 11 |);
+                  M.SubPointer.get_tuple_field (| M.read (| other |), 11 |)
                 ]
               |)))
           |)))
@@ -22405,8 +23123,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", E, [ E ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -22414,7 +23132,7 @@ Module tuple.
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
+                      M.SubPointer.get_struct_tuple_field (|
                         γ,
                         "core::option::Option::Some",
                         0
@@ -22430,8 +23148,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -22439,7 +23157,7 @@ Module tuple.
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
+                              M.SubPointer.get_struct_tuple_field (|
                                 γ,
                                 "core::option::Option::Some",
                                 0
@@ -22455,8 +23173,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -22464,7 +23182,7 @@ Module tuple.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -22480,8 +23198,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -22489,7 +23207,7 @@ Module tuple.
                                         fun γ =>
                                           ltac:(M.monadic
                                             (let γ0_0 :=
-                                              M.get_struct_tuple_field_or_break_match (|
+                                              M.SubPointer.get_struct_tuple_field (|
                                                 γ,
                                                 "core::option::Option::Some",
                                                 0
@@ -22505,8 +23223,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -22514,7 +23238,7 @@ Module tuple.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ0_0 :=
-                                                      M.get_struct_tuple_field_or_break_match (|
+                                                      M.SubPointer.get_struct_tuple_field (|
                                                         γ,
                                                         "core::option::Option::Some",
                                                         0
@@ -22530,8 +23254,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -22539,7 +23269,7 @@ Module tuple.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -22555,12 +23285,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -22568,7 +23300,7 @@ Module tuple.
                                                                 fun γ =>
                                                                   ltac:(M.monadic
                                                                     (let γ0_0 :=
-                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                         γ,
                                                                         "core::option::Option::Some",
                                                                         0
@@ -22584,12 +23316,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -22597,7 +23331,7 @@ Module tuple.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -22613,16 +23347,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -22630,7 +23366,7 @@ Module tuple.
                                                                                 fun γ =>
                                                                                   ltac:(M.monadic
                                                                                     (let γ0_0 :=
-                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                         γ,
                                                                                         "core::option::Option::Some",
                                                                                         0
@@ -22646,16 +23382,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |),
@@ -22664,7 +23402,7 @@ Module tuple.
                                                                                           ltac:(M.monadic
                                                                                             (let
                                                                                                   γ0_0 :=
-                                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                                 γ,
                                                                                                 "core::option::Option::Some",
                                                                                                 0
@@ -22682,16 +23420,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |),
@@ -22701,7 +23441,7 @@ Module tuple.
                                                                                                   ltac:(M.monadic
                                                                                                     (let
                                                                                                           γ0_0 :=
-                                                                                                      M.get_struct_tuple_field_or_break_match (|
+                                                                                                      M.SubPointer.get_struct_tuple_field (|
                                                                                                         γ,
                                                                                                         "core::option::Option::Some",
                                                                                                         0
@@ -22718,16 +23458,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)));
@@ -22833,8 +23575,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", E, [ E ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -22872,8 +23614,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -22915,8 +23657,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -22967,8 +23709,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -23024,8 +23766,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -23083,8 +23831,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -23142,12 +23896,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -23205,12 +23961,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -23270,16 +24028,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -23346,16 +24106,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -23427,16 +24189,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |) in
@@ -23509,16 +24273,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)))
@@ -23566,8 +24332,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", E, [ E ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -23605,8 +24371,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -23648,8 +24414,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -23700,8 +24466,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -23757,8 +24523,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -23816,8 +24588,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -23875,12 +24653,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -23938,12 +24718,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -24003,16 +24785,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -24079,16 +24863,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -24160,16 +24946,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |) in
@@ -24242,16 +25030,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)))
@@ -24299,8 +25089,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", E, [ E ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -24338,8 +25128,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -24384,8 +25174,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -24436,8 +25226,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -24495,8 +25285,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -24554,8 +25350,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -24613,12 +25415,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -24676,12 +25480,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -24741,16 +25547,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -24817,16 +25625,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -24898,16 +25708,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |) in
@@ -24980,16 +25792,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)))
@@ -25037,8 +25851,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::PartialOrd", E, [ E ], "partial_cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |) in
@@ -25076,8 +25890,8 @@ Module tuple.
                             []
                           |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |) in
@@ -25122,8 +25936,8 @@ Module tuple.
                                     []
                                   |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |) in
@@ -25174,8 +25988,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |) in
@@ -25233,8 +26047,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |) in
@@ -25292,8 +26112,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |) in
@@ -25351,12 +26177,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |) in
@@ -25414,12 +26242,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |) in
@@ -25479,16 +26309,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |) in
@@ -25555,16 +26387,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |) in
@@ -25636,16 +26470,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |) in
@@ -25718,16 +26554,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)))
@@ -25795,8 +26633,8 @@ Module tuple.
                 M.call_closure (|
                   M.get_trait_method (| "core::cmp::Ord", E, [], "cmp", [] |),
                   [
-                    M.get_tuple_field (M.read (| self |)) 0;
-                    M.get_tuple_field (M.read (| other |)) 0
+                    M.SubPointer.get_tuple_field (| M.read (| self |), 0 |);
+                    M.SubPointer.get_tuple_field (| M.read (| other |), 0 |)
                   ]
                 |)
               |),
@@ -25808,8 +26646,8 @@ Module tuple.
                         M.call_closure (|
                           M.get_trait_method (| "core::cmp::Ord", D, [], "cmp", [] |),
                           [
-                            M.get_tuple_field (M.read (| self |)) 1;
-                            M.get_tuple_field (M.read (| other |)) 1
+                            M.SubPointer.get_tuple_field (| M.read (| self |), 1 |);
+                            M.SubPointer.get_tuple_field (| M.read (| other |), 1 |)
                           ]
                         |)
                       |),
@@ -25821,8 +26659,8 @@ Module tuple.
                                 M.call_closure (|
                                   M.get_trait_method (| "core::cmp::Ord", C, [], "cmp", [] |),
                                   [
-                                    M.get_tuple_field (M.read (| self |)) 2;
-                                    M.get_tuple_field (M.read (| other |)) 2
+                                    M.SubPointer.get_tuple_field (| M.read (| self |), 2 |);
+                                    M.SubPointer.get_tuple_field (| M.read (| other |), 2 |)
                                   ]
                                 |)
                               |),
@@ -25840,8 +26678,8 @@ Module tuple.
                                             []
                                           |),
                                           [
-                                            M.get_tuple_field (M.read (| self |)) 3;
-                                            M.get_tuple_field (M.read (| other |)) 3
+                                            M.SubPointer.get_tuple_field (| M.read (| self |), 3 |);
+                                            M.SubPointer.get_tuple_field (| M.read (| other |), 3 |)
                                           ]
                                         |)
                                       |),
@@ -25859,8 +26697,14 @@ Module tuple.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_tuple_field (M.read (| self |)) 4;
-                                                    M.get_tuple_field (M.read (| other |)) 4
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| self |),
+                                                      4
+                                                    |);
+                                                    M.SubPointer.get_tuple_field (|
+                                                      M.read (| other |),
+                                                      4
+                                                    |)
                                                   ]
                                                 |)
                                               |),
@@ -25878,8 +26722,14 @@ Module tuple.
                                                             []
                                                           |),
                                                           [
-                                                            M.get_tuple_field (M.read (| self |)) 5;
-                                                            M.get_tuple_field (M.read (| other |)) 5
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| self |),
+                                                              5
+                                                            |);
+                                                            M.SubPointer.get_tuple_field (|
+                                                              M.read (| other |),
+                                                              5
+                                                            |)
                                                           ]
                                                         |)
                                                       |),
@@ -25897,12 +26747,14 @@ Module tuple.
                                                                     []
                                                                   |),
                                                                   [
-                                                                    M.get_tuple_field
-                                                                      (M.read (| self |))
-                                                                      6;
-                                                                    M.get_tuple_field
-                                                                      (M.read (| other |))
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| self |),
                                                                       6
+                                                                    |);
+                                                                    M.SubPointer.get_tuple_field (|
+                                                                      M.read (| other |),
+                                                                      6
+                                                                    |)
                                                                   ]
                                                                 |)
                                                               |),
@@ -25920,12 +26772,14 @@ Module tuple.
                                                                             []
                                                                           |),
                                                                           [
-                                                                            M.get_tuple_field
-                                                                              (M.read (| self |))
-                                                                              7;
-                                                                            M.get_tuple_field
-                                                                              (M.read (| other |))
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| self |),
                                                                               7
+                                                                            |);
+                                                                            M.SubPointer.get_tuple_field (|
+                                                                              M.read (| other |),
+                                                                              7
+                                                                            |)
                                                                           ]
                                                                         |)
                                                                       |),
@@ -25943,16 +26797,18 @@ Module tuple.
                                                                                     []
                                                                                   |),
                                                                                   [
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
                                                                                         self
-                                                                                      |))
-                                                                                      8;
-                                                                                    M.get_tuple_field
-                                                                                      (M.read (|
-                                                                                        other
-                                                                                      |))
+                                                                                      |),
                                                                                       8
+                                                                                    |);
+                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                      M.read (|
+                                                                                        other
+                                                                                      |),
+                                                                                      8
+                                                                                    |)
                                                                                   ]
                                                                                 |)
                                                                               |),
@@ -25970,16 +26826,18 @@ Module tuple.
                                                                                             []
                                                                                           |),
                                                                                           [
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
                                                                                                 self
-                                                                                              |))
-                                                                                              9;
-                                                                                            M.get_tuple_field
-                                                                                              (M.read (|
-                                                                                                other
-                                                                                              |))
+                                                                                              |),
                                                                                               9
+                                                                                            |);
+                                                                                            M.SubPointer.get_tuple_field (|
+                                                                                              M.read (|
+                                                                                                other
+                                                                                              |),
+                                                                                              9
+                                                                                            |)
                                                                                           ]
                                                                                         |)
                                                                                       |),
@@ -25997,16 +26855,18 @@ Module tuple.
                                                                                                     []
                                                                                                   |),
                                                                                                   [
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
                                                                                                         self
-                                                                                                      |))
-                                                                                                      10;
-                                                                                                    M.get_tuple_field
-                                                                                                      (M.read (|
-                                                                                                        other
-                                                                                                      |))
+                                                                                                      |),
                                                                                                       10
+                                                                                                    |);
+                                                                                                    M.SubPointer.get_tuple_field (|
+                                                                                                      M.read (|
+                                                                                                        other
+                                                                                                      |),
+                                                                                                      10
+                                                                                                    |)
                                                                                                   ]
                                                                                                 |)
                                                                                               |),
@@ -26024,16 +26884,18 @@ Module tuple.
                                                                                                           []
                                                                                                         |),
                                                                                                         [
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
                                                                                                               self
-                                                                                                            |))
-                                                                                                            11;
-                                                                                                          M.get_tuple_field
-                                                                                                            (M.read (|
-                                                                                                              other
-                                                                                                            |))
+                                                                                                            |),
                                                                                                             11
+                                                                                                          |);
+                                                                                                          M.SubPointer.get_tuple_field (|
+                                                                                                            M.read (|
+                                                                                                              other
+                                                                                                            |),
+                                                                                                            11
+                                                                                                          |)
                                                                                                         ]
                                                                                                       |)
                                                                                                     |)));
@@ -26300,18 +27162,18 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                    let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                    let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
-                    let γ0_3 := M.get_slice_index_or_break_match (| γ, 3 |) in
-                    let γ0_4 := M.get_slice_index_or_break_match (| γ, 4 |) in
-                    let γ0_5 := M.get_slice_index_or_break_match (| γ, 5 |) in
-                    let γ0_6 := M.get_slice_index_or_break_match (| γ, 6 |) in
-                    let γ0_7 := M.get_slice_index_or_break_match (| γ, 7 |) in
-                    let γ0_8 := M.get_slice_index_or_break_match (| γ, 8 |) in
-                    let γ0_9 := M.get_slice_index_or_break_match (| γ, 9 |) in
-                    let γ0_10 := M.get_slice_index_or_break_match (| γ, 10 |) in
-                    let γ0_11 := M.get_slice_index_or_break_match (| γ, 11 |) in
+                    (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_slice_index (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_slice_index (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_slice_index (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_slice_index (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_slice_index (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_slice_index (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_slice_index (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_slice_index (| γ, 10 |) in
+                    let γ0_11 := M.SubPointer.get_slice_index (| γ, 11 |) in
                     let value_E := M.copy (| γ0_0 |) in
                     let value_D := M.copy (| γ0_1 |) in
                     let value_C := M.copy (| γ0_2 |) in
@@ -26377,18 +27239,18 @@ Module tuple.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
-                    let γ0_2 := M.get_tuple_field γ 2 in
-                    let γ0_3 := M.get_tuple_field γ 3 in
-                    let γ0_4 := M.get_tuple_field γ 4 in
-                    let γ0_5 := M.get_tuple_field γ 5 in
-                    let γ0_6 := M.get_tuple_field γ 6 in
-                    let γ0_7 := M.get_tuple_field γ 7 in
-                    let γ0_8 := M.get_tuple_field γ 8 in
-                    let γ0_9 := M.get_tuple_field γ 9 in
-                    let γ0_10 := M.get_tuple_field γ 10 in
-                    let γ0_11 := M.get_tuple_field γ 11 in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                    let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                    let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
+                    let γ0_4 := M.SubPointer.get_tuple_field (| γ, 4 |) in
+                    let γ0_5 := M.SubPointer.get_tuple_field (| γ, 5 |) in
+                    let γ0_6 := M.SubPointer.get_tuple_field (| γ, 6 |) in
+                    let γ0_7 := M.SubPointer.get_tuple_field (| γ, 7 |) in
+                    let γ0_8 := M.SubPointer.get_tuple_field (| γ, 8 |) in
+                    let γ0_9 := M.SubPointer.get_tuple_field (| γ, 9 |) in
+                    let γ0_10 := M.SubPointer.get_tuple_field (| γ, 10 |) in
+                    let γ0_11 := M.SubPointer.get_tuple_field (| γ, 11 |) in
                     let value_E := M.copy (| γ0_0 |) in
                     let value_D := M.copy (| γ0_1 |) in
                     let value_C := M.copy (| γ0_2 |) in

--- a/CoqOfRust/core/unicode/printable.v
+++ b/CoqOfRust/core/unicode/printable.v
@@ -107,14 +107,14 @@ Module unicode.
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
                                             |) in
                                           let γ0_0 := M.read (| γ0_0 |) in
-                                          let γ2_0 := M.get_tuple_field γ0_0 0 in
-                                          let γ2_1 := M.get_tuple_field γ0_0 1 in
+                                          let γ2_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                          let γ2_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                           let upper := M.copy (| γ2_0 |) in
                                           let lowercount := M.copy (| γ2_1 |) in
                                           let lowerend :=
@@ -226,7 +226,7 @@ Module unicode.
                                                                         fun γ =>
                                                                           ltac:(M.monadic
                                                                             (let γ0_0 :=
-                                                                              M.get_struct_tuple_field_or_break_match (|
+                                                                              M.SubPointer.get_struct_tuple_field (|
                                                                                 γ,
                                                                                 "core::option::Option::Some",
                                                                                 0
@@ -377,7 +377,7 @@ Module unicode.
                                   |)
                                 |) in
                               let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
+                                M.SubPointer.get_struct_tuple_field (|
                                   γ,
                                   "core::option::Option::Some",
                                   0

--- a/CoqOfRust/core/unicode/unicode_data.v
+++ b/CoqOfRust/core/unicode/unicode_data.v
@@ -115,7 +115,10 @@ Module unicode.
                                 |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                            M.get_array_field (| M.read (| chunk_idx_map |), chunk_map_idx |)));
+                            M.SubPointer.get_array_field (|
+                              M.read (| chunk_idx_map |),
+                              chunk_map_idx
+                            |)));
                         fun γ =>
                           ltac:(M.monadic
                             (M.alloc (|
@@ -128,8 +131,8 @@ Module unicode.
                   M.alloc (|
                     M.rust_cast
                       (M.read (|
-                        M.get_array_field (|
-                          M.get_array_field (|
+                        M.SubPointer.get_array_field (|
+                          M.SubPointer.get_array_field (|
                             M.read (| bitset_chunk_idx |),
                             M.alloc (| M.rust_cast (M.read (| chunk_idx |)) |)
                           |),
@@ -163,11 +166,11 @@ Module unicode.
                                 |)) in
                             let _ :=
                               M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
-                            M.get_array_field (| M.read (| bitset_canonical |), idx |)));
+                            M.SubPointer.get_array_field (| M.read (| bitset_canonical |), idx |)));
                         fun γ =>
                           ltac:(M.monadic
                             (M.match_operator (|
-                              M.get_array_field (|
+                              M.SubPointer.get_array_field (|
                                 M.read (| bitset_canonicalized |),
                                 M.alloc (|
                                   BinOp.Panic.sub (|
@@ -189,13 +192,13 @@ Module unicode.
                               [
                                 fun γ =>
                                   ltac:(M.monadic
-                                    (let γ0_0 := M.get_tuple_field γ 0 in
-                                    let γ0_1 := M.get_tuple_field γ 1 in
+                                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                                     let real_idx := M.copy (| γ0_0 |) in
                                     let mapping := M.copy (| γ0_1 |) in
                                     let word :=
                                       M.copy (|
-                                        M.get_array_field (|
+                                        M.SubPointer.get_array_field (|
                                           M.read (| bitset_canonical |),
                                           M.alloc (| M.rust_cast (M.read (| real_idx |)) |)
                                         |)
@@ -457,7 +460,7 @@ Module unicode.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Ok",
                             0
@@ -469,7 +472,7 @@ Module unicode.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::result::Result::Err",
                             0
@@ -483,7 +486,11 @@ Module unicode.
               M.alloc (|
                 M.call_closure (|
                   M.get_function (| "core::unicode::unicode_data::decode_length", [] |),
-                  [ M.read (| M.get_array_field (| M.read (| short_offset_runs |), last_idx |) |) ]
+                  [
+                    M.read (|
+                      M.SubPointer.get_array_field (| M.read (| short_offset_runs |), last_idx |)
+                    |)
+                  ]
                 |)
               |) in
             let length :=
@@ -511,7 +518,7 @@ Module unicode.
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::option::Option::Some",
                             0
@@ -585,7 +592,7 @@ Module unicode.
                                           |),
                                           [
                                             M.read (|
-                                              M.get_array_field (|
+                                              M.SubPointer.get_array_field (|
                                                 M.read (| short_offset_runs |),
                                                 prev
                                               |)
@@ -662,14 +669,17 @@ Module unicode.
                                   fun γ =>
                                     ltac:(M.monadic
                                       (let γ0_0 :=
-                                        M.get_struct_tuple_field_or_break_match (|
+                                        M.SubPointer.get_struct_tuple_field (|
                                           γ,
                                           "core::option::Option::Some",
                                           0
                                         |) in
                                       let offset :=
                                         M.copy (|
-                                          M.get_array_field (| M.read (| offsets |), offset_idx |)
+                                          M.SubPointer.get_array_field (|
+                                            M.read (| offsets |),
+                                            offset_idx
+                                          |)
                                         |) in
                                       let _ :=
                                         let β := prefix_sum in
@@ -6452,7 +6462,7 @@ Module unicode.
                         BinOp.Pure.ne
                           (BinOp.Pure.bit_and
                             (M.read (|
-                              M.get_array_field (|
+                              M.SubPointer.get_array_field (|
                                 M.read (|
                                   M.get_constant (|
                                     "core::unicode::unicode_data::white_space::WHITESPACE_MAP"
@@ -6491,7 +6501,7 @@ Module unicode.
                         BinOp.Pure.ne
                           (BinOp.Pure.bit_and
                             (M.read (|
-                              M.get_array_field (|
+                              M.SubPointer.get_array_field (|
                                 M.read (|
                                   M.get_constant (|
                                     "core::unicode::unicode_data::white_space::WHITESPACE_MAP"
@@ -6649,8 +6659,10 @@ Module unicode.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ := M.read (| γ |) in
-                                                    let γ1_0 := M.get_tuple_field γ 0 in
-                                                    let γ1_1 := M.get_tuple_field γ 1 in
+                                                    let γ1_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ1_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let key := M.copy (| γ1_0 |) in
                                                     M.call_closure (|
                                                       M.get_trait_method (|
@@ -6682,8 +6694,8 @@ Module unicode.
                                                 M.read (|
                                                   let u :=
                                                     M.copy (|
-                                                      M.get_tuple_field
-                                                        (M.get_array_field (|
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (|
                                                             M.read (|
                                                               M.get_constant (|
@@ -6692,8 +6704,9 @@ Module unicode.
                                                             |)
                                                           |),
                                                           i
-                                                        |))
+                                                        |),
                                                         1
+                                                      |)
                                                     |) in
                                                   M.alloc (|
                                                     M.call_closure (|
@@ -6956,8 +6969,10 @@ Module unicode.
                                                 fun γ =>
                                                   ltac:(M.monadic
                                                     (let γ := M.read (| γ |) in
-                                                    let γ1_0 := M.get_tuple_field γ 0 in
-                                                    let γ1_1 := M.get_tuple_field γ 1 in
+                                                    let γ1_0 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 0 |) in
+                                                    let γ1_1 :=
+                                                      M.SubPointer.get_tuple_field (| γ, 1 |) in
                                                     let key := M.copy (| γ1_0 |) in
                                                     M.call_closure (|
                                                       M.get_trait_method (|
@@ -6989,8 +7004,8 @@ Module unicode.
                                                 M.read (|
                                                   let u :=
                                                     M.copy (|
-                                                      M.get_tuple_field
-                                                        (M.get_array_field (|
+                                                      M.SubPointer.get_tuple_field (|
+                                                        M.SubPointer.get_array_field (|
                                                           M.read (|
                                                             M.read (|
                                                               M.get_constant (|
@@ -6999,8 +7014,9 @@ Module unicode.
                                                             |)
                                                           |),
                                                           i
-                                                        |))
+                                                        |),
                                                         1
+                                                      |)
                                                     |) in
                                                   M.alloc (|
                                                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/custom/constructor_as_function.v
+++ b/CoqOfRust/examples/default/examples/custom/constructor_as_function.v
@@ -20,8 +20,8 @@ Definition matching (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -35,8 +35,8 @@ Definition matching (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Integer Integer.I32 0 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 M.alloc (| Value.Integer Integer.I32 1 |)))
           ]
         |)
@@ -73,7 +73,7 @@ Module Impl_core_fmt_Debug_for_constructor_as_function_Constructor.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "constructor_as_function::Constructor",
                   0

--- a/CoqOfRust/examples/default/examples/custom/constructor_as_function.v
+++ b/CoqOfRust/examples/default/examples/custom/constructor_as_function.v
@@ -20,8 +20,8 @@ Definition matching (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -35,8 +35,8 @@ Definition matching (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Integer Integer.I32 0 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 M.alloc (| Value.Integer Integer.I32 1 |)))
           ]
         |)
@@ -73,10 +73,11 @@ Module Impl_core_fmt_Debug_for_constructor_as_function_Constructor.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "constructor_as_function::Constructor"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "constructor_as_function::Constructor",
                   0
+                |)
               |))
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/custom/hello_world.v
+++ b/CoqOfRust/examples/default/examples/custom/hello_world.v
@@ -97,12 +97,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := number in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -159,12 +154,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := letter in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let j := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -254,12 +244,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ := emoticon in
-                let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let i := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=

--- a/CoqOfRust/examples/default/examples/custom/hello_world.v
+++ b/CoqOfRust/examples/default/examples/custom/hello_world.v
@@ -97,7 +97,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := number in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -154,7 +155,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := letter in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let j := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -244,7 +246,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ := emoticon in
-                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let i := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=

--- a/CoqOfRust/examples/default/examples/custom/if_let.v
+++ b/CoqOfRust/examples/default/examples/custom/if_let.v
@@ -74,21 +74,13 @@ Definition extract_value (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "if_let::Container::Left",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "if_let::Container::Left", 0 |) in
                         let value := M.copy (| γ0_0 |) in
                         Value.Tuple [ value ]));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "if_let::Container::Right",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "if_let::Container::Right", 0 |) in
                         let value := M.copy (| γ0_0 |) in
                         Value.Tuple [ value ]))
                   ],
@@ -152,12 +144,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := x in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -213,19 +200,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ := x in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -280,12 +257,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := x in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let γ :=
                     M.use
@@ -294,12 +266,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       |)) in
                   let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                   let γ := x in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let z := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -363,30 +330,15 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let γ := x in
-                let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let y := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| y |)) (Value.Integer Integer.I32 3) |) in
                 let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                 let γ := x in
-                let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let z := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/custom/if_let.v
+++ b/CoqOfRust/examples/default/examples/custom/if_let.v
@@ -74,13 +74,21 @@ Definition extract_value (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "if_let::Container::Left", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "if_let::Container::Left",
+                            0
+                          |) in
                         let value := M.copy (| γ0_0 |) in
                         Value.Tuple [ value ]));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "if_let::Container::Right", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "if_let::Container::Right",
+                            0
+                          |) in
                         let value := M.copy (| γ0_0 |) in
                         Value.Tuple [ value ]))
                   ],
@@ -144,7 +152,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := x in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -200,9 +209,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ := x in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -257,7 +268,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := x in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let y := M.copy (| γ0_0 |) in
                   let γ :=
                     M.use
@@ -266,7 +278,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       |)) in
                   let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                   let γ := x in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let z := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -330,15 +343,18 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let γ := x in
-                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let y := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| y |)) (Value.Integer Integer.I32 3) |) in
                 let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
                 let γ := x in
-                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let z := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/custom/pattern_in_function_parameters.v
+++ b/CoqOfRust/examples/default/examples/custom/pattern_in_function_parameters.v
@@ -16,8 +16,8 @@ Definition sum (τ : list Ty.t) (α : list Value.t) : M :=
         [
           fun γ =>
             ltac:(M.monadic
-              (let γ0_0 := M.get_tuple_field γ 0 in
-              let γ0_1 := M.get_tuple_field γ 1 in
+              (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+              let γ0_1 := M.get_tuple_field (| γ, 1 |) in
               let x := M.copy (| γ0_0 |) in
               let y := M.copy (| γ0_1 |) in
               BinOp.Panic.add (| M.read (| x |), M.read (| y |) |)))

--- a/CoqOfRust/examples/default/examples/custom/pattern_in_function_parameters.v
+++ b/CoqOfRust/examples/default/examples/custom/pattern_in_function_parameters.v
@@ -16,8 +16,8 @@ Definition sum (τ : list Ty.t) (α : list Value.t) : M :=
         [
           fun γ =>
             ltac:(M.monadic
-              (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-              let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+              (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+              let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
               let x := M.copy (| γ0_0 |) in
               let y := M.copy (| γ0_1 |) in
               BinOp.Panic.add (| M.read (| x |), M.read (| y |) |)))

--- a/CoqOfRust/examples/default/examples/custom/polymorphic_associated_function.v
+++ b/CoqOfRust/examples/default/examples/custom/polymorphic_associated_function.v
@@ -33,7 +33,7 @@ Module Impl_polymorphic_associated_function_Foo_A.
                 M.get_trait_method (| "core::convert::Into", A, [ B ], "into", [] |),
                 [
                   M.read (|
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       self,
                       "polymorphic_associated_function::Foo",
                       "data"
@@ -85,7 +85,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             M.alloc (|
               Value.Tuple
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     bar,
                     "polymorphic_associated_function::Foo",
                     "data"
@@ -96,8 +96,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/custom/polymorphic_associated_function.v
+++ b/CoqOfRust/examples/default/examples/custom/polymorphic_associated_function.v
@@ -33,7 +33,11 @@ Module Impl_polymorphic_associated_function_Foo_A.
                 M.get_trait_method (| "core::convert::Into", A, [ B ], "into", [] |),
                 [
                   M.read (|
-                    M.get_struct_record_field self "polymorphic_associated_function::Foo" "data"
+                    M.get_struct_record_field (|
+                      self,
+                      "polymorphic_associated_function::Foo",
+                      "data"
+                    |)
                   |)
                 ]
               |))
@@ -81,15 +85,19 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             M.alloc (|
               Value.Tuple
                 [
-                  M.get_struct_record_field bar "polymorphic_associated_function::Foo" "data";
+                  M.get_struct_record_field (|
+                    bar,
+                    "polymorphic_associated_function::Foo",
+                    "data"
+                  |);
                   UnsupportedLiteral
                 ]
             |),
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/custom/provided_method.v
+++ b/CoqOfRust/examples/default/examples/custom/provided_method.v
@@ -130,8 +130,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -202,8 +202,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/custom/provided_method.v
+++ b/CoqOfRust/examples/default/examples/custom/provided_method.v
@@ -130,8 +130,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -202,8 +202,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/ink_contracts/basic_contract_caller.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/basic_contract_caller.v
@@ -120,14 +120,14 @@ Module Impl_basic_contract_caller_OtherContract.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "basic_contract_caller::OtherContract",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "basic_contract_caller::OtherContract",
                     "value"
@@ -152,7 +152,7 @@ Module Impl_basic_contract_caller_OtherContract.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "basic_contract_caller::OtherContract",
             "value"
@@ -233,7 +233,7 @@ Module Impl_basic_contract_caller_BasicContractCaller.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "basic_contract_caller::BasicContractCaller",
                     "other_contract"
@@ -249,7 +249,7 @@ Module Impl_basic_contract_caller_BasicContractCaller.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "basic_contract_caller::BasicContractCaller",
                   "other_contract"

--- a/CoqOfRust/examples/default/examples/ink_contracts/basic_contract_caller.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/basic_contract_caller.v
@@ -120,16 +120,18 @@ Module Impl_basic_contract_caller_OtherContract.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "basic_contract_caller::OtherContract"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "basic_contract_caller::OtherContract",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "basic_contract_caller::OtherContract"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "basic_contract_caller::OtherContract",
                     "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -150,10 +152,11 @@ Module Impl_basic_contract_caller_OtherContract.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "basic_contract_caller::OtherContract"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "basic_contract_caller::OtherContract",
             "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -230,10 +233,11 @@ Module Impl_basic_contract_caller_BasicContractCaller.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "basic_contract_caller::BasicContractCaller"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "basic_contract_caller::BasicContractCaller",
                     "other_contract"
+                  |)
                 ]
               |)
             |) in
@@ -245,10 +249,11 @@ Module Impl_basic_contract_caller_BasicContractCaller.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "basic_contract_caller::BasicContractCaller"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "basic_contract_caller::BasicContractCaller",
                   "other_contract"
+                |)
               ]
             |)
           |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/conditional_compilation.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/conditional_compilation.v
@@ -136,7 +136,11 @@ Module Impl_conditional_compilation_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "conditional_compilation::Env" "caller"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "conditional_compilation::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -307,16 +311,18 @@ Module Impl_conditional_compilation_ConditionalCompilation.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "conditional_compilation::ConditionalCompilation"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "conditional_compilation::ConditionalCompilation",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "conditional_compilation::ConditionalCompilation"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "conditional_compilation::ConditionalCompilation",
                     "value"
+                  |)
                 |))
             |) in
           let caller :=
@@ -368,10 +374,11 @@ Module Impl_conditional_compilation_ConditionalCompilation.
                         [
                           ("new_value",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "conditional_compilation::ConditionalCompilation"
+                              M.get_struct_record_field (|
+                                M.read (| self |),
+                                "conditional_compilation::ConditionalCompilation",
                                 "value"
+                              |)
                             |));
                           ("by_", M.read (| caller |))
                         ]
@@ -451,16 +458,18 @@ Module Impl_conditional_compilation_ConditionalCompilation.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "conditional_compilation::ConditionalCompilation"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "conditional_compilation::ConditionalCompilation",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "conditional_compilation::ConditionalCompilation"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "conditional_compilation::ConditionalCompilation",
                     "value"
+                  |)
                 |))
             |) in
           let _ :=
@@ -490,10 +499,11 @@ Module Impl_conditional_compilation_ConditionalCompilation.
                         [
                           ("new_value",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "conditional_compilation::ConditionalCompilation"
+                              M.get_struct_record_field (|
+                                M.read (| self |),
+                                "conditional_compilation::ConditionalCompilation",
                                 "value"
+                              |)
                             |));
                           ("by_", M.read (| caller |));
                           ("when", M.read (| block_number |))
@@ -527,16 +537,18 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "conditional_compilation::ConditionalCompilation"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "conditional_compilation::ConditionalCompilation",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "conditional_compilation::ConditionalCompilation"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "conditional_compilation::ConditionalCompilation",
                     "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -555,10 +567,11 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "conditional_compilation::ConditionalCompilation"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "conditional_compilation::ConditionalCompilation",
             "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -633,10 +646,11 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "conditional_compilation::ConditionalCompilation"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "conditional_compilation::ConditionalCompilation",
+                "value"
+              |),
               M.read (| value |)
             |) in
           M.alloc (| Value.Tuple [] |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/conditional_compilation.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/conditional_compilation.v
@@ -136,7 +136,7 @@ Module Impl_conditional_compilation_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "conditional_compilation::Env",
             "caller"
@@ -311,14 +311,14 @@ Module Impl_conditional_compilation_ConditionalCompilation.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "conditional_compilation::ConditionalCompilation",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "conditional_compilation::ConditionalCompilation",
                     "value"
@@ -374,7 +374,7 @@ Module Impl_conditional_compilation_ConditionalCompilation.
                         [
                           ("new_value",
                             M.read (|
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 M.read (| self |),
                                 "conditional_compilation::ConditionalCompilation",
                                 "value"
@@ -458,14 +458,14 @@ Module Impl_conditional_compilation_ConditionalCompilation.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "conditional_compilation::ConditionalCompilation",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "conditional_compilation::ConditionalCompilation",
                     "value"
@@ -499,7 +499,7 @@ Module Impl_conditional_compilation_ConditionalCompilation.
                         [
                           ("new_value",
                             M.read (|
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 M.read (| self |),
                                 "conditional_compilation::ConditionalCompilation",
                                 "value"
@@ -537,14 +537,14 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "conditional_compilation::ConditionalCompilation",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "conditional_compilation::ConditionalCompilation",
                     "value"
@@ -567,7 +567,7 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "conditional_compilation::ConditionalCompilation",
             "value"
@@ -646,7 +646,7 @@ Module Impl_conditional_compilation_Flip_for_conditional_compilation_Conditional
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "conditional_compilation::ConditionalCompilation",
                 "value"

--- a/CoqOfRust/examples/default/examples/ink_contracts/contract_terminate.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/contract_terminate.v
@@ -89,7 +89,11 @@ Module Impl_contract_terminate_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "contract_terminate::Env", "caller" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "contract_terminate::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/contract_terminate.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/contract_terminate.v
@@ -89,7 +89,7 @@ Module Impl_contract_terminate_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "contract_terminate::Env" "caller"
+          M.get_struct_record_field (| M.read (| self |), "contract_terminate::Env", "caller" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/contract_transfer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/contract_transfer.v
@@ -91,7 +91,11 @@ Module Impl_contract_transfer_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "contract_transfer::Env", "caller" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "contract_transfer::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/contract_transfer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/contract_transfer.v
@@ -91,7 +91,7 @@ Module Impl_contract_transfer_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "contract_transfer::Env" "caller"
+          M.get_struct_record_field (| M.read (| self |), "contract_transfer::Env", "caller" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/custom_allocator.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/custom_allocator.v
@@ -110,7 +110,7 @@ Module Impl_custom_allocator_CustomAllocator.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "custom_allocator::CustomAllocator",
                     "value"
@@ -131,7 +131,7 @@ Module Impl_custom_allocator_CustomAllocator.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "custom_allocator::CustomAllocator",
                         "value"
@@ -170,7 +170,7 @@ Module Impl_custom_allocator_CustomAllocator.
               []
             |),
             [
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "custom_allocator::CustomAllocator",
                 "value"

--- a/CoqOfRust/examples/default/examples/ink_contracts/custom_allocator.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/custom_allocator.v
@@ -110,10 +110,11 @@ Module Impl_custom_allocator_CustomAllocator.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "custom_allocator::CustomAllocator"
-                    "value";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "custom_allocator::CustomAllocator",
+                    "value"
+                  |);
                   Value.Integer Integer.Usize 0
                 ]
               |),
@@ -130,10 +131,11 @@ Module Impl_custom_allocator_CustomAllocator.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "custom_allocator::CustomAllocator"
-                        "value";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "custom_allocator::CustomAllocator",
+                        "value"
+                      |);
                       Value.Integer Integer.Usize 0
                     ]
                   |)
@@ -168,10 +170,11 @@ Module Impl_custom_allocator_CustomAllocator.
               []
             |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "custom_allocator::CustomAllocator"
-                "value";
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "custom_allocator::CustomAllocator",
+                "value"
+              |);
               Value.Integer Integer.Usize 0
             ]
           |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/custom_environment.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/custom_environment.v
@@ -223,7 +223,11 @@ Module Impl_custom_environment_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "custom_environment::Env", "caller" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "custom_environment::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/custom_environment.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/custom_environment.v
@@ -223,7 +223,7 @@ Module Impl_custom_environment_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "custom_environment::Env" "caller"
+          M.get_struct_record_field (| M.read (| self |), "custom_environment::Env", "caller" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/dns.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/dns.v
@@ -229,8 +229,8 @@ Module Impl_core_cmp_PartialEq_for_dns_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "dns::AccountId" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "dns::AccountId" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "dns::AccountId", 0 |) |))
+          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "dns::AccountId", 0 |) |))))
     | _, _ => M.impossible
     end.
   
@@ -343,7 +343,7 @@ Module Impl_dns_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "dns::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "dns::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -751,10 +751,11 @@ Module Impl_dns_DomainNameService.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "dns::DomainNameService"
-                                    "name_to_owner";
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "dns::DomainNameService",
+                                    "name_to_owner"
+                                  |);
                                   name
                                 ]
                               |)
@@ -786,10 +787,11 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "dns::DomainNameService"
-                        "name_to_owner";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "dns::DomainNameService",
+                        "name_to_owner"
+                      |);
                       M.read (| name |);
                       M.read (| caller |)
                     ]
@@ -857,18 +859,20 @@ Module Impl_dns_DomainNameService.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "dns::DomainNameService"
-                  "name_to_owner";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "dns::DomainNameService",
+                  "name_to_owner"
+                |);
                 name
               ]
             |);
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "dns::DomainNameService"
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "dns::DomainNameService",
                 "default_address"
+              |)
             |)
           ]
         |)))
@@ -984,10 +988,11 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "dns::DomainNameService"
-                        "name_to_address";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "dns::DomainNameService",
+                        "name_to_address"
+                      |);
                       name
                     ]
                   |)
@@ -1003,10 +1008,11 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "dns::DomainNameService"
-                        "name_to_address";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "dns::DomainNameService",
+                        "name_to_address"
+                      |);
                       M.read (| name |);
                       M.read (| new_address |)
                     ]
@@ -1157,10 +1163,11 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "dns::DomainNameService"
-                        "name_to_owner";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "dns::DomainNameService",
+                        "name_to_owner"
+                      |);
                       name
                     ]
                   |)
@@ -1176,10 +1183,11 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "dns::DomainNameService"
-                        "name_to_owner";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "dns::DomainNameService",
+                        "name_to_owner"
+                      |);
                       M.read (| name |);
                       M.read (| to |)
                     ]
@@ -1252,18 +1260,20 @@ Module Impl_dns_DomainNameService.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "dns::DomainNameService"
-                  "name_to_address";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "dns::DomainNameService",
+                  "name_to_address"
+                |);
                 name
               ]
             |);
             M.read (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "dns::DomainNameService"
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "dns::DomainNameService",
                 "default_address"
+              |)
             |)
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/ink_contracts/dns.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/dns.v
@@ -229,8 +229,12 @@ Module Impl_core_cmp_PartialEq_for_dns_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "dns::AccountId", 0 |) |))
-          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "dns::AccountId", 0 |) |))))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "dns::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "dns::AccountId", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -343,7 +347,9 @@ Module Impl_dns_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "dns::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "dns::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -751,7 +757,7 @@ Module Impl_dns_DomainNameService.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "dns::DomainNameService",
                                     "name_to_owner"
@@ -787,7 +793,7 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "dns::DomainNameService",
                         "name_to_owner"
@@ -859,7 +865,7 @@ Module Impl_dns_DomainNameService.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "dns::DomainNameService",
                   "name_to_owner"
@@ -868,7 +874,7 @@ Module Impl_dns_DomainNameService.
               ]
             |);
             M.read (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "dns::DomainNameService",
                 "default_address"
@@ -988,7 +994,7 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "dns::DomainNameService",
                         "name_to_address"
@@ -1008,7 +1014,7 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "dns::DomainNameService",
                         "name_to_address"
@@ -1163,7 +1169,7 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "dns::DomainNameService",
                         "name_to_owner"
@@ -1183,7 +1189,7 @@ Module Impl_dns_DomainNameService.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "dns::DomainNameService",
                         "name_to_owner"
@@ -1260,7 +1266,7 @@ Module Impl_dns_DomainNameService.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "dns::DomainNameService",
                   "name_to_address"
@@ -1269,7 +1275,7 @@ Module Impl_dns_DomainNameService.
               ]
             |);
             M.read (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "dns::DomainNameService",
                 "default_address"

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
@@ -218,9 +218,11 @@ Module Impl_core_cmp_PartialEq_for_erc1155_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "erc1155::AccountId", 0 |) |))
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| other |), "erc1155::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "erc1155::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "erc1155::AccountId", 0 |)
           |))))
     | _, _ => M.impossible
     end.
@@ -524,7 +526,9 @@ Module Impl_erc1155_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "erc1155::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "erc1155::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -721,7 +725,7 @@ Module Impl_erc1155_Contract.
             |) in
           let _ :=
             let β :=
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "erc1155::Contract",
                 "token_id_nonce"
@@ -738,7 +742,7 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "erc1155::Contract",
                     "balances"
@@ -747,7 +751,7 @@ Module Impl_erc1155_Contract.
                     [
                       M.read (| caller |);
                       M.read (|
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "erc1155::Contract",
                           "token_id_nonce"
@@ -812,7 +816,7 @@ Module Impl_erc1155_Contract.
                             |));
                           ("token_id",
                             M.read (|
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 M.read (| self |),
                                 "erc1155::Contract",
                                 "token_id_nonce"
@@ -824,7 +828,11 @@ Module Impl_erc1155_Contract.
                 ]
               |)
             |) in
-          M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "token_id_nonce" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "erc1155::Contract",
+            "token_id_nonce"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -873,7 +881,7 @@ Module Impl_erc1155_Contract.
                                 (BinOp.Pure.le
                                   (M.read (| token_id |))
                                   (M.read (|
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "erc1155::Contract",
                                       "token_id_nonce"
@@ -933,7 +941,7 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "erc1155::Contract",
                         "balances"
@@ -1042,7 +1050,7 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "erc1155::Contract",
                         "balances"
@@ -1070,7 +1078,7 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "erc1155::Contract",
                     "balances"
@@ -1099,7 +1107,7 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "erc1155::Contract",
                         "balances"
@@ -1125,7 +1133,7 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "erc1155::Contract",
                     "balances"
@@ -1304,7 +1312,11 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
             []
           |),
           [
-            M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "approvals" |);
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "erc1155::Contract",
+              "approvals"
+            |);
             M.alloc (| Value.Tuple [ M.read (| owner |); M.read (| operator |) ] |)
           ]
         |)))
@@ -1339,7 +1351,11 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "balances" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "erc1155::Contract",
+                  "balances"
+                |);
                 M.alloc (| Value.Tuple [ M.read (| owner |); M.read (| token_id |) ] |)
               ]
             |);
@@ -2076,13 +2092,13 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let γ1_0 := M.read (| γ1_0 |) in
                                         let id := M.copy (| γ1_0 |) in
                                         let γ1_1 := M.read (| γ1_1 |) in
@@ -2218,13 +2234,13 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let γ1_0 := M.read (| γ1_0 |) in
                                         let id := M.copy (| γ1_0 |) in
                                         let γ1_1 := M.read (| γ1_1 |) in
@@ -2387,7 +2403,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -2447,7 +2463,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field (|
+                                                              M.SubPointer.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -2622,7 +2638,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc1155::Contract",
                                   "approvals"
@@ -2651,7 +2667,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc1155::Contract",
                                   "approvals"

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc1155.v
@@ -218,8 +218,10 @@ Module Impl_core_cmp_PartialEq_for_erc1155_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "erc1155::AccountId" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "erc1155::AccountId" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "erc1155::AccountId", 0 |) |))
+          (M.read (|
+            M.get_struct_tuple_field (| M.read (| other |), "erc1155::AccountId", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -522,7 +524,7 @@ Module Impl_erc1155_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "erc1155::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "erc1155::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -719,7 +721,11 @@ Module Impl_erc1155_Contract.
             |) in
           let _ :=
             let β :=
-              M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "token_id_nonce" in
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "erc1155::Contract",
+                "token_id_nonce"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.U128 1 |) |) in
           let _ :=
             M.alloc (|
@@ -732,15 +738,20 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "erc1155::Contract",
+                    "balances"
+                  |);
                   Value.Tuple
                     [
                       M.read (| caller |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "erc1155::Contract"
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "erc1155::Contract",
                           "token_id_nonce"
+                        |)
                       |)
                     ];
                   M.read (| value |)
@@ -801,10 +812,11 @@ Module Impl_erc1155_Contract.
                             |));
                           ("token_id",
                             M.read (|
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "erc1155::Contract"
+                              M.get_struct_record_field (|
+                                M.read (| self |),
+                                "erc1155::Contract",
                                 "token_id_nonce"
+                              |)
                             |));
                           ("value", M.read (| value |))
                         ]
@@ -812,7 +824,7 @@ Module Impl_erc1155_Contract.
                 ]
               |)
             |) in
-          M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "token_id_nonce"
+          M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "token_id_nonce" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -861,10 +873,11 @@ Module Impl_erc1155_Contract.
                                 (BinOp.Pure.le
                                   (M.read (| token_id |))
                                   (M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "erc1155::Contract"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "erc1155::Contract",
                                       "token_id_nonce"
+                                    |)
                                   |)))
                             |)) in
                         let _ :=
@@ -920,7 +933,11 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc1155::Contract",
+                        "balances"
+                      |);
                       Value.Tuple [ M.read (| caller |); M.read (| token_id |) ];
                       M.read (| value |)
                     ]
@@ -1025,7 +1042,11 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc1155::Contract",
+                        "balances"
+                      |);
                       M.alloc (| Value.Tuple [ M.read (| from |); M.read (| token_id |) ] |)
                     ]
                   |);
@@ -1049,7 +1070,11 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "erc1155::Contract",
+                    "balances"
+                  |);
                   Value.Tuple [ M.read (| from |); M.read (| token_id |) ];
                   M.read (| sender_balance |)
                 ]
@@ -1074,7 +1099,11 @@ Module Impl_erc1155_Contract.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc1155::Contract",
+                        "balances"
+                      |);
                       M.alloc (| Value.Tuple [ M.read (| to |); M.read (| token_id |) ] |)
                     ]
                   |);
@@ -1096,7 +1125,11 @@ Module Impl_erc1155_Contract.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "erc1155::Contract",
+                    "balances"
+                  |);
                   Value.Tuple [ M.read (| to |); M.read (| token_id |) ];
                   M.read (| recipient_balance |)
                 ]
@@ -1271,7 +1304,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
             []
           |),
           [
-            M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "approvals";
+            M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "approvals" |);
             M.alloc (| Value.Tuple [ M.read (| owner |); M.read (| operator |) ] |)
           ]
         |)))
@@ -1306,7 +1339,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "erc1155::Contract" "balances";
+                M.get_struct_record_field (| M.read (| self |), "erc1155::Contract", "balances" |);
                 M.alloc (| Value.Tuple [ M.read (| owner |); M.read (| token_id |) ] |)
               ]
             |);
@@ -2043,13 +2076,13 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                         let γ1_0 := M.read (| γ1_0 |) in
                                         let id := M.copy (| γ1_0 |) in
                                         let γ1_1 := M.read (| γ1_1 |) in
@@ -2185,13 +2218,13 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                         let γ1_0 := M.read (| γ1_0 |) in
                                         let id := M.copy (| γ1_0 |) in
                                         let γ1_1 := M.read (| γ1_1 |) in
@@ -2354,7 +2387,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -2414,7 +2447,7 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                                         fun γ =>
                                                           ltac:(M.monadic
                                                             (let γ0_0 :=
-                                                              M.get_struct_tuple_field_or_break_match (|
+                                                              M.get_struct_tuple_field (|
                                                                 γ,
                                                                 "core::option::Option::Some",
                                                                 0
@@ -2589,10 +2622,11 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc1155::Contract"
-                                  "approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc1155::Contract",
+                                  "approvals"
+                                |);
                                 Value.Tuple [ M.read (| caller |); M.read (| operator |) ];
                                 Value.Tuple []
                               ]
@@ -2617,10 +2651,11 @@ Module Impl_erc1155_Erc1155_for_erc1155_Contract.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc1155::Contract"
-                                  "approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc1155::Contract",
+                                  "approvals"
+                                |);
                                 Value.Tuple [ M.read (| caller |); M.read (| operator |) ]
                               ]
                             |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
@@ -322,7 +322,9 @@ Module Impl_erc20_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "erc20::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "erc20::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -500,7 +502,11 @@ Module Impl_erc20_Erc20.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "total_supply" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "erc20::Erc20",
+            "total_supply"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -532,7 +538,11 @@ Module Impl_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "erc20::Erc20",
+                  "balances"
+                |);
                 M.read (| owner |)
               ]
             |)
@@ -595,7 +605,11 @@ Module Impl_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "allowances" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "erc20::Erc20",
+                  "allowances"
+                |);
                 M.alloc (|
                   Value.Tuple [ M.read (| M.read (| owner |) |); M.read (| M.read (| spender |) |) ]
                 |)
@@ -704,7 +718,11 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc20::Erc20",
+                        "balances"
+                      |);
                       M.read (| M.read (| from |) |);
                       BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
                     ]
@@ -728,7 +746,11 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc20::Erc20",
+                        "balances"
+                      |);
                       M.read (| M.read (| to |) |);
                       BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
                     ]
@@ -862,7 +884,11 @@ Module Impl_erc20_Erc20.
                   []
                 |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "allowances" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "erc20::Erc20",
+                    "allowances"
+                  |);
                   Value.Tuple [ M.read (| owner |); M.read (| spender |) ];
                   M.read (| value |)
                 ]
@@ -1000,7 +1026,7 @@ Module Impl_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1036,7 +1062,7 @@ Module Impl_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1059,7 +1085,7 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "erc20::Erc20",
                         "allowances"

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc20.v
@@ -322,7 +322,7 @@ Module Impl_erc20_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "erc20::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "erc20::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -499,7 +499,9 @@ Module Impl_erc20_Erc20.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "total_supply" |)))
+        M.read (|
+          M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "total_supply" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -530,7 +532,7 @@ Module Impl_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
+                M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
                 M.read (| owner |)
               ]
             |)
@@ -593,7 +595,7 @@ Module Impl_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "allowances";
+                M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "allowances" |);
                 M.alloc (|
                   Value.Tuple [ M.read (| M.read (| owner |) |); M.read (| M.read (| spender |) |) ]
                 |)
@@ -702,7 +704,7 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
+                      M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
                       M.read (| M.read (| from |) |);
                       BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
                     ]
@@ -726,7 +728,7 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "balances";
+                      M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "balances" |);
                       M.read (| M.read (| to |) |);
                       BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
                     ]
@@ -860,7 +862,7 @@ Module Impl_erc20_Erc20.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "allowances";
+                  M.get_struct_record_field (| M.read (| self |), "erc20::Erc20", "allowances" |);
                   Value.Tuple [ M.read (| owner |); M.read (| spender |) ];
                   M.read (| value |)
                 ]
@@ -998,7 +1000,7 @@ Module Impl_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1034,7 +1036,7 @@ Module Impl_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1057,7 +1059,11 @@ Module Impl_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "erc20::Erc20" "allowances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "erc20::Erc20",
+                        "allowances"
+                      |);
                       Value.Tuple [ M.read (| from |); M.read (| caller |) ];
                       BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
                     ]

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
@@ -218,8 +218,8 @@ Module Impl_core_cmp_PartialEq_for_erc721_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "erc721::AccountId" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "erc721::AccountId" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "erc721::AccountId", 0 |) |))
+          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "erc721::AccountId", 0 |) |))))
     | _, _ => M.impossible
     end.
   
@@ -592,7 +592,7 @@ Module Impl_erc721_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "erc721::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "erc721::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -688,7 +688,11 @@ Module Impl_erc721_Erc721.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "owned_tokens_count";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "erc721::Erc721",
+                  "owned_tokens_count"
+                |);
                 M.read (| of |)
               ]
             |);
@@ -724,7 +728,11 @@ Module Impl_erc721_Erc721.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "token_approvals";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "erc721::Erc721",
+                    "token_approvals"
+                  |);
                   M.read (| id |)
                 ]
               |)
@@ -759,7 +767,11 @@ Module Impl_erc721_Erc721.
             []
           |),
           [
-            M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "operator_approvals";
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "erc721::Erc721",
+              "operator_approvals"
+            |);
             M.alloc (| Value.Tuple [ M.read (| owner |); M.read (| operator |) ] |)
           ]
         |)))
@@ -786,7 +798,7 @@ Module Impl_erc721_Erc721.
             "get",
             []
           |),
-          [ M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "token_owner"; id ]
+          [ M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_owner" |); id ]
         |)))
     | _, _ => M.impossible
     end.
@@ -889,10 +901,11 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc721::Erc721"
-                                  "token_approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc721::Erc721",
+                                  "token_approvals"
+                                |);
                                 id
                               ]
                             |)
@@ -958,7 +971,7 @@ Module Impl_erc721_Erc721.
             "contains",
             []
           |),
-          [ M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "token_owner"; id ]
+          [ M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_owner" |); id ]
         |)))
     | _, _ => M.impossible
     end.
@@ -1002,7 +1015,10 @@ Module Impl_erc721_Erc721.
             "get",
             []
           |),
-          [ M.get_struct_record_field (M.read (| self |)) "erc721::Erc721" "token_approvals"; id ]
+          [
+            M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_approvals" |);
+            id
+          ]
         |)))
     | _, _ => M.impossible
     end.
@@ -1161,10 +1177,11 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc721::Erc721"
-                                  "operator_approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc721::Erc721",
+                                  "operator_approvals"
+                                |);
                                 Value.Tuple [ M.read (| caller |); M.read (| to |) ];
                                 Value.Tuple []
                               ]
@@ -1188,10 +1205,11 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc721::Erc721"
-                                  "operator_approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc721::Erc721",
+                                  "operator_approvals"
+                                |);
                                 Value.Tuple [ M.read (| caller |); M.read (| to |) ]
                               ]
                             |)
@@ -1253,7 +1271,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1289,7 +1307,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1512,10 +1530,11 @@ Module Impl_erc721_Erc721.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "erc721::Erc721"
-                                    "token_approvals";
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "erc721::Erc721",
+                                    "token_approvals"
+                                  |);
                                   id
                                 ]
                               |)
@@ -1546,10 +1565,11 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "erc721::Erc721"
-                                  "token_approvals";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "erc721::Erc721",
+                                  "token_approvals"
+                                |);
                                 M.read (| id |);
                                 M.read (| M.read (| to |) |)
                               ]
@@ -1636,7 +1656,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1672,7 +1692,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1728,17 +1748,9 @@ Module Impl_erc721_Erc721.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_record_field_or_break_match (|
-                          γ,
-                          "erc721::Erc721",
-                          "token_owner"
-                        |) in
+                        M.get_struct_record_field (| γ, "erc721::Erc721", "token_owner" |) in
                       let γ1_1 :=
-                        M.get_struct_record_field_or_break_match (|
-                          γ,
-                          "erc721::Erc721",
-                          "owned_tokens_count"
-                        |) in
+                        M.get_struct_record_field (| γ, "erc721::Erc721", "owned_tokens_count" |) in
                       let token_owner := M.alloc (| γ1_0 |) in
                       let owned_tokens_count := M.alloc (| γ1_1 |) in
                       let _ :=
@@ -1863,7 +1875,7 @@ Module Impl_erc721_Erc721.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1899,7 +1911,7 @@ Module Impl_erc721_Erc721.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2073,7 +2085,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2109,7 +2121,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2177,7 +2189,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2213,7 +2225,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2295,7 +2307,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2331,7 +2343,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0

--- a/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/erc721.v
@@ -218,8 +218,12 @@ Module Impl_core_cmp_PartialEq_for_erc721_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "erc721::AccountId", 0 |) |))
-          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "erc721::AccountId", 0 |) |))))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "erc721::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "erc721::AccountId", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -592,7 +596,9 @@ Module Impl_erc721_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "erc721::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "erc721::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -688,7 +694,7 @@ Module Impl_erc721_Erc721.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "erc721::Erc721",
                   "owned_tokens_count"
@@ -728,7 +734,7 @@ Module Impl_erc721_Erc721.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "erc721::Erc721",
                     "token_approvals"
@@ -767,7 +773,7 @@ Module Impl_erc721_Erc721.
             []
           |),
           [
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "erc721::Erc721",
               "operator_approvals"
@@ -798,7 +804,14 @@ Module Impl_erc721_Erc721.
             "get",
             []
           |),
-          [ M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_owner" |); id ]
+          [
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "erc721::Erc721",
+              "token_owner"
+            |);
+            id
+          ]
         |)))
     | _, _ => M.impossible
     end.
@@ -901,7 +914,7 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc721::Erc721",
                                   "token_approvals"
@@ -971,7 +984,14 @@ Module Impl_erc721_Erc721.
             "contains",
             []
           |),
-          [ M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_owner" |); id ]
+          [
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "erc721::Erc721",
+              "token_owner"
+            |);
+            id
+          ]
         |)))
     | _, _ => M.impossible
     end.
@@ -1016,7 +1036,11 @@ Module Impl_erc721_Erc721.
             []
           |),
           [
-            M.get_struct_record_field (| M.read (| self |), "erc721::Erc721", "token_approvals" |);
+            M.SubPointer.get_struct_record_field (|
+              M.read (| self |),
+              "erc721::Erc721",
+              "token_approvals"
+            |);
             id
           ]
         |)))
@@ -1177,7 +1201,7 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc721::Erc721",
                                   "operator_approvals"
@@ -1205,7 +1229,7 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc721::Erc721",
                                   "operator_approvals"
@@ -1271,7 +1295,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1307,7 +1331,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1530,7 +1554,7 @@ Module Impl_erc721_Erc721.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "erc721::Erc721",
                                     "token_approvals"
@@ -1565,7 +1589,7 @@ Module Impl_erc721_Erc721.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "erc721::Erc721",
                                   "token_approvals"
@@ -1656,7 +1680,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1692,7 +1716,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1748,9 +1772,17 @@ Module Impl_erc721_Erc721.
                     ltac:(M.monadic
                       (let γ := M.read (| γ |) in
                       let γ1_0 :=
-                        M.get_struct_record_field (| γ, "erc721::Erc721", "token_owner" |) in
+                        M.SubPointer.get_struct_record_field (|
+                          γ,
+                          "erc721::Erc721",
+                          "token_owner"
+                        |) in
                       let γ1_1 :=
-                        M.get_struct_record_field (| γ, "erc721::Erc721", "owned_tokens_count" |) in
+                        M.SubPointer.get_struct_record_field (|
+                          γ,
+                          "erc721::Erc721",
+                          "owned_tokens_count"
+                        |) in
                       let token_owner := M.alloc (| γ1_0 |) in
                       let owned_tokens_count := M.alloc (| γ1_1 |) in
                       let _ :=
@@ -1875,7 +1907,7 @@ Module Impl_erc721_Erc721.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Break",
                                       0
@@ -1911,7 +1943,7 @@ Module Impl_erc721_Erc721.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::ops::control_flow::ControlFlow::Continue",
                                       0
@@ -2085,7 +2117,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2121,7 +2153,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2189,7 +2221,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2225,7 +2257,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -2307,7 +2339,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -2343,7 +2375,7 @@ Module Impl_erc721_Erc721.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0

--- a/CoqOfRust/examples/default/examples/ink_contracts/flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/flipper.v
@@ -63,10 +63,10 @@ Module Impl_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "flipper::Flipper" "value",
+              M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "flipper::Flipper" "value"
+                  M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -86,7 +86,9 @@ Module Impl_flipper_Flipper.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "flipper::Flipper" "value" |)))
+        M.read (|
+          M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |)
+        |)))
     | _, _ => M.impossible
     end.
   

--- a/CoqOfRust/examples/default/examples/ink_contracts/flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/flipper.v
@@ -63,10 +63,18 @@ Module Impl_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |),
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "flipper::Flipper",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |)
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "flipper::Flipper",
+                    "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -87,7 +95,7 @@ Module Impl_flipper_Flipper.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |)
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "flipper::Flipper", "value" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/incrementer.v
@@ -64,7 +64,7 @@ Module Impl_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "incrementer::Incrementer",
                 "value"
@@ -88,7 +88,11 @@ Module Impl_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "incrementer::Incrementer", "value" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "incrementer::Incrementer",
+            "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/incrementer.v
@@ -64,7 +64,11 @@ Module Impl_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (M.read (| self |)) "incrementer::Incrementer" "value" in
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "incrementer::Incrementer",
+                "value"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| by_ |) |) |) in
           M.alloc (| Value.Tuple [] |)
         |)))
@@ -84,7 +88,7 @@ Module Impl_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "incrementer::Incrementer" "value"
+          M.get_struct_record_field (| M.read (| self |), "incrementer::Incrementer", "value" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/call_builder.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/call_builder.v
@@ -205,31 +205,16 @@ Module Impl_call_builder_CallBuilderTest.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let e := M.copy (| γ0_0 |) in
                   M.alloc (| Value.StructTuple "core::option::Option::Some" [ M.read (| e |) ] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/call_builder.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/call_builder.v
@@ -205,16 +205,19 @@ Module Impl_call_builder_CallBuilderTest.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let e := M.copy (| γ0_0 |) in
                   M.alloc (| Value.StructTuple "core::option::Option::Some" [ M.read (| e |) ] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/constructors_return_value.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/constructors_return_value.v
@@ -433,7 +433,7 @@ Module Impl_constructors_return_value_ConstructorsReturnValue.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "constructors_return_value::ConstructorsReturnValue",
             "value"

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/constructors_return_value.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/constructors_return_value.v
@@ -433,10 +433,11 @@ Module Impl_constructors_return_value_ConstructorsReturnValue.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "constructors_return_value::ConstructorsReturnValue"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "constructors_return_value::ConstructorsReturnValue",
             "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/contract_ref.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/contract_ref.v
@@ -252,10 +252,18 @@ Module Impl_contract_ref_FlipperRef.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "contract_ref::FlipperRef" "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "contract_ref::FlipperRef",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "contract_ref::FlipperRef" "value"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "contract_ref::FlipperRef",
+                    "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -276,7 +284,7 @@ Module Impl_contract_ref_FlipperRef.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "contract_ref::FlipperRef" "value"
+          M.get_struct_record_field (| M.read (| self |), "contract_ref::FlipperRef", "value" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -420,10 +428,11 @@ Module Impl_contract_ref_ContractRef.
               M.call_closure (|
                 M.get_associated_function (| Ty.path "contract_ref::FlipperRef", "flip", [] |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "contract_ref::ContractRef"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "contract_ref::ContractRef",
                     "flipper"
+                  |)
                 ]
               |)
             |) in
@@ -446,7 +455,13 @@ Module Impl_contract_ref_ContractRef.
         (let self := M.alloc (| self |) in
         M.call_closure (|
           M.get_associated_function (| Ty.path "contract_ref::FlipperRef", "get", [] |),
-          [ M.get_struct_record_field (M.read (| self |)) "contract_ref::ContractRef" "flipper" ]
+          [
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "contract_ref::ContractRef",
+              "flipper"
+            |)
+          ]
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/contract_ref.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/contract_ref.v
@@ -252,14 +252,14 @@ Module Impl_contract_ref_FlipperRef.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "contract_ref::FlipperRef",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "contract_ref::FlipperRef",
                     "value"
@@ -284,7 +284,11 @@ Module Impl_contract_ref_FlipperRef.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "contract_ref::FlipperRef", "value" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "contract_ref::FlipperRef",
+            "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -428,7 +432,7 @@ Module Impl_contract_ref_ContractRef.
               M.call_closure (|
                 M.get_associated_function (| Ty.path "contract_ref::FlipperRef", "flip", [] |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "contract_ref::ContractRef",
                     "flipper"
@@ -456,7 +460,7 @@ Module Impl_contract_ref_ContractRef.
         M.call_closure (|
           M.get_associated_function (| Ty.path "contract_ref::FlipperRef", "get", [] |),
           [
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "contract_ref::ContractRef",
               "flipper"

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/integration_flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/integration_flipper.v
@@ -146,14 +146,14 @@ Module Impl_integration_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "integration_flipper::Flipper",
                 "value"
               |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "integration_flipper::Flipper",
                     "value"
@@ -178,7 +178,11 @@ Module Impl_integration_flipper_Flipper.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "integration_flipper::Flipper", "value" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "integration_flipper::Flipper",
+            "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/integration_flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/lang_err_integration_tests/integration_flipper.v
@@ -146,13 +146,18 @@ Module Impl_integration_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "integration_flipper::Flipper" "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "integration_flipper::Flipper",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "integration_flipper::Flipper"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "integration_flipper::Flipper",
                     "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -173,7 +178,7 @@ Module Impl_integration_flipper_Flipper.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "integration_flipper::Flipper" "value"
+          M.get_struct_record_field (| M.read (| self |), "integration_flipper::Flipper", "value" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
@@ -232,7 +232,7 @@ Module Impl_mapping_integration_tests_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "mapping_integration_tests::Env",
             "caller"
@@ -395,7 +395,7 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "mapping_integration_tests::Mappings",
                   "balances"
@@ -455,7 +455,7 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "mapping_integration_tests::Mappings",
                   "balances"
@@ -516,7 +516,7 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "mapping_integration_tests::Mappings",
                   "balances"
@@ -575,7 +575,7 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "mapping_integration_tests::Mappings",
                   "balances"
@@ -636,7 +636,7 @@ Module Impl_mapping_integration_tests_Mappings.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "mapping_integration_tests::Mappings",
                     "balances"
@@ -697,7 +697,7 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "mapping_integration_tests::Mappings",
                   "balances"

--- a/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mapping_integration_tests.v
@@ -232,7 +232,11 @@ Module Impl_mapping_integration_tests_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "mapping_integration_tests::Env" "caller"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "mapping_integration_tests::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -391,10 +395,11 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "mapping_integration_tests::Mappings"
-                  "balances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "mapping_integration_tests::Mappings",
+                  "balances"
+                |);
                 caller
               ]
             |)
@@ -450,10 +455,11 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "mapping_integration_tests::Mappings"
-                  "balances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "mapping_integration_tests::Mappings",
+                  "balances"
+                |);
                 M.read (| caller |);
                 M.read (| value |)
               ]
@@ -510,10 +516,11 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "mapping_integration_tests::Mappings"
-                  "balances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "mapping_integration_tests::Mappings",
+                  "balances"
+                |);
                 M.read (| caller |)
               ]
             |)
@@ -568,10 +575,11 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "mapping_integration_tests::Mappings"
-                  "balances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "mapping_integration_tests::Mappings",
+                  "balances"
+                |);
                 caller
               ]
             |)
@@ -628,10 +636,11 @@ Module Impl_mapping_integration_tests_Mappings.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "mapping_integration_tests::Mappings"
-                    "balances";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "mapping_integration_tests::Mappings",
+                    "balances"
+                  |);
                   M.read (| caller |)
                 ]
               |)
@@ -688,10 +697,11 @@ Module Impl_mapping_integration_tests_Mappings.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "mapping_integration_tests::Mappings"
-                  "balances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "mapping_integration_tests::Mappings",
+                  "balances"
+                |);
                 M.read (| caller |)
               ]
             |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/mother.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mother.v
@@ -174,8 +174,12 @@ Module Impl_core_cmp_PartialEq_for_mother_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "mother::AccountId", 0 |) |))
-          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "mother::AccountId", 0 |) |))))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "mother::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "mother::AccountId", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -361,8 +365,8 @@ Module Impl_core_cmp_PartialEq_for_mother_Bids.
             []
           |),
           [
-            M.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |);
-            M.get_struct_tuple_field (| M.read (| other |), "mother::Bids", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |);
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "mother::Bids", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -446,7 +450,7 @@ Module Impl_core_clone_Clone_for_mother_Bids.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |) ]
+              [ M.SubPointer.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |) ]
             |)
           ]))
     | _, _ => M.impossible
@@ -699,11 +703,11 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_0,
                               "mother::Status::EndingPeriod",
                               0
@@ -711,7 +715,7 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ0_1,
                               "mother::Status::EndingPeriod",
                               0
@@ -724,15 +728,23 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_0, "mother::Status::Ended", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_0,
+                              "mother::Status::Ended",
+                              0
+                            |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_1, "mother::Status::Ended", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_1,
+                              "mother::Status::Ended",
+                              0
+                            |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             M.call_closure (|
@@ -748,15 +760,23 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_0, "mother::Status::RfDelay", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_0,
+                              "mother::Status::RfDelay",
+                              0
+                            |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_1, "mother::Status::RfDelay", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_1,
+                              "mother::Status::RfDelay",
+                              0
+                            |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             BinOp.Pure.eq
@@ -850,7 +870,12 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::EndingPeriod", 0 |) in
+                  let γ1_0 :=
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "mother::Status::EndingPeriod",
+                      0
+                    |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -871,7 +896,8 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::Ended", 0 |) in
+                  let γ1_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "mother::Status::Ended", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -892,7 +918,8 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::RfDelay", 0 |) in
+                  let γ1_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "mother::Status::RfDelay", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -977,12 +1004,12 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                         []
                       |),
                       [
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "mother::Auction",
                           "name"
                         |);
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| other |),
                           "mother::Auction",
                           "name"
@@ -999,12 +1026,12 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                           []
                         |),
                         [
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.read (| self |),
                             "mother::Auction",
                             "subject"
                           |);
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.read (| other |),
                             "mother::Auction",
                             "subject"
@@ -1022,12 +1049,12 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                         []
                       |),
                       [
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "mother::Auction",
                           "bids"
                         |);
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| other |),
                           "mother::Auction",
                           "bids"
@@ -1045,8 +1072,16 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                       []
                     |),
                     [
-                      M.get_struct_record_field (| M.read (| self |), "mother::Auction", "terms" |);
-                      M.get_struct_record_field (| M.read (| other |), "mother::Auction", "terms" |)
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "mother::Auction",
+                        "terms"
+                      |);
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| other |),
+                        "mother::Auction",
+                        "terms"
+                      |)
                     ]
                   |)))
               |),
@@ -1060,18 +1095,34 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                     []
                   |),
                   [
-                    M.get_struct_record_field (| M.read (| self |), "mother::Auction", "status" |);
-                    M.get_struct_record_field (| M.read (| other |), "mother::Auction", "status" |)
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| self |),
+                      "mother::Auction",
+                      "status"
+                    |);
+                    M.SubPointer.get_struct_record_field (|
+                      M.read (| other |),
+                      "mother::Auction",
+                      "status"
+                    |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field (| M.read (| self |), "mother::Auction", "finalized" |)
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "finalized"
+                  |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field (| M.read (| other |), "mother::Auction", "finalized" |)
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| other |),
+                    "mother::Auction",
+                    "finalized"
+                  |)
                 |))))
           |),
           ltac:(M.monadic
@@ -1090,8 +1141,16 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| self |), "mother::Auction", "vector" |);
-                M.get_struct_record_field (| M.read (| other |), "mother::Auction", "vector" |)
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "mother::Auction",
+                  "vector"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| other |),
+                  "mother::Auction",
+                  "vector"
+                |)
               ]
             |)))
         |)))
@@ -1211,7 +1270,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "name" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "name"
+                  |)
+                ]
               |));
             ("subject",
               M.call_closure (|
@@ -1222,7 +1287,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "subject" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "subject"
+                  |)
+                ]
               |));
             ("bids",
               M.call_closure (|
@@ -1233,7 +1304,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "bids" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "bids"
+                  |)
+                ]
               |));
             ("terms",
               M.call_closure (|
@@ -1244,7 +1321,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "terms" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "terms"
+                  |)
+                ]
               |));
             ("status",
               M.call_closure (|
@@ -1255,12 +1338,23 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "status" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "status"
+                  |)
+                ]
               |));
             ("finalized",
               M.call_closure (|
                 M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "finalized" |)
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "finalized"
+                  |)
                 ]
               |));
             ("vector",
@@ -1274,7 +1368,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "vector" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "mother::Auction",
+                    "vector"
+                  |)
+                ]
               |))
           ]))
     | _, _ => M.impossible
@@ -1454,15 +1554,23 @@ Module Impl_core_cmp_PartialEq_for_mother_Failure.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_0, "mother::Failure::Revert", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_0,
+                              "mother::Failure::Revert",
+                              0
+                            |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field (| γ0_1, "mother::Failure::Revert", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ0_1,
+                              "mother::Failure::Revert",
+                              0
+                            |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             M.call_closure (|
@@ -1567,7 +1675,9 @@ Module Impl_mother_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "mother::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "mother::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -1881,8 +1991,10 @@ Module Impl_mother_Mother.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
-                  let γ1_0 := M.get_struct_tuple_field (| γ0_0, "mother::Failure::Revert", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ1_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ0_0, "mother::Failure::Revert", 0 |) in
                   M.alloc (|
                     Value.StructTuple
                       "core::result::Result::Err"
@@ -1905,7 +2017,8 @@ Module Impl_mother_Mother.
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|

--- a/CoqOfRust/examples/default/examples/ink_contracts/mother.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/mother.v
@@ -174,8 +174,8 @@ Module Impl_core_cmp_PartialEq_for_mother_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "mother::AccountId" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "mother::AccountId" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "mother::AccountId", 0 |) |))
+          (M.read (| M.get_struct_tuple_field (| M.read (| other |), "mother::AccountId", 0 |) |))))
     | _, _ => M.impossible
     end.
   
@@ -361,8 +361,8 @@ Module Impl_core_cmp_PartialEq_for_mother_Bids.
             []
           |),
           [
-            M.get_struct_tuple_field (M.read (| self |)) "mother::Bids" 0;
-            M.get_struct_tuple_field (M.read (| other |)) "mother::Bids" 0
+            M.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |);
+            M.get_struct_tuple_field (| M.read (| other |), "mother::Bids", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -446,7 +446,7 @@ Module Impl_core_clone_Clone_for_mother_Bids.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "mother::Bids" 0 ]
+              [ M.get_struct_tuple_field (| M.read (| self |), "mother::Bids", 0 |) ]
             |)
           ]))
     | _, _ => M.impossible
@@ -699,11 +699,11 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ0_0,
                               "mother::Status::EndingPeriod",
                               0
@@ -711,7 +711,7 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ0_1,
                               "mother::Status::EndingPeriod",
                               0
@@ -724,23 +724,15 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_0,
-                              "mother::Status::Ended",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_0, "mother::Status::Ended", 0 |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_1,
-                              "mother::Status::Ended",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_1, "mother::Status::Ended", 0 |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             M.call_closure (|
@@ -756,23 +748,15 @@ Module Impl_core_cmp_PartialEq_for_mother_Status.
                           |)));
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_0,
-                              "mother::Status::RfDelay",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_0, "mother::Status::RfDelay", 0 |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_1,
-                              "mother::Status::RfDelay",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_1, "mother::Status::RfDelay", 0 |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             BinOp.Pure.eq
@@ -866,12 +850,7 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "mother::Status::EndingPeriod",
-                      0
-                    |) in
+                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::EndingPeriod", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -892,8 +871,7 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (| γ, "mother::Status::Ended", 0 |) in
+                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::Ended", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -914,8 +892,7 @@ Module Impl_core_clone_Clone_for_mother_Status.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (| γ, "mother::Status::RfDelay", 0 |) in
+                  let γ1_0 := M.get_struct_tuple_field (| γ, "mother::Status::RfDelay", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -1000,8 +977,16 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                         []
                       |),
                       [
-                        M.get_struct_record_field (M.read (| self |)) "mother::Auction" "name";
-                        M.get_struct_record_field (M.read (| other |)) "mother::Auction" "name"
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "mother::Auction",
+                          "name"
+                        |);
+                        M.get_struct_record_field (|
+                          M.read (| other |),
+                          "mother::Auction",
+                          "name"
+                        |)
                       ]
                     |),
                     ltac:(M.monadic
@@ -1014,8 +999,16 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                           []
                         |),
                         [
-                          M.get_struct_record_field (M.read (| self |)) "mother::Auction" "subject";
-                          M.get_struct_record_field (M.read (| other |)) "mother::Auction" "subject"
+                          M.get_struct_record_field (|
+                            M.read (| self |),
+                            "mother::Auction",
+                            "subject"
+                          |);
+                          M.get_struct_record_field (|
+                            M.read (| other |),
+                            "mother::Auction",
+                            "subject"
+                          |)
                         ]
                       |)))
                   |),
@@ -1029,8 +1022,16 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                         []
                       |),
                       [
-                        M.get_struct_record_field (M.read (| self |)) "mother::Auction" "bids";
-                        M.get_struct_record_field (M.read (| other |)) "mother::Auction" "bids"
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "mother::Auction",
+                          "bids"
+                        |);
+                        M.get_struct_record_field (|
+                          M.read (| other |),
+                          "mother::Auction",
+                          "bids"
+                        |)
                       ]
                     |)))
                 |),
@@ -1044,8 +1045,8 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "mother::Auction" "terms";
-                      M.get_struct_record_field (M.read (| other |)) "mother::Auction" "terms"
+                      M.get_struct_record_field (| M.read (| self |), "mother::Auction", "terms" |);
+                      M.get_struct_record_field (| M.read (| other |), "mother::Auction", "terms" |)
                     ]
                   |)))
               |),
@@ -1059,18 +1060,18 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                     []
                   |),
                   [
-                    M.get_struct_record_field (M.read (| self |)) "mother::Auction" "status";
-                    M.get_struct_record_field (M.read (| other |)) "mother::Auction" "status"
+                    M.get_struct_record_field (| M.read (| self |), "mother::Auction", "status" |);
+                    M.get_struct_record_field (| M.read (| other |), "mother::Auction", "status" |)
                   ]
                 |)))
             |),
             ltac:(M.monadic
               (BinOp.Pure.eq
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "mother::Auction" "finalized"
+                  M.get_struct_record_field (| M.read (| self |), "mother::Auction", "finalized" |)
                 |))
                 (M.read (|
-                  M.get_struct_record_field (M.read (| other |)) "mother::Auction" "finalized"
+                  M.get_struct_record_field (| M.read (| other |), "mother::Auction", "finalized" |)
                 |))))
           |),
           ltac:(M.monadic
@@ -1089,8 +1090,8 @@ Module Impl_core_cmp_PartialEq_for_mother_Auction.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "mother::Auction" "vector";
-                M.get_struct_record_field (M.read (| other |)) "mother::Auction" "vector"
+                M.get_struct_record_field (| M.read (| self |), "mother::Auction", "vector" |);
+                M.get_struct_record_field (| M.read (| other |), "mother::Auction", "vector" |)
               ]
             |)))
         |)))
@@ -1210,7 +1211,7 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "name" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "name" |) ]
               |));
             ("subject",
               M.call_closure (|
@@ -1221,7 +1222,7 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "subject" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "subject" |) ]
               |));
             ("bids",
               M.call_closure (|
@@ -1232,7 +1233,7 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "bids" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "bids" |) ]
               |));
             ("terms",
               M.call_closure (|
@@ -1243,7 +1244,7 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "terms" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "terms" |) ]
               |));
             ("status",
               M.call_closure (|
@@ -1254,12 +1255,13 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "status" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "status" |) ]
               |));
             ("finalized",
               M.call_closure (|
                 M.get_trait_method (| "core::clone::Clone", Ty.path "bool", [], "clone", [] |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "finalized" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "finalized" |)
+                ]
               |));
             ("vector",
               M.call_closure (|
@@ -1272,7 +1274,7 @@ Module Impl_core_clone_Clone_for_mother_Auction.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "mother::Auction" "vector" ]
+                [ M.get_struct_record_field (| M.read (| self |), "mother::Auction", "vector" |) ]
               |))
           ]))
     | _, _ => M.impossible
@@ -1452,23 +1454,15 @@ Module Impl_core_cmp_PartialEq_for_mother_Failure.
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                           let γ0_0 := M.read (| γ0_0 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_0,
-                              "mother::Failure::Revert",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_0, "mother::Failure::Revert", 0 |) in
                           let __self_0 := M.alloc (| γ2_0 |) in
                           let γ0_1 := M.read (| γ0_1 |) in
                           let γ2_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ0_1,
-                              "mother::Failure::Revert",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ0_1, "mother::Failure::Revert", 0 |) in
                           let __arg1_0 := M.alloc (| γ2_0 |) in
                           M.alloc (|
                             M.call_closure (|
@@ -1573,7 +1567,7 @@ Module Impl_mother_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "mother::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "mother::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -1887,18 +1881,8 @@ Module Impl_mother_Mother.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
-                  let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ0_0,
-                      "mother::Failure::Revert",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ1_0 := M.get_struct_tuple_field (| γ0_0, "mother::Failure::Revert", 0 |) in
                   M.alloc (|
                     Value.StructTuple
                       "core::result::Result::Err"
@@ -1921,12 +1905,7 @@ Module Impl_mother_Mother.
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   M.alloc (|
                     M.never_to_any (|
                       M.call_closure (|

--- a/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
@@ -185,7 +185,11 @@ Module Impl_core_fmt_Debug_for_multisig_AccountId.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |)
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "multisig::AccountId",
+                  0
+                |)
               |))
           ]
         |)))
@@ -255,9 +259,11 @@ Module Impl_core_cmp_PartialEq_for_multisig_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |) |))
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
           |))))
     | _, _ => M.impossible
     end.
@@ -327,8 +333,8 @@ Module Impl_core_cmp_PartialOrd_for_multisig_AccountId.
             []
           |),
           [
-            M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
-            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -355,8 +361,8 @@ Module Impl_core_cmp_Ord_for_multisig_AccountId.
         M.call_closure (|
           M.get_trait_method (| "core::cmp::Ord", Ty.path "u128", [], "cmp", [] |),
           [
-            M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
-            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -850,7 +856,9 @@ Module Impl_multisig_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "multisig::Env", "caller" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "multisig::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -1247,7 +1255,7 @@ Module Impl_multisig_Multisig.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -1264,7 +1272,7 @@ Module Impl_multisig_Multisig.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field (|
+                                            M.SubPointer.get_struct_record_field (|
                                               contract,
                                               "multisig::Multisig",
                                               "is_owner"
@@ -1283,12 +1291,16 @@ Module Impl_multisig_Multisig.
               |)) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (| contract, "multisig::Multisig", "owners" |),
+              M.SubPointer.get_struct_record_field (| contract, "multisig::Multisig", "owners" |),
               M.read (| owners |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (| contract, "multisig::Multisig", "transaction_list" |),
+              M.SubPointer.get_struct_record_field (|
+                contract,
+                "multisig::Multisig",
+                "transaction_list"
+              |),
               M.call_closure (|
                 M.get_trait_method (|
                   "core::default::Default",
@@ -1302,7 +1314,11 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (| contract, "multisig::Multisig", "requirement" |),
+              M.SubPointer.get_struct_record_field (|
+                contract,
+                "multisig::Multisig",
+                "requirement"
+              |),
               M.read (| requirement |)
             |) in
           contract
@@ -1356,7 +1372,7 @@ Module Impl_multisig_Multisig.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
                                         M.read (| self |),
                                         "multisig::Multisig",
                                         "confirmation_count"
@@ -1368,7 +1384,7 @@ Module Impl_multisig_Multisig.
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "multisig::Multisig",
                                   "requirement"
@@ -1433,7 +1449,7 @@ Module Impl_multisig_Multisig.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "multisig::Multisig",
                         "transactions"
@@ -1484,7 +1500,7 @@ Module Impl_multisig_Multisig.
                                 []
                               |),
                               [
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "multisig::Multisig",
                                   "is_owner"
@@ -1612,8 +1628,8 @@ Module Impl_multisig_Multisig.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1710,7 +1726,7 @@ Module Impl_multisig_Multisig.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "multisig::Multisig",
                                     "is_owner"
@@ -1795,7 +1811,7 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.read (| self |),
                             "multisig::Multisig",
                             "owners"
@@ -1805,7 +1821,7 @@ Module Impl_multisig_Multisig.
                     Value.Integer Integer.U32 1
                   |);
                   M.read (|
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "multisig::Multisig",
                       "requirement"
@@ -1825,7 +1841,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "is_owner"
@@ -1846,7 +1862,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "owners"
+                  |);
                   M.read (| new_owner |)
                 ]
               |)
@@ -1933,7 +1953,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "owners"
@@ -2020,8 +2040,8 @@ Module Impl_multisig_Multisig.
                     []
                   |),
                   [
-                    M.get_struct_record_field (|
-                      M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "multisig::Multisig",
                         "transaction_list"
@@ -2059,7 +2079,7 @@ Module Impl_multisig_Multisig.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -2097,7 +2117,7 @@ Module Impl_multisig_Multisig.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field (|
+                                                    M.SubPointer.get_struct_record_field (|
                                                       M.read (| self |),
                                                       "multisig::Multisig",
                                                       "confirmations"
@@ -2129,7 +2149,7 @@ Module Impl_multisig_Multisig.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field (|
+                                                  M.SubPointer.get_struct_record_field (|
                                                     M.read (| self |),
                                                     "multisig::Multisig",
                                                     "confirmations"
@@ -2158,7 +2178,7 @@ Module Impl_multisig_Multisig.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field (|
+                                                      M.SubPointer.get_struct_record_field (|
                                                         M.read (| self |),
                                                         "multisig::Multisig",
                                                         "confirmation_count"
@@ -2193,7 +2213,7 @@ Module Impl_multisig_Multisig.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field (|
+                                                  M.SubPointer.get_struct_record_field (|
                                                     M.read (| self |),
                                                     "multisig::Multisig",
                                                     "confirmation_count"
@@ -2274,7 +2294,7 @@ Module Impl_multisig_Multisig.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "multisig::Multisig",
                         "owners"
@@ -2291,7 +2311,7 @@ Module Impl_multisig_Multisig.
                 [
                   M.read (| len |);
                   M.read (|
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "multisig::Multisig",
                       "requirement"
@@ -2326,7 +2346,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "owners"
+                  |);
                   M.read (| owner_index |)
                 ]
               |)
@@ -2342,7 +2366,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "is_owner"
@@ -2353,7 +2377,7 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "multisig::Multisig",
                 "requirement"
@@ -2465,7 +2489,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "owners"
+                  |);
                   M.rust_cast (M.read (| owner_index |))
                 ]
               |),
@@ -2482,7 +2510,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "is_owner"
@@ -2502,7 +2530,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "is_owner"
@@ -2617,7 +2645,7 @@ Module Impl_multisig_Multisig.
                         []
                       |),
                       [
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "multisig::Multisig",
                           "owners"
@@ -2630,7 +2658,7 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "multisig::Multisig",
                 "requirement"
@@ -2724,7 +2752,7 @@ Module Impl_multisig_Multisig.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "multisig::Multisig",
                         "confirmation_count"
@@ -2750,7 +2778,7 @@ Module Impl_multisig_Multisig.
                     []
                   |),
                   [
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "multisig::Multisig",
                       "confirmations"
@@ -2787,7 +2815,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "confirmations"
@@ -2806,7 +2834,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "confirmation_count"
@@ -2833,7 +2861,7 @@ Module Impl_multisig_Multisig.
                             BinOp.Pure.ge
                               (M.read (| count |))
                               (M.read (|
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "multisig::Multisig",
                                   "requirement"
@@ -2852,7 +2880,7 @@ Module Impl_multisig_Multisig.
                           [
                             BinOp.Panic.sub (|
                               M.read (|
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "multisig::Multisig",
                                   "requirement"
@@ -2955,8 +2983,8 @@ Module Impl_multisig_Multisig.
             |) in
           let trans_id :=
             M.copy (|
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "multisig::Multisig",
                   "transaction_list"
@@ -2967,8 +2995,8 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "multisig::Multisig",
                   "transaction_list"
@@ -3005,7 +3033,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "transactions"
@@ -3026,8 +3054,8 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
-                    M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "multisig::Multisig",
                       "transaction_list"
@@ -3133,7 +3161,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "multisig::Multisig",
                     "transactions"
@@ -3174,7 +3202,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "transactions"
@@ -3224,8 +3252,8 @@ Module Impl_multisig_Multisig.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field (|
-                                            M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
+                                            M.SubPointer.get_struct_record_field (|
                                               M.read (| self |),
                                               "multisig::Multisig",
                                               "transaction_list"
@@ -3283,8 +3311,8 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
-                              M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 M.read (| self |),
                                 "multisig::Multisig",
                                 "transaction_list"
@@ -3332,7 +3360,7 @@ Module Impl_multisig_Multisig.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
                                           M.read (| self |),
                                           "multisig::Multisig",
                                           "owners"
@@ -3375,7 +3403,7 @@ Module Impl_multisig_Multisig.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field (|
+                                                M.SubPointer.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -3399,7 +3427,7 @@ Module Impl_multisig_Multisig.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field (|
+                                                      M.SubPointer.get_struct_record_field (|
                                                         M.read (| self |),
                                                         "multisig::Multisig",
                                                         "confirmations"
@@ -3428,7 +3456,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "confirmation_count"
@@ -3679,7 +3707,7 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "multisig::Multisig",
                               "confirmations"
@@ -3701,7 +3729,7 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.read (| self |),
                             "multisig::Multisig",
                             "confirmations"
@@ -3728,7 +3756,7 @@ Module Impl_multisig_Multisig.
                               []
                             |),
                             [
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 M.read (| self |),
                                 "multisig::Multisig",
                                 "confirmation_count"
@@ -3758,7 +3786,7 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.read (| self |),
                             "multisig::Multisig",
                             "confirmation_count"
@@ -3904,7 +3932,7 @@ Module Impl_multisig_Multisig.
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   t,
                                   "multisig::Transaction",
                                   "transferred_value"
@@ -3945,9 +3973,17 @@ Module Impl_multisig_Multisig.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                        M.SubPointer.get_struct_tuple_field (|
+                          γ,
+                          "core::result::Result::Ok",
+                          0
+                        |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field (| γ0_0, "core::result::Result::Ok", 0 |) in
+                        M.SubPointer.get_struct_tuple_field (|
+                          γ0_0,
+                          "core::result::Result::Ok",
+                          0
+                        |) in
                       M.alloc (|
                         Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ]
                       |)));

--- a/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/multisig.v
@@ -184,7 +184,9 @@ Module Impl_core_fmt_Debug_for_multisig_AccountId.
             M.read (| Value.String "AccountId" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "multisig::AccountId" 0 |))
+              (M.alloc (|
+                M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |)
+              |))
           ]
         |)))
     | _, _ => M.impossible
@@ -253,8 +255,10 @@ Module Impl_core_cmp_PartialEq_for_multisig_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "multisig::AccountId" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "multisig::AccountId" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |) |))
+          (M.read (|
+            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -323,8 +327,8 @@ Module Impl_core_cmp_PartialOrd_for_multisig_AccountId.
             []
           |),
           [
-            M.get_struct_tuple_field (M.read (| self |)) "multisig::AccountId" 0;
-            M.get_struct_tuple_field (M.read (| other |)) "multisig::AccountId" 0
+            M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
+            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -351,8 +355,8 @@ Module Impl_core_cmp_Ord_for_multisig_AccountId.
         M.call_closure (|
           M.get_trait_method (| "core::cmp::Ord", Ty.path "u128", [], "cmp", [] |),
           [
-            M.get_struct_tuple_field (M.read (| self |)) "multisig::AccountId" 0;
-            M.get_struct_tuple_field (M.read (| other |)) "multisig::AccountId" 0
+            M.get_struct_tuple_field (| M.read (| self |), "multisig::AccountId", 0 |);
+            M.get_struct_tuple_field (| M.read (| other |), "multisig::AccountId", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -846,7 +850,7 @@ Module Impl_multisig_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "multisig::Env" "caller" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "multisig::Env", "caller" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -1243,7 +1247,7 @@ Module Impl_multisig_Multisig.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0
@@ -1260,10 +1264,11 @@ Module Impl_multisig_Multisig.
                                             []
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              contract
-                                              "multisig::Multisig"
-                                              "is_owner";
+                                            M.get_struct_record_field (|
+                                              contract,
+                                              "multisig::Multisig",
+                                              "is_owner"
+                                            |);
                                             M.read (| M.read (| owner |) |);
                                             Value.Tuple []
                                           ]
@@ -1278,12 +1283,12 @@ Module Impl_multisig_Multisig.
               |)) in
           let _ :=
             M.write (|
-              M.get_struct_record_field contract "multisig::Multisig" "owners",
+              M.get_struct_record_field (| contract, "multisig::Multisig", "owners" |),
               M.read (| owners |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field contract "multisig::Multisig" "transaction_list",
+              M.get_struct_record_field (| contract, "multisig::Multisig", "transaction_list" |),
               M.call_closure (|
                 M.get_trait_method (|
                   "core::default::Default",
@@ -1297,7 +1302,7 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field contract "multisig::Multisig" "requirement",
+              M.get_struct_record_field (| contract, "multisig::Multisig", "requirement" |),
               M.read (| requirement |)
             |) in
           contract
@@ -1351,10 +1356,11 @@ Module Impl_multisig_Multisig.
                                       []
                                     |),
                                     [
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "multisig::Multisig"
-                                        "confirmation_count";
+                                      M.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "multisig::Multisig",
+                                        "confirmation_count"
+                                      |);
                                       trans_id
                                     ]
                                   |);
@@ -1362,10 +1368,11 @@ Module Impl_multisig_Multisig.
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "multisig::Multisig"
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "multisig::Multisig",
                                   "requirement"
+                                |)
                               |)))
                         |)) in
                     let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -1426,10 +1433,11 @@ Module Impl_multisig_Multisig.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "multisig::Multisig"
-                        "transactions";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "multisig::Multisig",
+                        "transactions"
+                      |);
                       trans_id
                     ]
                   |);
@@ -1476,10 +1484,11 @@ Module Impl_multisig_Multisig.
                                 []
                               |),
                               [
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "multisig::Multisig"
-                                  "is_owner";
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "multisig::Multisig",
+                                  "is_owner"
+                                |);
                                 M.read (| owner |)
                               ]
                             |))
@@ -1603,8 +1612,8 @@ Module Impl_multisig_Multisig.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -1701,10 +1710,11 @@ Module Impl_multisig_Multisig.
                                   []
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "multisig::Multisig"
-                                    "is_owner";
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "multisig::Multisig",
+                                    "is_owner"
+                                  |);
                                   M.read (| owner |)
                                 ]
                               |)))
@@ -1785,16 +1795,21 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "multisig::Multisig"
+                          M.get_struct_record_field (|
+                            M.read (| self |),
+                            "multisig::Multisig",
                             "owners"
+                          |)
                         ]
                       |)),
                     Value.Integer Integer.U32 1
                   |);
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "requirement"
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "multisig::Multisig",
+                      "requirement"
+                    |)
                   |)
                 ]
               |)
@@ -1810,7 +1825,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "is_owner";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "is_owner"
+                  |);
                   M.read (| new_owner |);
                   Value.Tuple []
                 ]
@@ -1827,7 +1846,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "owners";
+                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
                   M.read (| new_owner |)
                 ]
               |)
@@ -1914,10 +1933,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
                               "owners"
+                            |)
                           ]
                         |)
                       ]
@@ -2000,13 +2020,15 @@ Module Impl_multisig_Multisig.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.get_struct_record_field
-                        (M.read (| self |))
-                        "multisig::Multisig"
-                        "transaction_list")
-                      "multisig::Transactions"
+                    M.get_struct_record_field (|
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "multisig::Multisig",
+                        "transaction_list"
+                      |),
+                      "multisig::Transactions",
                       "transactions"
+                    |)
                   ]
                 |)
               |),
@@ -2037,7 +2059,7 @@ Module Impl_multisig_Multisig.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -2075,10 +2097,11 @@ Module Impl_multisig_Multisig.
                                                     []
                                                   |),
                                                   [
-                                                    M.get_struct_record_field
-                                                      (M.read (| self |))
-                                                      "multisig::Multisig"
-                                                      "confirmations";
+                                                    M.get_struct_record_field (|
+                                                      M.read (| self |),
+                                                      "multisig::Multisig",
+                                                      "confirmations"
+                                                    |);
                                                     key
                                                   ]
                                                 |)
@@ -2106,10 +2129,11 @@ Module Impl_multisig_Multisig.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "multisig::Multisig"
-                                                    "confirmations";
+                                                  M.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "multisig::Multisig",
+                                                    "confirmations"
+                                                  |);
                                                   M.read (| key |)
                                                 ]
                                               |)
@@ -2134,10 +2158,11 @@ Module Impl_multisig_Multisig.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "multisig::Multisig"
-                                                        "confirmation_count";
+                                                      M.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "multisig::Multisig",
+                                                        "confirmation_count"
+                                                      |);
                                                       M.read (| trans_id |)
                                                     ]
                                                   |);
@@ -2168,10 +2193,11 @@ Module Impl_multisig_Multisig.
                                                   []
                                                 |),
                                                 [
-                                                  M.get_struct_record_field
-                                                    (M.read (| self |))
-                                                    "multisig::Multisig"
-                                                    "confirmation_count";
+                                                  M.get_struct_record_field (|
+                                                    M.read (| self |),
+                                                    "multisig::Multisig",
+                                                    "confirmation_count"
+                                                  |);
                                                   M.read (| M.read (| trans_id |) |);
                                                   M.read (| count |)
                                                 ]
@@ -2247,7 +2273,13 @@ Module Impl_multisig_Multisig.
                       "len",
                       []
                     |),
-                    [ M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "owners" ]
+                    [
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "multisig::Multisig",
+                        "owners"
+                      |)
+                    ]
                   |)),
                 Value.Integer Integer.U32 1
               |)
@@ -2259,7 +2291,11 @@ Module Impl_multisig_Multisig.
                 [
                   M.read (| len |);
                   M.read (|
-                    M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "requirement"
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "multisig::Multisig",
+                      "requirement"
+                    |)
                   |)
                 ]
               |)
@@ -2290,7 +2326,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "owners";
+                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
                   M.read (| owner_index |)
                 ]
               |)
@@ -2306,14 +2342,22 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "is_owner";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "is_owner"
+                  |);
                   M.read (| owner |)
                 ]
               |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "requirement",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "multisig::Multisig",
+                "requirement"
+              |),
               M.read (| requirement |)
             |) in
           let _ :=
@@ -2421,7 +2465,7 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "owners";
+                  M.get_struct_record_field (| M.read (| self |), "multisig::Multisig", "owners" |);
                   M.rust_cast (M.read (| owner_index |))
                 ]
               |),
@@ -2438,7 +2482,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "is_owner";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "is_owner"
+                  |);
                   M.read (| old_owner |)
                 ]
               |)
@@ -2454,7 +2502,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "is_owner";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "is_owner"
+                  |);
                   M.read (| new_owner |);
                   Value.Tuple []
                 ]
@@ -2564,7 +2616,12 @@ Module Impl_multisig_Multisig.
                         "len",
                         []
                       |),
-                      [ M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "owners"
+                      [
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "multisig::Multisig",
+                          "owners"
+                        |)
                       ]
                     |));
                   M.read (| new_requirement |)
@@ -2573,7 +2630,11 @@ Module Impl_multisig_Multisig.
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "requirement",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "multisig::Multisig",
+                "requirement"
+              |),
               M.read (| new_requirement |)
             |) in
           let _ :=
@@ -2663,10 +2724,11 @@ Module Impl_multisig_Multisig.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "multisig::Multisig"
-                        "confirmation_count";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "multisig::Multisig",
+                        "confirmation_count"
+                      |);
                       transaction
                     ]
                   |);
@@ -2688,10 +2750,11 @@ Module Impl_multisig_Multisig.
                     []
                   |),
                   [
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "multisig::Multisig"
-                      "confirmations";
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "multisig::Multisig",
+                      "confirmations"
+                    |);
                     key
                   ]
                 |))
@@ -2724,10 +2787,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
-                              "confirmations";
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
+                              "confirmations"
+                            |);
                             M.read (| key |);
                             Value.Tuple []
                           ]
@@ -2742,10 +2806,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
-                              "confirmation_count";
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
+                              "confirmation_count"
+                            |);
                             M.read (| transaction |);
                             M.read (| count |)
                           ]
@@ -2768,10 +2833,11 @@ Module Impl_multisig_Multisig.
                             BinOp.Pure.ge
                               (M.read (| count |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "multisig::Multisig"
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "multisig::Multisig",
                                   "requirement"
+                                |)
                               |))
                           |)) in
                       let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -2786,10 +2852,11 @@ Module Impl_multisig_Multisig.
                           [
                             BinOp.Panic.sub (|
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "multisig::Multisig"
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "multisig::Multisig",
                                   "requirement"
+                                |)
                               |),
                               M.read (| count |)
                             |)
@@ -2888,23 +2955,27 @@ Module Impl_multisig_Multisig.
             |) in
           let trans_id :=
             M.copy (|
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "multisig::Multisig"
-                  "transaction_list")
-                "multisig::Transactions"
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "multisig::Multisig",
+                  "transaction_list"
+                |),
+                "multisig::Transactions",
                 "next_id"
+              |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "multisig::Multisig"
-                  "transaction_list")
-                "multisig::Transactions"
-                "next_id",
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "multisig::Multisig",
+                  "transaction_list"
+                |),
+                "multisig::Transactions",
+                "next_id"
+              |),
               M.call_closure (|
                 M.get_associated_function (|
                   Ty.apply (Ty.path "core::option::Option") [ Ty.path "u32" ],
@@ -2934,7 +3005,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "transactions";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "transactions"
+                  |);
                   M.read (| trans_id |);
                   M.read (| transaction |)
                 ]
@@ -2951,13 +3026,15 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.get_struct_record_field
-                      (M.read (| self |))
-                      "multisig::Multisig"
-                      "transaction_list")
-                    "multisig::Transactions"
-                    "transactions";
+                  M.get_struct_record_field (|
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "multisig::Multisig",
+                      "transaction_list"
+                    |),
+                    "multisig::Transactions",
+                    "transactions"
+                  |);
                   M.read (| trans_id |)
                 ]
               |)
@@ -3056,7 +3133,11 @@ Module Impl_multisig_Multisig.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "multisig::Multisig" "transactions";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "multisig::Multisig",
+                    "transactions"
+                  |);
                   trans_id
                 ]
               |)
@@ -3093,10 +3174,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
-                              "transactions";
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
+                              "transactions"
+                            |);
                             M.read (| trans_id |)
                           ]
                         |)
@@ -3142,13 +3224,15 @@ Module Impl_multisig_Multisig.
                                           []
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "multisig::Multisig"
-                                              "transaction_list")
-                                            "multisig::Transactions"
+                                          M.get_struct_record_field (|
+                                            M.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "multisig::Multisig",
+                                              "transaction_list"
+                                            |),
+                                            "multisig::Transactions",
                                             "transactions"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -3199,13 +3283,15 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.get_struct_record_field
-                                (M.read (| self |))
-                                "multisig::Multisig"
-                                "transaction_list")
-                              "multisig::Transactions"
-                              "transactions";
+                            M.get_struct_record_field (|
+                              M.get_struct_record_field (|
+                                M.read (| self |),
+                                "multisig::Multisig",
+                                "transaction_list"
+                              |),
+                              "multisig::Transactions",
+                              "transactions"
+                            |);
                             M.read (| pos |)
                           ]
                         |)
@@ -3246,10 +3332,11 @@ Module Impl_multisig_Multisig.
                                         []
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "multisig::Multisig"
+                                        M.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "multisig::Multisig",
                                           "owners"
+                                        |)
                                       ]
                                     |)
                                   ]
@@ -3288,7 +3375,7 @@ Module Impl_multisig_Multisig.
                                           fun γ =>
                                             ltac:(M.monadic
                                               (let γ0_0 :=
-                                                M.get_struct_tuple_field_or_break_match (|
+                                                M.get_struct_tuple_field (|
                                                   γ,
                                                   "core::option::Option::Some",
                                                   0
@@ -3312,10 +3399,11 @@ Module Impl_multisig_Multisig.
                                                       []
                                                     |),
                                                     [
-                                                      M.get_struct_record_field
-                                                        (M.read (| self |))
-                                                        "multisig::Multisig"
-                                                        "confirmations";
+                                                      M.get_struct_record_field (|
+                                                        M.read (| self |),
+                                                        "multisig::Multisig",
+                                                        "confirmations"
+                                                      |);
                                                       Value.Tuple
                                                         [
                                                           M.read (| trans_id |);
@@ -3340,10 +3428,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
-                              "confirmation_count";
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
+                              "confirmation_count"
+                            |);
                             M.read (| trans_id |)
                           ]
                         |)
@@ -3590,10 +3679,11 @@ Module Impl_multisig_Multisig.
                             []
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "multisig::Multisig"
-                              "confirmations";
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "multisig::Multisig",
+                              "confirmations"
+                            |);
                             M.alloc (| Value.Tuple [ M.read (| trans_id |); M.read (| caller |) ] |)
                           ]
                         |)
@@ -3611,10 +3701,11 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "multisig::Multisig"
-                            "confirmations";
+                          M.get_struct_record_field (|
+                            M.read (| self |),
+                            "multisig::Multisig",
+                            "confirmations"
+                          |);
                           Value.Tuple [ M.read (| trans_id |); M.read (| caller |) ]
                         ]
                       |)
@@ -3637,10 +3728,11 @@ Module Impl_multisig_Multisig.
                               []
                             |),
                             [
-                              M.get_struct_record_field
-                                (M.read (| self |))
-                                "multisig::Multisig"
-                                "confirmation_count";
+                              M.get_struct_record_field (|
+                                M.read (| self |),
+                                "multisig::Multisig",
+                                "confirmation_count"
+                              |);
                               trans_id
                             ]
                           |);
@@ -3666,10 +3758,11 @@ Module Impl_multisig_Multisig.
                           []
                         |),
                         [
-                          M.get_struct_record_field
-                            (M.read (| self |))
-                            "multisig::Multisig"
-                            "confirmation_count";
+                          M.get_struct_record_field (|
+                            M.read (| self |),
+                            "multisig::Multisig",
+                            "confirmation_count"
+                          |);
                           M.read (| trans_id |);
                           M.read (| confirmation_count |)
                         ]
@@ -3811,10 +3904,11 @@ Module Impl_multisig_Multisig.
                                 ]
                               |))
                               (M.read (|
-                                M.get_struct_record_field
-                                  t
-                                  "multisig::Transaction"
+                                M.get_struct_record_field (|
+                                  t,
+                                  "multisig::Transaction",
                                   "transferred_value"
+                                |)
                               |)))
                         |)) in
                     let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -3851,17 +3945,9 @@ Module Impl_multisig_Multisig.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::result::Result::Ok",
-                          0
-                        |) in
+                        M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                       let γ1_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ0_0,
-                          "core::result::Result::Ok",
-                          0
-                        |) in
+                        M.get_struct_tuple_field (| γ0_0, "core::result::Result::Ok", 0 |) in
                       M.alloc (|
                         Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ]
                       |)));

--- a/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
@@ -91,10 +91,18 @@ Module Impl_core_cmp_PartialEq_for_payment_channel_AccountId.
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| self |), "payment_channel::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (|
+              M.read (| self |),
+              "payment_channel::AccountId",
+              0
+            |)
           |))
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| other |), "payment_channel::AccountId", 0 |)
+            M.SubPointer.get_struct_tuple_field (|
+              M.read (| other |),
+              "payment_channel::AccountId",
+              0
+            |)
           |))))
     | _, _ => M.impossible
     end.
@@ -357,7 +365,11 @@ Module Impl_payment_channel_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "payment_channel::Env", "caller" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::Env",
+            "caller"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -781,7 +793,7 @@ Module Impl_payment_channel_PaymentChannel.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "payment_channel::PaymentChannel",
                   "recipient"
@@ -925,7 +937,7 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "recipient"
@@ -965,7 +977,7 @@ Module Impl_payment_channel_PaymentChannel.
                               BinOp.Pure.lt
                                 (M.read (| amount |))
                                 (M.read (|
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "withdrawn"
@@ -1074,7 +1086,7 @@ Module Impl_payment_channel_PaymentChannel.
                                   |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "recipient"
@@ -1083,7 +1095,7 @@ Module Impl_payment_channel_PaymentChannel.
                                 BinOp.Panic.sub (|
                                   M.read (| amount |),
                                   M.read (|
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "payment_channel::PaymentChannel",
                                       "withdrawn"
@@ -1118,7 +1130,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1154,7 +1166,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1218,7 +1230,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1254,7 +1266,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1283,7 +1295,7 @@ Module Impl_payment_channel_PaymentChannel.
                         |)
                       |);
                       M.read (|
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "payment_channel::PaymentChannel",
                           "sender"
@@ -1367,7 +1379,7 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "sender"
@@ -1419,7 +1431,7 @@ Module Impl_payment_channel_PaymentChannel.
                   BinOp.Panic.add (|
                     M.read (| now |),
                     M.read (|
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "payment_channel::PaymentChannel",
                         "close_duration"
@@ -1455,7 +1467,7 @@ Module Impl_payment_channel_PaymentChannel.
                               ("expiration", M.read (| expiration |));
                               ("close_duration",
                                 M.read (|
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "close_duration"
@@ -1468,7 +1480,7 @@ Module Impl_payment_channel_PaymentChannel.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "payment_channel::PaymentChannel",
                     "expiration"
@@ -1513,7 +1525,7 @@ Module Impl_payment_channel_PaymentChannel.
           ltac:(M.monadic
             (M.read (|
               M.match_operator (|
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "payment_channel::PaymentChannel",
                   "expiration"
@@ -1522,7 +1534,11 @@ Module Impl_payment_channel_PaymentChannel.
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                        M.SubPointer.get_struct_tuple_field (|
+                          γ,
+                          "core::option::Option::Some",
+                          0
+                        |) in
                       let expiration := M.copy (| γ0_0 |) in
                       let now :=
                         M.alloc (|
@@ -1600,7 +1616,7 @@ Module Impl_payment_channel_PaymentChannel.
                                 |)
                               |);
                               M.read (|
-                                M.get_struct_record_field (|
+                                M.SubPointer.get_struct_record_field (|
                                   M.read (| self |),
                                   "payment_channel::PaymentChannel",
                                   "sender"
@@ -1704,7 +1720,7 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "recipient"
@@ -1780,7 +1796,7 @@ Module Impl_payment_channel_PaymentChannel.
                               BinOp.Pure.lt
                                 (M.read (| amount |))
                                 (M.read (|
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "withdrawn"
@@ -1812,7 +1828,7 @@ Module Impl_payment_channel_PaymentChannel.
                   BinOp.Panic.sub (|
                     M.read (| amount |),
                     M.read (|
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "payment_channel::PaymentChannel",
                         "withdrawn"
@@ -1822,7 +1838,7 @@ Module Impl_payment_channel_PaymentChannel.
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "payment_channel::PaymentChannel",
                     "withdrawn"
@@ -1877,7 +1893,7 @@ Module Impl_payment_channel_PaymentChannel.
                                   |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| self |),
                                     "payment_channel::PaymentChannel",
                                     "recipient"
@@ -1912,7 +1928,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1948,7 +1964,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1976,7 +1992,7 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "payment_channel::PaymentChannel",
             "sender"
@@ -1998,7 +2014,7 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "payment_channel::PaymentChannel",
             "recipient"
@@ -2021,7 +2037,7 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "payment_channel::PaymentChannel",
             "expiration"
@@ -2044,7 +2060,7 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "payment_channel::PaymentChannel",
             "withdrawn"
@@ -2067,7 +2083,7 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "payment_channel::PaymentChannel",
             "close_duration"

--- a/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/payment_channel.v
@@ -90,9 +90,11 @@ Module Impl_core_cmp_PartialEq_for_payment_channel_AccountId.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "payment_channel::AccountId" 0 |))
           (M.read (|
-            M.get_struct_tuple_field (M.read (| other |)) "payment_channel::AccountId" 0
+            M.get_struct_tuple_field (| M.read (| self |), "payment_channel::AccountId", 0 |)
+          |))
+          (M.read (|
+            M.get_struct_tuple_field (| M.read (| other |), "payment_channel::AccountId", 0 |)
           |))))
     | _, _ => M.impossible
     end.
@@ -354,7 +356,9 @@ Module Impl_payment_channel_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "payment_channel::Env" "caller" |)))
+        M.read (|
+          M.get_struct_record_field (| M.read (| self |), "payment_channel::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -777,10 +781,11 @@ Module Impl_payment_channel_PaymentChannel.
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "payment_channel::PaymentChannel"
-                  "recipient";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "payment_channel::PaymentChannel",
+                  "recipient"
+                |);
                 M.alloc (|
                   M.call_closure (|
                     M.get_trait_method (|
@@ -920,10 +925,11 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "recipient"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -959,10 +965,11 @@ Module Impl_payment_channel_PaymentChannel.
                               BinOp.Pure.lt
                                 (M.read (| amount |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "withdrawn"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
@@ -1067,18 +1074,20 @@ Module Impl_payment_channel_PaymentChannel.
                                   |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "recipient"
+                                  |)
                                 |);
                                 BinOp.Panic.sub (|
                                   M.read (| amount |),
                                   M.read (|
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "payment_channel::PaymentChannel"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "payment_channel::PaymentChannel",
                                       "withdrawn"
+                                    |)
                                   |)
                                 |)
                               ]
@@ -1109,7 +1118,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1145,7 +1154,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1209,7 +1218,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1245,7 +1254,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1274,10 +1283,11 @@ Module Impl_payment_channel_PaymentChannel.
                         |)
                       |);
                       M.read (|
-                        M.get_struct_record_field
-                          (M.read (| self |))
-                          "payment_channel::PaymentChannel"
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "payment_channel::PaymentChannel",
                           "sender"
+                        |)
                       |)
                     ]
                   |)
@@ -1357,10 +1367,11 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "sender"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -1408,10 +1419,11 @@ Module Impl_payment_channel_PaymentChannel.
                   BinOp.Panic.add (|
                     M.read (| now |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "payment_channel::PaymentChannel"
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "payment_channel::PaymentChannel",
                         "close_duration"
+                      |)
                     |)
                   |)
                 |) in
@@ -1443,10 +1455,11 @@ Module Impl_payment_channel_PaymentChannel.
                               ("expiration", M.read (| expiration |));
                               ("close_duration",
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "close_duration"
+                                  |)
                                 |))
                             ]
                         ]
@@ -1455,10 +1468,11 @@ Module Impl_payment_channel_PaymentChannel.
                 |) in
               let _ :=
                 M.write (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "payment_channel::PaymentChannel"
-                    "expiration",
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "payment_channel::PaymentChannel",
+                    "expiration"
+                  |),
                   Value.StructTuple "core::option::Option::Some" [ M.read (| expiration |) ]
                 |) in
               M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)
@@ -1499,19 +1513,16 @@ Module Impl_payment_channel_PaymentChannel.
           ltac:(M.monadic
             (M.read (|
               M.match_operator (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "payment_channel::PaymentChannel"
-                  "expiration",
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "payment_channel::PaymentChannel",
+                  "expiration"
+                |),
                 [
                   fun γ =>
                     ltac:(M.monadic
                       (let γ0_0 :=
-                        M.get_struct_tuple_field_or_break_match (|
-                          γ,
-                          "core::option::Option::Some",
-                          0
-                        |) in
+                        M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                       let expiration := M.copy (| γ0_0 |) in
                       let now :=
                         M.alloc (|
@@ -1589,10 +1600,11 @@ Module Impl_payment_channel_PaymentChannel.
                                 |)
                               |);
                               M.read (|
-                                M.get_struct_record_field
-                                  (M.read (| self |))
-                                  "payment_channel::PaymentChannel"
+                                M.get_struct_record_field (|
+                                  M.read (| self |),
+                                  "payment_channel::PaymentChannel",
                                   "sender"
+                                |)
                               |)
                             ]
                           |)
@@ -1692,10 +1704,11 @@ Module Impl_payment_channel_PaymentChannel.
                                       ]
                                     |)
                                   |);
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "recipient"
+                                  |)
                                 ]
                               |)
                             |)) in
@@ -1767,10 +1780,11 @@ Module Impl_payment_channel_PaymentChannel.
                               BinOp.Pure.lt
                                 (M.read (| amount |))
                                 (M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "withdrawn"
+                                  |)
                                 |))
                             |)) in
                         let _ :=
@@ -1798,19 +1812,21 @@ Module Impl_payment_channel_PaymentChannel.
                   BinOp.Panic.sub (|
                     M.read (| amount |),
                     M.read (|
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "payment_channel::PaymentChannel"
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "payment_channel::PaymentChannel",
                         "withdrawn"
+                      |)
                     |)
                   |)
                 |) in
               let _ :=
                 let β :=
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "payment_channel::PaymentChannel"
-                    "withdrawn" in
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "payment_channel::PaymentChannel",
+                    "withdrawn"
+                  |) in
                 M.write (|
                   β,
                   BinOp.Panic.add (| M.read (| β |), M.read (| amount_to_withdraw |) |)
@@ -1861,10 +1877,11 @@ Module Impl_payment_channel_PaymentChannel.
                                   |)
                                 |);
                                 M.read (|
-                                  M.get_struct_record_field
-                                    (M.read (| self |))
-                                    "payment_channel::PaymentChannel"
+                                  M.get_struct_record_field (|
+                                    M.read (| self |),
+                                    "payment_channel::PaymentChannel",
                                     "recipient"
+                                  |)
                                 |);
                                 M.read (| amount_to_withdraw |)
                               ]
@@ -1895,7 +1912,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1931,7 +1948,7 @@ Module Impl_payment_channel_PaymentChannel.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1959,7 +1976,11 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "payment_channel::PaymentChannel" "sender"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::PaymentChannel",
+            "sender"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -1977,10 +1998,11 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "payment_channel::PaymentChannel"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::PaymentChannel",
             "recipient"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -1999,10 +2021,11 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "payment_channel::PaymentChannel"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::PaymentChannel",
             "expiration"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -2021,10 +2044,11 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "payment_channel::PaymentChannel"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::PaymentChannel",
             "withdrawn"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -2043,10 +2067,11 @@ Module Impl_payment_channel_PaymentChannel.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "payment_channel::PaymentChannel"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "payment_channel::PaymentChannel",
             "close_duration"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash.v
@@ -95,7 +95,11 @@ Module Impl_set_code_hash_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (M.read (| self |)) "set_code_hash::Incrementer" "count" in
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "set_code_hash::Incrementer",
+                "count"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.U32 1 |) |) in
           let _ :=
             let _ :=
@@ -131,10 +135,11 @@ Module Impl_set_code_hash_Incrementer.
                                     [ Ty.path "u32" ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "set_code_hash::Incrementer"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "set_code_hash::Incrementer",
                                       "count"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -163,7 +168,7 @@ Module Impl_set_code_hash_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "set_code_hash::Incrementer" "count"
+          M.get_struct_record_field (| M.read (| self |), "set_code_hash::Incrementer", "count" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash.v
@@ -95,7 +95,7 @@ Module Impl_set_code_hash_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "set_code_hash::Incrementer",
                 "count"
@@ -135,7 +135,7 @@ Module Impl_set_code_hash_Incrementer.
                                     [ Ty.path "u32" ]
                                   |),
                                   [
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "set_code_hash::Incrementer",
                                       "count"
@@ -168,7 +168,11 @@ Module Impl_set_code_hash_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "set_code_hash::Incrementer", "count" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "set_code_hash::Incrementer",
+            "count"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash/updated_incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash/updated_incrementer.v
@@ -181,7 +181,7 @@ Module Impl_updated_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "updated_incrementer::Incrementer",
                 "count"
@@ -221,7 +221,7 @@ Module Impl_updated_incrementer_Incrementer.
                                     [ Ty.path "u32" ]
                                   |),
                                   [
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "updated_incrementer::Incrementer",
                                       "count"
@@ -254,7 +254,7 @@ Module Impl_updated_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "updated_incrementer::Incrementer",
             "count"

--- a/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash/updated_incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/set_code_hash/updated_incrementer.v
@@ -181,10 +181,11 @@ Module Impl_updated_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.read (| self |))
-                "updated_incrementer::Incrementer"
-                "count" in
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "updated_incrementer::Incrementer",
+                "count"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.U32 4 |) |) in
           let _ :=
             let _ :=
@@ -220,10 +221,11 @@ Module Impl_updated_incrementer_Incrementer.
                                     [ Ty.path "u32" ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "updated_incrementer::Incrementer"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "updated_incrementer::Incrementer",
                                       "count"
+                                    |)
                                   ]
                                 |)
                               ]
@@ -252,7 +254,11 @@ Module Impl_updated_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "updated_incrementer::Incrementer" "count"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "updated_incrementer::Incrementer",
+            "count"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
@@ -461,7 +461,9 @@ Module Impl_trait_erc20_Env.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "trait_erc20::Env" "caller" |)))
+        M.read (|
+          M.get_struct_record_field (| M.read (| self |), "trait_erc20::Env", "caller" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -657,7 +659,7 @@ Module Impl_trait_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
+                M.get_struct_record_field (| M.read (| self |), "trait_erc20::Erc20", "balances" |);
                 M.read (| owner |)
               ]
             |)
@@ -700,7 +702,11 @@ Module Impl_trait_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "allowances";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "trait_erc20::Erc20",
+                  "allowances"
+                |);
                 M.alloc (|
                   Value.Tuple [ M.read (| M.read (| owner |) |); M.read (| M.read (| spender |) |) ]
                 |)
@@ -792,7 +798,11 @@ Module Impl_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "trait_erc20::Erc20",
+                        "balances"
+                      |);
                       M.read (| M.read (| from |) |);
                       BinOp.Panic.sub (| M.read (| from_balance |), M.read (| value |) |)
                     ]
@@ -820,7 +830,11 @@ Module Impl_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "balances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "trait_erc20::Erc20",
+                        "balances"
+                      |);
                       M.read (| M.read (| to |) |);
                       BinOp.Panic.add (| M.read (| to_balance |), M.read (| value |) |)
                     ]
@@ -881,7 +895,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "total_supply"
+          M.get_struct_record_field (| M.read (| self |), "trait_erc20::Erc20", "total_supply" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -1010,7 +1024,11 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                   []
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "trait_erc20::Erc20" "allowances";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "trait_erc20::Erc20",
+                    "allowances"
+                  |);
                   Value.Tuple [ M.read (| owner |); M.read (| spender |) ];
                   M.read (| value |)
                 ]
@@ -1151,7 +1169,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1187,7 +1205,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1211,10 +1229,11 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field
-                        (M.read (| self |))
-                        "trait_erc20::Erc20"
-                        "allowances";
+                      M.get_struct_record_field (|
+                        M.read (| self |),
+                        "trait_erc20::Erc20",
+                        "allowances"
+                      |);
                       Value.Tuple [ M.read (| from |); M.read (| caller |) ];
                       BinOp.Panic.sub (| M.read (| allowance |), M.read (| value |) |)
                     ]

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_erc20.v
@@ -462,7 +462,7 @@ Module Impl_trait_erc20_Env.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "trait_erc20::Env", "caller" |)
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "trait_erc20::Env", "caller" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -659,7 +659,11 @@ Module Impl_trait_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| self |), "trait_erc20::Erc20", "balances" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "trait_erc20::Erc20",
+                  "balances"
+                |);
                 M.read (| owner |)
               ]
             |)
@@ -702,7 +706,7 @@ Module Impl_trait_erc20_Erc20.
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "trait_erc20::Erc20",
                   "allowances"
@@ -798,7 +802,7 @@ Module Impl_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "trait_erc20::Erc20",
                         "balances"
@@ -830,7 +834,7 @@ Module Impl_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "trait_erc20::Erc20",
                         "balances"
@@ -895,7 +899,11 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "trait_erc20::Erc20", "total_supply" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "trait_erc20::Erc20",
+            "total_supply"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -1024,7 +1032,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                   []
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "trait_erc20::Erc20",
                     "allowances"
@@ -1169,7 +1177,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -1205,7 +1213,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -1229,7 +1237,7 @@ Module Impl_trait_erc20_BaseErc20_for_trait_erc20_Erc20.
                       []
                     |),
                     [
-                      M.get_struct_record_field (|
+                      M.SubPointer.get_struct_record_field (|
                         M.read (| self |),
                         "trait_erc20::Erc20",
                         "allowances"

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_flipper.v
@@ -62,10 +62,14 @@ Module Impl_trait_flipper_Flip_for_trait_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (| M.read (| self |), "trait_flipper::Flipper", "value" |),
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "trait_flipper::Flipper",
+                "value"
+              |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "trait_flipper::Flipper",
                     "value"
@@ -88,7 +92,11 @@ Module Impl_trait_flipper_Flip_for_trait_flipper_Flipper.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "trait_flipper::Flipper", "value" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "trait_flipper::Flipper",
+            "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_flipper.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_flipper.v
@@ -62,10 +62,14 @@ Module Impl_trait_flipper_Flip_for_trait_flipper_Flipper.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "trait_flipper::Flipper" "value",
+              M.get_struct_record_field (| M.read (| self |), "trait_flipper::Flipper", "value" |),
               UnOp.Pure.not
                 (M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "trait_flipper::Flipper" "value"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "trait_flipper::Flipper",
+                    "value"
+                  |)
                 |))
             |) in
           M.alloc (| Value.Tuple [] |)
@@ -84,7 +88,7 @@ Module Impl_trait_flipper_Flip_for_trait_flipper_Flipper.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "trait_flipper::Flipper" "value"
+          M.get_struct_record_field (| M.read (| self |), "trait_flipper::Flipper", "value" |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_incrementer.v
@@ -47,10 +47,11 @@ Module Impl_trait_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.read (| self |))
-                "trait_incrementer::Incrementer"
-                "value" in
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "trait_incrementer::Incrementer",
+                "value"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| delta |) |) |) in
           M.alloc (| Value.Tuple [] |)
         |)))
@@ -91,7 +92,11 @@ Module Impl_trait_incrementer_Increment_for_trait_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (M.read (| self |)) "trait_incrementer::Incrementer" "value"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "trait_incrementer::Incrementer",
+            "value"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -120,10 +125,11 @@ Module Impl_trait_incrementer_Reset_for_trait_incrementer_Incrementer.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field
-                (M.read (| self |))
-                "trait_incrementer::Incrementer"
-                "value",
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "trait_incrementer::Incrementer",
+                "value"
+              |),
               Value.Integer Integer.U64 0
             |) in
           M.alloc (| Value.Tuple [] |)

--- a/CoqOfRust/examples/default/examples/ink_contracts/trait_incrementer.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/trait_incrementer.v
@@ -47,7 +47,7 @@ Module Impl_trait_incrementer_Incrementer.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "trait_incrementer::Incrementer",
                 "value"
@@ -92,7 +92,7 @@ Module Impl_trait_incrementer_Increment_for_trait_incrementer_Incrementer.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "trait_incrementer::Incrementer",
             "value"
@@ -125,7 +125,7 @@ Module Impl_trait_incrementer_Reset_for_trait_incrementer_Incrementer.
         M.read (|
           let _ :=
             M.write (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "trait_incrementer::Incrementer",
                 "value"

--- a/CoqOfRust/examples/default/examples/ink_contracts/wildcard_selector.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/wildcard_selector.v
@@ -80,8 +80,8 @@ Module Impl_wildcard_selector_WildcardSelector.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let _selector := M.copy (| γ0_0 |) in
                   let _message := M.copy (| γ0_1 |) in
                   let _ :=

--- a/CoqOfRust/examples/default/examples/ink_contracts/wildcard_selector.v
+++ b/CoqOfRust/examples/default/examples/ink_contracts/wildcard_selector.v
@@ -80,8 +80,8 @@ Module Impl_wildcard_selector_WildcardSelector.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let _selector := M.copy (| γ0_0 |) in
                   let _message := M.copy (| γ0_1 |) in
                   let _ :=

--- a/CoqOfRust/examples/default/examples/monadic_transformation/example05.v
+++ b/CoqOfRust/examples/default/examples/monadic_transformation/example05.v
@@ -22,7 +22,7 @@ Module Impl_example05_Foo.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         BinOp.Panic.add (|
-          M.read (| M.get_struct_tuple_field (| self, "example05::Foo", 0 |) |),
+          M.read (| M.SubPointer.get_struct_tuple_field (| self, "example05::Foo", 0 |) |),
           Value.Integer Integer.U32 1
         |)))
     | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/monadic_transformation/example05.v
+++ b/CoqOfRust/examples/default/examples/monadic_transformation/example05.v
@@ -22,7 +22,7 @@ Module Impl_example05_Foo.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         BinOp.Panic.add (|
-          M.read (| M.get_struct_tuple_field self "example05::Foo" 0 |),
+          M.read (| M.get_struct_tuple_field (| self, "example05::Foo", 0 |) |),
           Value.Integer Integer.U32 1
         |)))
     | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/cargo/concurrent_tests.v
+++ b/CoqOfRust/examples/default/examples/rust_book/cargo/concurrent_tests.v
@@ -20,7 +20,8 @@ Definition foo (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let _a := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -199,7 +200,7 @@ Module tests.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -375,7 +376,7 @@ Module tests.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/cargo/concurrent_tests.v
+++ b/CoqOfRust/examples/default/examples/rust_book/cargo/concurrent_tests.v
@@ -20,12 +20,7 @@ Definition foo (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let _a := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -204,7 +199,7 @@ Module tests.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -380,7 +375,7 @@ Module tests.
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/conversion/converting_to_string.v
+++ b/CoqOfRust/examples/default/examples/rust_book/conversion/converting_to_string.v
@@ -44,7 +44,7 @@ Module Impl_core_fmt_Display_for_converting_to_string_Circle.
                             [ Ty.path "i32" ]
                           |),
                           [
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "converting_to_string::Circle",
                               "radius"

--- a/CoqOfRust/examples/default/examples/rust_book/conversion/converting_to_string.v
+++ b/CoqOfRust/examples/default/examples/rust_book/conversion/converting_to_string.v
@@ -44,10 +44,11 @@ Module Impl_core_fmt_Display_for_converting_to_string_Circle.
                             [ Ty.path "i32" ]
                           |),
                           [
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "converting_to_string::Circle"
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "converting_to_string::Circle",
                               "radius"
+                            |)
                           ]
                         |)
                       ]

--- a/CoqOfRust/examples/default/examples/rust_book/conversion/try_from_and_try_into.v
+++ b/CoqOfRust/examples/default/examples/rust_book/conversion/try_from_and_try_into.v
@@ -30,7 +30,7 @@ Module Impl_core_fmt_Debug_for_try_from_and_try_into_EvenNumber.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "try_from_and_try_into::EvenNumber",
                   0
@@ -72,10 +72,14 @@ Module Impl_core_cmp_PartialEq_for_try_from_and_try_into_EvenNumber.
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| self |), "try_from_and_try_into::EvenNumber", 0 |)
+            M.SubPointer.get_struct_tuple_field (|
+              M.read (| self |),
+              "try_from_and_try_into::EvenNumber",
+              0
+            |)
           |))
           (M.read (|
-            M.get_struct_tuple_field (|
+            M.SubPointer.get_struct_tuple_field (|
               M.read (| other |),
               "try_from_and_try_into::EvenNumber",
               0
@@ -201,8 +205,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -296,8 +300,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -401,8 +405,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -498,8 +502,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/conversion/try_from_and_try_into.v
+++ b/CoqOfRust/examples/default/examples/rust_book/conversion/try_from_and_try_into.v
@@ -30,7 +30,11 @@ Module Impl_core_fmt_Debug_for_try_from_and_try_into_EvenNumber.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "try_from_and_try_into::EvenNumber" 0
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "try_from_and_try_into::EvenNumber",
+                  0
+                |)
               |))
           ]
         |)))
@@ -68,10 +72,14 @@ Module Impl_core_cmp_PartialEq_for_try_from_and_try_into_EvenNumber.
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
           (M.read (|
-            M.get_struct_tuple_field (M.read (| self |)) "try_from_and_try_into::EvenNumber" 0
+            M.get_struct_tuple_field (| M.read (| self |), "try_from_and_try_into::EvenNumber", 0 |)
           |))
           (M.read (|
-            M.get_struct_tuple_field (M.read (| other |)) "try_from_and_try_into::EvenNumber" 0
+            M.get_struct_tuple_field (|
+              M.read (| other |),
+              "try_from_and_try_into::EvenNumber",
+              0
+            |)
           |))))
     | _, _ => M.impossible
     end.
@@ -193,8 +201,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -288,8 +296,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -393,8 +401,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -490,8 +498,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/enums.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/enums.v
@@ -122,7 +122,8 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "enums::WebEvent::KeyPress", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "enums::WebEvent::KeyPress", 0 |) in
                 let c := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -169,7 +170,8 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "enums::WebEvent::Paste", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "enums::WebEvent::Paste", 0 |) in
                 let s := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -216,8 +218,10 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_record_field (| γ, "enums::WebEvent::Click", "x" |) in
-                let γ0_1 := M.get_struct_record_field (| γ, "enums::WebEvent::Click", "y" |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_record_field (| γ, "enums::WebEvent::Click", "x" |) in
+                let γ0_1 :=
+                  M.SubPointer.get_struct_record_field (| γ, "enums::WebEvent::Click", "y" |) in
                 let x := M.copy (| γ0_0 |) in
                 let y := M.copy (| γ0_1 |) in
                 let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/enums.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/enums.v
@@ -122,8 +122,7 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "enums::WebEvent::KeyPress", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "enums::WebEvent::KeyPress", 0 |) in
                 let c := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -170,8 +169,7 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "enums::WebEvent::Paste", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "enums::WebEvent::Paste", 0 |) in
                 let s := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -218,10 +216,8 @@ Definition inspect (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (| γ, "enums::WebEvent::Click", "x" |) in
-                let γ0_1 :=
-                  M.get_struct_record_field_or_break_match (| γ, "enums::WebEvent::Click", "y" |) in
+                (let γ0_0 := M.get_struct_record_field (| γ, "enums::WebEvent::Click", "x" |) in
+                let γ0_1 := M.get_struct_record_field (| γ, "enums::WebEvent::Click", "y" |) in
                 let x := M.copy (| γ0_0 |) in
                 let y := M.copy (| γ0_1 |) in
                 let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/enums_testcase_linked_list.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/enums_testcase_linked_list.v
@@ -107,9 +107,17 @@ Module Impl_enums_testcase_linked_list_List.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "enums_testcase_linked_list::List::Cons",
+                      0
+                    |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 1 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "enums_testcase_linked_list::List::Cons",
+                      1
+                    |) in
                   let tail := M.alloc (| γ0_1 |) in
                   M.alloc (|
                     BinOp.Panic.add (|
@@ -159,9 +167,17 @@ Module Impl_enums_testcase_linked_list_List.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "enums_testcase_linked_list::List::Cons",
+                      0
+                    |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 1 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "enums_testcase_linked_list::List::Cons",
+                      1
+                    |) in
                   let head := M.copy (| γ0_0 |) in
                   let tail := M.alloc (| γ0_1 |) in
                   let res :=

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/enums_testcase_linked_list.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/enums_testcase_linked_list.v
@@ -107,17 +107,9 @@ Module Impl_enums_testcase_linked_list_List.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "enums_testcase_linked_list::List::Cons",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 0 |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "enums_testcase_linked_list::List::Cons",
-                      1
-                    |) in
+                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 1 |) in
                   let tail := M.alloc (| γ0_1 |) in
                   M.alloc (|
                     BinOp.Panic.add (|
@@ -167,17 +159,9 @@ Module Impl_enums_testcase_linked_list_List.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "enums_testcase_linked_list::List::Cons",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 0 |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "enums_testcase_linked_list::List::Cons",
-                      1
-                    |) in
+                    M.get_struct_tuple_field (| γ, "enums_testcase_linked_list::List::Cons", 1 |) in
                   let head := M.copy (| γ0_0 |) in
                   let tail := M.alloc (| γ0_1 |) in
                   let res :=

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
@@ -30,12 +30,20 @@ Module Impl_core_fmt_Debug_for_structures_Person.
             M.read (| Value.String "name" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (| M.read (| self |), "structures::Person", "name" |));
+              (M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "structures::Person",
+                "name"
+              |));
             M.read (| Value.String "age" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (| M.read (| self |), "structures::Person", "age" |)
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "structures::Person",
+                  "age"
+                |)
               |))
           ]
         |)))
@@ -232,7 +240,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field (| point, "structures::Point", "x" |) ]
+                                [
+                                  M.SubPointer.get_struct_record_field (|
+                                    point,
+                                    "structures::Point",
+                                    "x"
+                                  |)
+                                ]
                               |);
                               M.call_closure (|
                                 M.get_associated_function (|
@@ -240,7 +254,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field (| point, "structures::Point", "y" |) ]
+                                [
+                                  M.SubPointer.get_struct_record_field (|
+                                    point,
+                                    "structures::Point",
+                                    "y"
+                                  |)
+                                ]
                               |)
                             ]
                         |))
@@ -286,7 +306,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     bottom_right,
                                     "structures::Point",
                                     "x"
@@ -300,7 +320,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     bottom_right,
                                     "structures::Point",
                                     "y"
@@ -320,8 +340,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_record_field (| γ, "structures::Point", "x" |) in
-                let γ0_1 := M.get_struct_record_field (| γ, "structures::Point", "y" |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_record_field (| γ, "structures::Point", "x" |) in
+                let γ0_1 :=
+                  M.SubPointer.get_struct_record_field (| γ, "structures::Point", "y" |) in
                 let left_edge := M.copy (| γ0_0 |) in
                 let top_edge := M.copy (| γ0_1 |) in
                 let _rectangle :=
@@ -379,7 +401,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             pair_,
                                             "structures::Pair",
                                             0
@@ -393,7 +415,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "f32" ]
                                         |),
                                         [
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             pair_,
                                             "structures::Pair",
                                             1
@@ -413,8 +435,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 := M.get_struct_tuple_field (| γ, "structures::Pair", 0 |) in
-                        let γ0_1 := M.get_struct_tuple_field (| γ, "structures::Pair", 1 |) in
+                        (let γ0_0 :=
+                          M.SubPointer.get_struct_tuple_field (| γ, "structures::Pair", 0 |) in
+                        let γ0_1 :=
+                          M.SubPointer.get_struct_tuple_field (| γ, "structures::Pair", 1 |) in
                         let integer := M.copy (| γ0_0 |) in
                         let decimal := M.copy (| γ0_1 |) in
                         let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
+++ b/CoqOfRust/examples/default/examples/rust_book/custom_types/structures.v
@@ -30,12 +30,12 @@ Module Impl_core_fmt_Debug_for_structures_Person.
             M.read (| Value.String "name" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (M.read (| self |)) "structures::Person" "name");
+              (M.get_struct_record_field (| M.read (| self |), "structures::Person", "name" |));
             M.read (| Value.String "age" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (M.read (| self |)) "structures::Person" "age"
+                M.get_struct_record_field (| M.read (| self |), "structures::Person", "age" |)
               |))
           ]
         |)))
@@ -232,7 +232,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field point "structures::Point" "x" ]
+                                [ M.get_struct_record_field (| point, "structures::Point", "x" |) ]
                               |);
                               M.call_closure (|
                                 M.get_associated_function (|
@@ -240,7 +240,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field point "structures::Point" "y" ]
+                                [ M.get_struct_record_field (| point, "structures::Point", "y" |) ]
                               |)
                             ]
                         |))
@@ -285,7 +285,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field bottom_right "structures::Point" "x" ]
+                                [
+                                  M.get_struct_record_field (|
+                                    bottom_right,
+                                    "structures::Point",
+                                    "x"
+                                  |)
+                                ]
                               |);
                               M.call_closure (|
                                 M.get_associated_function (|
@@ -293,7 +299,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "f32" ]
                                 |),
-                                [ M.get_struct_record_field bottom_right "structures::Point" "y" ]
+                                [
+                                  M.get_struct_record_field (|
+                                    bottom_right,
+                                    "structures::Point",
+                                    "y"
+                                  |)
+                                ]
                               |)
                             ]
                         |))
@@ -308,10 +320,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (| γ, "structures::Point", "x" |) in
-                let γ0_1 :=
-                  M.get_struct_record_field_or_break_match (| γ, "structures::Point", "y" |) in
+                (let γ0_0 := M.get_struct_record_field (| γ, "structures::Point", "x" |) in
+                let γ0_1 := M.get_struct_record_field (| γ, "structures::Point", "y" |) in
                 let left_edge := M.copy (| γ0_0 |) in
                 let top_edge := M.copy (| γ0_1 |) in
                 let _rectangle :=
@@ -368,7 +378,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           "new_debug",
                                           [ Ty.path "i32" ]
                                         |),
-                                        [ M.get_struct_tuple_field pair_ "structures::Pair" 0 ]
+                                        [
+                                          M.get_struct_tuple_field (|
+                                            pair_,
+                                            "structures::Pair",
+                                            0
+                                          |)
+                                        ]
                                       |);
                                       M.call_closure (|
                                         M.get_associated_function (|
@@ -376,7 +392,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           "new_debug",
                                           [ Ty.path "f32" ]
                                         |),
-                                        [ M.get_struct_tuple_field pair_ "structures::Pair" 1 ]
+                                        [
+                                          M.get_struct_tuple_field (|
+                                            pair_,
+                                            "structures::Pair",
+                                            1
+                                          |)
+                                        ]
                                       |)
                                     ]
                                 |))
@@ -391,10 +413,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   [
                     fun γ =>
                       ltac:(M.monadic
-                        (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (| γ, "structures::Pair", 0 |) in
-                        let γ0_1 :=
-                          M.get_struct_tuple_field_or_break_match (| γ, "structures::Pair", 1 |) in
+                        (let γ0_0 := M.get_struct_tuple_field (| γ, "structures::Pair", 0 |) in
+                        let γ0_1 := M.get_struct_tuple_field (| γ, "structures::Pair", 1 |) in
                         let integer := M.copy (| γ0_0 |) in
                         let decimal := M.copy (| γ0_1 |) in
                         let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/aliases_for_result.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/aliases_for_result.v
@@ -121,8 +121,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -167,8 +166,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/aliases_for_result.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/aliases_for_result.v
@@ -121,7 +121,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -166,7 +167,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/boxing_errors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/boxing_errors.v
@@ -377,8 +377,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -425,8 +424,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/boxing_errors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/boxing_errors.v
@@ -377,7 +377,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -424,7 +425,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_and_then.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_and_then.v
@@ -232,12 +232,7 @@ Definition cookable_v1 (τ : list Ty.t) (α : list Value.t) : M :=
               ltac:(M.monadic (M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -253,11 +248,7 @@ Definition cookable_v1 (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::option::Option::Some",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                         let food := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple "core::option::Option::Some" [ M.read (| food |) ]
@@ -327,12 +318,7 @@ Definition eat (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -463,9 +449,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let cordon_bleu := M.copy (| γ0_0 |) in
                 let steak := M.copy (| γ0_1 |) in
                 let sushi := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_and_then.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_and_then.v
@@ -232,7 +232,8 @@ Definition cookable_v1 (τ : list Ty.t) (α : list Value.t) : M :=
               ltac:(M.monadic (M.alloc (| Value.StructTuple "core::option::Option::None" [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -248,7 +249,11 @@ Definition cookable_v1 (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::option::Option::Some",
+                            0
+                          |) in
                         let food := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple "core::option::Option::Some" [ M.read (| food |) ]
@@ -318,7 +323,8 @@ Definition eat (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -449,9 +455,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let cordon_bleu := M.copy (| γ0_0 |) in
                 let steak := M.copy (| γ0_1 |) in
                 let sushi := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_map.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_map.v
@@ -101,7 +101,7 @@ Module Impl_core_fmt_Debug_for_combinators_map_Peeled.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "combinators_map::Peeled" 0
+                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Peeled", 0 |)
               |))
           ]
         |)))
@@ -145,7 +145,7 @@ Module Impl_core_fmt_Debug_for_combinators_map_Chopped.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "combinators_map::Chopped" 0
+                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Chopped", 0 |)
               |))
           ]
         |)))
@@ -189,7 +189,7 @@ Module Impl_core_fmt_Debug_for_combinators_map_Cooked.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "combinators_map::Cooked" 0
+                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Cooked", 0 |)
               |))
           ]
         |)))
@@ -223,12 +223,7 @@ Definition peel (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 M.alloc (|
                   Value.StructTuple
@@ -262,18 +257,8 @@ Definition chop (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
-                let γ1_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ0_0,
-                    "combinators_map::Peeled",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ1_0 := M.get_struct_tuple_field (| γ0_0, "combinators_map::Peeled", 0 |) in
                 let food := M.copy (| γ1_0 |) in
                 M.alloc (|
                   Value.StructTuple
@@ -322,11 +307,7 @@ Definition cook (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ,
-                              "combinators_map::Chopped",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ, "combinators_map::Chopped", 0 |) in
                           let food := M.copy (| γ0_0 |) in
                           Value.StructTuple "combinators_map::Cooked" [ M.read (| food |) ]))
                     ]
@@ -416,11 +397,7 @@ Definition process (τ : list Ty.t) (α : list Value.t) : M :=
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field_or_break_match (|
-                                  γ,
-                                  "combinators_map::Peeled",
-                                  0
-                                |) in
+                                M.get_struct_tuple_field (| γ, "combinators_map::Peeled", 0 |) in
                               let f := M.copy (| γ0_0 |) in
                               Value.StructTuple "combinators_map::Chopped" [ M.read (| f |) ]))
                         ]
@@ -440,11 +417,7 @@ Definition process (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
-                              γ,
-                              "combinators_map::Chopped",
-                              0
-                            |) in
+                            M.get_struct_tuple_field (| γ, "combinators_map::Chopped", 0 |) in
                           let f := M.copy (| γ0_0 |) in
                           Value.StructTuple "combinators_map::Cooked" [ M.read (| f |) ]))
                     ]
@@ -475,12 +448,7 @@ Definition eat (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_map.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/combinators_map.v
@@ -101,7 +101,11 @@ Module Impl_core_fmt_Debug_for_combinators_map_Peeled.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Peeled", 0 |)
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "combinators_map::Peeled",
+                  0
+                |)
               |))
           ]
         |)))
@@ -145,7 +149,11 @@ Module Impl_core_fmt_Debug_for_combinators_map_Chopped.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Chopped", 0 |)
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "combinators_map::Chopped",
+                  0
+                |)
               |))
           ]
         |)))
@@ -189,7 +197,11 @@ Module Impl_core_fmt_Debug_for_combinators_map_Cooked.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (| M.read (| self |), "combinators_map::Cooked", 0 |)
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "combinators_map::Cooked",
+                  0
+                |)
               |))
           ]
         |)))
@@ -223,7 +235,8 @@ Definition peel (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 M.alloc (|
                   Value.StructTuple
@@ -257,8 +270,10 @@ Definition chop (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
-                let γ1_0 := M.get_struct_tuple_field (| γ0_0, "combinators_map::Peeled", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ1_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ0_0, "combinators_map::Peeled", 0 |) in
                 let food := M.copy (| γ1_0 |) in
                 M.alloc (|
                   Value.StructTuple
@@ -307,7 +322,11 @@ Definition cook (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (| γ, "combinators_map::Chopped", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ,
+                              "combinators_map::Chopped",
+                              0
+                            |) in
                           let food := M.copy (| γ0_0 |) in
                           Value.StructTuple "combinators_map::Cooked" [ M.read (| food |) ]))
                     ]
@@ -397,7 +416,11 @@ Definition process (τ : list Ty.t) (α : list Value.t) : M :=
                           fun γ =>
                             ltac:(M.monadic
                               (let γ0_0 :=
-                                M.get_struct_tuple_field (| γ, "combinators_map::Peeled", 0 |) in
+                                M.SubPointer.get_struct_tuple_field (|
+                                  γ,
+                                  "combinators_map::Peeled",
+                                  0
+                                |) in
                               let f := M.copy (| γ0_0 |) in
                               Value.StructTuple "combinators_map::Chopped" [ M.read (| f |) ]))
                         ]
@@ -417,7 +440,11 @@ Definition process (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (| γ, "combinators_map::Chopped", 0 |) in
+                            M.SubPointer.get_struct_tuple_field (|
+                              γ,
+                              "combinators_map::Chopped",
+                              0
+                            |) in
                           let f := M.copy (| γ0_0 |) in
                           Value.StructTuple "combinators_map::Cooked" [ M.read (| f |) ]))
                     ]
@@ -448,7 +475,8 @@ Definition eat (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let food := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/defining_an_error_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/defining_an_error_type.v
@@ -286,7 +286,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -333,7 +334,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/defining_an_error_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/defining_an_error_type.v
@@ -286,8 +286,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -334,8 +333,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
@@ -38,21 +38,13 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let first_number := M.copy (| γ0_0 |) in
                         first_number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -79,21 +71,13 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let second_number := M.copy (| γ0_0 |) in
                         second_number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -136,8 +120,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -182,8 +165,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/early_returns.v
@@ -38,13 +38,21 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let first_number := M.copy (| γ0_0 |) in
                         first_number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -71,13 +79,21 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let second_number := M.copy (| γ0_0 |) in
                         second_number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -120,7 +136,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -165,7 +182,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
@@ -44,7 +44,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -80,7 +80,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -116,7 +116,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -152,7 +152,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -191,8 +191,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -237,8 +236,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark.v
@@ -44,7 +44,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -80,7 +80,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -116,7 +116,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -152,7 +152,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -191,7 +191,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -236,7 +237,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
@@ -31,13 +31,21 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let val := M.copy (| γ0_0 |) in
                         val));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let err := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -77,13 +85,21 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let val := M.copy (| γ0_0 |) in
                         val));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let err := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -139,7 +155,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -184,7 +201,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/introducing_question_mark_is_an_replacement_for_deprecated_try.v
@@ -31,21 +31,13 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let val := M.copy (| γ0_0 |) in
                         val));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let err := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -85,21 +77,13 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let val := M.copy (| γ0_0 |) in
                         val));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let err := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -155,8 +139,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -201,8 +184,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition.v
@@ -168,8 +168,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 let numbers := M.copy (| γ0_0 |) in
                 let errors := M.copy (| γ0_1 |) in
                 let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition.v
@@ -168,8 +168,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 let numbers := M.copy (| γ0_0 |) in
                 let errors := M.copy (| γ0_1 |) in
                 let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition_unwrapped.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition_unwrapped.v
@@ -170,8 +170,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 let numbers := M.copy (| γ0_0 |) in
                 let errors := M.copy (| γ0_1 |) in
                 let numbers :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition_unwrapped.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/iterating_over_results_collect_valid_values_and_failures_via_partition_unwrapped.v
@@ -170,8 +170,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 let numbers := M.copy (| γ0_0 |) in
                 let errors := M.copy (| γ0_1 |) in
                 let numbers :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_combinators.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_combinators.v
@@ -116,7 +116,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -161,7 +162,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_combinators.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_combinators.v
@@ -116,8 +116,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -162,8 +161,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_match.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_match.v
@@ -29,7 +29,8 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let first_number := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -42,7 +43,11 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let second_number := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple
@@ -57,7 +62,11 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
@@ -66,7 +75,8 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
           ]
@@ -94,7 +104,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -139,7 +150,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_match.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/map_in_result_via_match.v
@@ -29,8 +29,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let first_number := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -43,11 +42,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let second_number := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple
@@ -62,11 +57,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ]
@@ -75,8 +66,7 @@ Definition multiply (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
           ]
@@ -104,8 +94,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -150,8 +139,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/option_and_unwrap.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/option_and_unwrap.v
@@ -22,7 +22,8 @@ Definition give_adult (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.String "lemonade" |) in
                 let _ :=
@@ -51,7 +52,8 @@ Definition give_adult (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let inner := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/option_and_unwrap.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/option_and_unwrap.v
@@ -22,12 +22,7 @@ Definition give_adult (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (| M.read (| γ0_0 |), Value.String "lemonade" |) in
                 let _ :=
@@ -56,12 +51,7 @@ Definition give_adult (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let inner := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
@@ -172,7 +172,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -216,7 +216,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -252,7 +252,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -296,7 +296,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -335,7 +335,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -382,7 +383,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/other_uses_of_question_mark.v
@@ -172,7 +172,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -216,7 +216,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -252,7 +252,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -296,7 +296,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -335,8 +335,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -383,8 +382,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
@@ -33,21 +33,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let number := M.copy (| γ0_0 |) in
                         number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/result_use_in_main.v
@@ -33,13 +33,21 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let number := M.copy (| γ0_0 |) in
                         number));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let e := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
@@ -130,7 +130,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
         M.catch_return (|
           ltac:(M.monadic
             (M.read (|
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.match_operator (|
                   M.alloc (|
                     M.call_closure (|
@@ -145,7 +145,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field (|
+                          M.SubPointer.get_struct_record_field (|
                             M.match_operator (|
                               M.alloc (|
                                 M.call_closure (|
@@ -160,7 +160,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field (|
+                                      M.SubPointer.get_struct_record_field (|
                                         M.read (| self |),
                                         "unpacking_options_via_question_mark::Person",
                                         "job"
@@ -173,7 +173,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -206,7 +206,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -226,7 +226,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -257,7 +257,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -350,8 +350,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/unpacking_options_via_question_mark.v
@@ -130,8 +130,8 @@ Module Impl_unpacking_options_via_question_mark_Person.
         M.catch_return (|
           ltac:(M.monadic
             (M.read (|
-              M.get_struct_record_field
-                (M.match_operator (|
+              M.get_struct_record_field (|
+                M.match_operator (|
                   M.alloc (|
                     M.call_closure (|
                       M.get_trait_method (|
@@ -145,8 +145,8 @@ Module Impl_unpacking_options_via_question_mark_Person.
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field
-                            (M.match_operator (|
+                          M.get_struct_record_field (|
+                            M.match_operator (|
                               M.alloc (|
                                 M.call_closure (|
                                   M.get_trait_method (|
@@ -160,10 +160,11 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                   |),
                                   [
                                     M.read (|
-                                      M.get_struct_record_field
-                                        (M.read (| self |))
-                                        "unpacking_options_via_question_mark::Person"
+                                      M.get_struct_record_field (|
+                                        M.read (| self |),
+                                        "unpacking_options_via_question_mark::Person",
                                         "job"
+                                      |)
                                     |)
                                   ]
                                 |)
@@ -172,7 +173,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Break",
                                         0
@@ -205,7 +206,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.get_struct_tuple_field (|
                                         γ,
                                         "core::ops::control_flow::ControlFlow::Continue",
                                         0
@@ -213,9 +214,10 @@ Module Impl_unpacking_options_via_question_mark_Person.
                                     let val := M.copy (| γ0_0 |) in
                                     val))
                               ]
-                            |))
-                            "unpacking_options_via_question_mark::Job"
+                            |),
+                            "unpacking_options_via_question_mark::Job",
                             "phone_number"
+                          |)
                         |)
                       ]
                     |)
@@ -224,7 +226,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -255,7 +257,7 @@ Module Impl_unpacking_options_via_question_mark_Person.
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -263,9 +265,10 @@ Module Impl_unpacking_options_via_question_mark_Person.
                         let val := M.copy (| γ0_0 |) in
                         val))
                   ]
-                |))
-                "unpacking_options_via_question_mark::PhoneNumber"
+                |),
+                "unpacking_options_via_question_mark::PhoneNumber",
                 "area_code"
+              |)
             |)))
         |)))
     | _, _ => M.impossible
@@ -347,8 +350,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
@@ -52,11 +52,7 @@ Module Impl_core_fmt_Debug_for_wrapping_errors_DoubleError.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "wrapping_errors::DoubleError::Parse",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "wrapping_errors::DoubleError::Parse", 0 |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     M.call_closure (|
@@ -222,11 +218,7 @@ Module Impl_core_error_Error_for_wrapping_errors_DoubleError.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "wrapping_errors::DoubleError::Parse",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "wrapping_errors::DoubleError::Parse", 0 |) in
                   let e := M.alloc (| γ0_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -354,7 +346,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -390,7 +382,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -426,7 +418,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -462,7 +454,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -506,8 +498,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -554,8 +545,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=
@@ -620,11 +610,7 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::option::Option::Some",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                         let source := M.copy (| γ0_0 |) in
                         let _ :=
                           let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/error_handling/wrapping_errors.v
@@ -52,7 +52,11 @@ Module Impl_core_fmt_Debug_for_wrapping_errors_DoubleError.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field (| γ, "wrapping_errors::DoubleError::Parse", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "wrapping_errors::DoubleError::Parse",
+                      0
+                    |) in
                   let __self_0 := M.alloc (| γ1_0 |) in
                   M.alloc (|
                     M.call_closure (|
@@ -218,7 +222,11 @@ Module Impl_core_error_Error_for_wrapping_errors_DoubleError.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field (| γ, "wrapping_errors::DoubleError::Parse", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "wrapping_errors::DoubleError::Parse",
+                      0
+                    |) in
                   let e := M.alloc (| γ0_0 |) in
                   M.alloc (|
                     Value.StructTuple
@@ -346,7 +354,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -382,7 +390,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -418,7 +426,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -454,7 +462,7 @@ Definition double_first (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -498,7 +506,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -545,7 +554,8 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=
@@ -610,7 +620,11 @@ Definition print (τ : list Ty.t) (α : list Value.t) : M :=
                             |)
                           |) in
                         let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::option::Option::Some",
+                            0
+                          |) in
                         let source := M.copy (| γ0_0 |) in
                         let _ :=
                           let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/expressions/const_underscore_expression.v
+++ b/CoqOfRust/examples/default/examples/rust_book/expressions/const_underscore_expression.v
@@ -21,7 +21,9 @@ Module underscore.
       | [], [ self ] =>
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
-          M.read (| M.get_struct_record_field self "const_underscore_expression::Bar" "test" |)))
+          M.read (|
+            M.get_struct_record_field (| self, "const_underscore_expression::Bar", "test" |)
+          |)))
       | _, _ => M.impossible
       end.
     

--- a/CoqOfRust/examples/default/examples/rust_book/expressions/const_underscore_expression.v
+++ b/CoqOfRust/examples/default/examples/rust_book/expressions/const_underscore_expression.v
@@ -22,7 +22,11 @@ Module underscore.
         ltac:(M.monadic
           (let self := M.alloc (| self |) in
           M.read (|
-            M.get_struct_record_field (| self, "const_underscore_expression::Bar", "test" |)
+            M.SubPointer.get_struct_record_field (|
+              self,
+              "const_underscore_expression::Bar",
+              "test"
+            |)
           |)))
       | _, _ => M.impossible
       end.

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_into_iter.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_into_iter.v
@@ -121,7 +121,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_into_iter.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_into_iter.v
@@ -121,7 +121,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter.v
@@ -130,7 +130,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter.v
@@ -130,7 +130,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter_mut.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter_mut.v
@@ -129,7 +129,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter_mut.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_iterators_iter_mut.v
@@ -129,7 +129,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_completely_inclusive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_completely_inclusive.v
@@ -74,7 +74,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_completely_inclusive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_completely_inclusive.v
@@ -74,7 +74,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_inclusive_to_exclusive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_inclusive_to_exclusive.v
@@ -70,7 +70,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_inclusive_to_exclusive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/for_and_range_inclusive_to_exclusive.v
@@ -70,7 +70,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let.v
@@ -55,12 +55,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := number in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -117,12 +112,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := letter in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -212,12 +202,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ := emoticon in
-                let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let i := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let.v
@@ -55,7 +55,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := number in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -112,7 +113,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               fun γ =>
                 ltac:(M.monadic
                   (let γ := letter in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -202,7 +204,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ := emoticon in
-                let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let i := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_dont_use_match.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_dont_use_match.v
@@ -33,7 +33,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_dont_use_match.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_dont_use_match.v
@@ -33,12 +33,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let i := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_match_enum_values.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_match_enum_values.v
@@ -147,7 +147,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 ltac:(M.monadic
                   (let γ := c in
                   let γ0_0 :=
-                    M.get_struct_tuple_field (| γ, "if_let_match_enum_values::Foo::Qux", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "if_let_match_enum_values::Foo::Qux",
+                      0
+                    |) in
                   let value := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -204,7 +208,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               ltac:(M.monadic
                 (let γ := c in
                 let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "if_let_match_enum_values::Foo::Qux", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "if_let_match_enum_values::Foo::Qux",
+                    0
+                  |) in
                 let value := M.copy (| γ0_0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_match_enum_values.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/if_let_match_enum_values.v
@@ -147,11 +147,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 ltac:(M.monadic
                   (let γ := c in
                   let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "if_let_match_enum_values::Foo::Qux",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "if_let_match_enum_values::Foo::Qux", 0 |) in
                   let value := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -208,11 +204,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               ltac:(M.monadic
                 (let γ := c in
                 let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "if_let_match_enum_values::Foo::Qux",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "if_let_match_enum_values::Foo::Qux", 0 |) in
                 let value := M.copy (| γ0_0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/loop_returning_from_loops.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/loop_returning_from_loops.v
@@ -56,8 +56,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/loop_returning_from_loops.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/loop_returning_from_loops.v
@@ -56,8 +56,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_binding_destructure_enum_variants.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_binding_destructure_enum_variants.v
@@ -42,12 +42,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
@@ -99,12 +94,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_binding_destructure_enum_variants.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_binding_destructure_enum_variants.v
@@ -42,7 +42,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
@@ -94,7 +95,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let n := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_arrays_slices.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_arrays_slices.v
@@ -59,9 +59,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
+                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.get_slice_index (| γ, 1 |) in
+                let γ0_2 := M.get_slice_index (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -123,9 +123,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                let γ0_2 := M.get_slice_index_or_break_match (| γ, 2 |) in
+                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.get_slice_index (| γ, 1 |) in
+                let γ0_2 := M.get_slice_index (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -177,9 +177,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                let γ0_rest := M.get_slice_rest_or_break_match (| γ, 2, 0 |) in
+                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.get_slice_index (| γ, 1 |) in
+                let γ0_rest := M.get_slice_rest (| γ, 2, 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -233,9 +233,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index_or_break_match (| γ, 1 |) in
-                let γ0_rest := M.get_slice_rest_or_break_match (| γ, 2, 0 |) in
+                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.get_slice_index (| γ, 1 |) in
+                let γ0_rest := M.get_slice_rest (| γ, 2, 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -297,9 +297,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index_or_break_match (| γ, 0 |) in
-                let γ0_rest := M.get_slice_rest_or_break_match (| γ, 1, 1 |) in
-                let γ0_rev0 := M.get_slice_rev_index_or_break_match (| γ, 0 |) in
+                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
+                let γ0_rest := M.get_slice_rest (| γ, 1, 1 |) in
+                let γ0_rev0 := M.get_slice_rev_index (| γ, 0 |) in
                 let first := M.copy (| γ0_0 |) in
                 let middle := M.copy (| γ0_rest |) in
                 let last := M.copy (| γ0_rev0 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_arrays_slices.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_arrays_slices.v
@@ -59,9 +59,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index (| γ, 1 |) in
-                let γ0_2 := M.get_slice_index (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -123,9 +123,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index (| γ, 1 |) in
-                let γ0_2 := M.get_slice_index (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_slice_index (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -177,9 +177,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index (| γ, 1 |) in
-                let γ0_rest := M.get_slice_rest (| γ, 2, 0 |) in
+                (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                let γ0_rest := M.SubPointer.get_slice_rest (| γ, 2, 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -233,9 +233,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
-                let γ0_1 := M.get_slice_index (| γ, 1 |) in
-                let γ0_rest := M.get_slice_rest (| γ, 2, 0 |) in
+                (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_slice_index (| γ, 1 |) in
+                let γ0_rest := M.SubPointer.get_slice_rest (| γ, 2, 0 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -297,9 +297,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_slice_index (| γ, 0 |) in
-                let γ0_rest := M.get_slice_rest (| γ, 1, 1 |) in
-                let γ0_rev0 := M.get_slice_rev_index (| γ, 0 |) in
+                (let γ0_0 := M.SubPointer.get_slice_index (| γ, 0 |) in
+                let γ0_rest := M.SubPointer.get_slice_rest (| γ, 1, 1 |) in
+                let γ0_rev0 := M.SubPointer.get_slice_rev_index (| γ, 0 |) in
                 let first := M.copy (| γ0_0 |) in
                 let middle := M.copy (| γ0_rest |) in
                 let last := M.copy (| γ0_rev0 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_enums.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_enums.v
@@ -194,11 +194,23 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::RGB",
+                    0
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 1 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::RGB",
+                    1
+                  |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 2 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::RGB",
+                    2
+                  |) in
                 let r := M.copy (| γ0_0 |) in
                 let g := M.copy (| γ0_1 |) in
                 let b := M.copy (| γ0_2 |) in
@@ -266,11 +278,23 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSV",
+                    0
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 1 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSV",
+                    1
+                  |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 2 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSV",
+                    2
+                  |) in
                 let h := M.copy (| γ0_0 |) in
                 let s := M.copy (| γ0_1 |) in
                 let v := M.copy (| γ0_2 |) in
@@ -338,11 +362,23 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSL",
+                    0
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 1 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSL",
+                    1
+                  |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 2 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::HSL",
+                    2
+                  |) in
                 let h := M.copy (| γ0_0 |) in
                 let s := M.copy (| γ0_1 |) in
                 let l := M.copy (| γ0_2 |) in
@@ -410,11 +446,23 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMY",
+                    0
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 1 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMY",
+                    1
+                  |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 2 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMY",
+                    2
+                  |) in
                 let c := M.copy (| γ0_0 |) in
                 let m := M.copy (| γ0_1 |) in
                 let y := M.copy (| γ0_2 |) in
@@ -482,13 +530,29 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMYK",
+                    0
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 1 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMYK",
+                    1
+                  |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 2 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMYK",
+                    2
+                  |) in
                 let γ0_3 :=
-                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 3 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_destructuring_enums::Color::CMYK",
+                    3
+                  |) in
                 let c := M.copy (| γ0_0 |) in
                 let m := M.copy (| γ0_1 |) in
                 let y := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_enums.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_enums.v
@@ -194,23 +194,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::RGB",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 0 |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::RGB",
-                    1
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 1 |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::RGB",
-                    2
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::RGB", 2 |) in
                 let r := M.copy (| γ0_0 |) in
                 let g := M.copy (| γ0_1 |) in
                 let b := M.copy (| γ0_2 |) in
@@ -278,23 +266,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSV",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 0 |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSV",
-                    1
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 1 |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSV",
-                    2
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSV", 2 |) in
                 let h := M.copy (| γ0_0 |) in
                 let s := M.copy (| γ0_1 |) in
                 let v := M.copy (| γ0_2 |) in
@@ -362,23 +338,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSL",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 0 |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSL",
-                    1
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 1 |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::HSL",
-                    2
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::HSL", 2 |) in
                 let h := M.copy (| γ0_0 |) in
                 let s := M.copy (| γ0_1 |) in
                 let l := M.copy (| γ0_2 |) in
@@ -446,23 +410,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMY",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 0 |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMY",
-                    1
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 1 |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMY",
-                    2
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMY", 2 |) in
                 let c := M.copy (| γ0_0 |) in
                 let m := M.copy (| γ0_1 |) in
                 let y := M.copy (| γ0_2 |) in
@@ -530,29 +482,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMYK",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 0 |) in
                 let γ0_1 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMYK",
-                    1
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 1 |) in
                 let γ0_2 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMYK",
-                    2
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 2 |) in
                 let γ0_3 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_destructuring_enums::Color::CMYK",
-                    3
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_destructuring_enums::Color::CMYK", 3 |) in
                 let c := M.copy (| γ0_0 |) in
                 let m := M.copy (| γ0_1 |) in
                 let y := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_structs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_structs.v
@@ -47,11 +47,19 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "x" |) in
+                  M.SubPointer.get_struct_record_field (|
+                    γ,
+                    "match_destructuring_structs::Foo",
+                    "x"
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
-                let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                  M.SubPointer.get_struct_record_field (|
+                    γ,
+                    "match_destructuring_structs::Foo",
+                    "y"
+                  |) in
+                let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ1_0 |),
@@ -114,9 +122,17 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
+                  M.SubPointer.get_struct_record_field (|
+                    γ,
+                    "match_destructuring_structs::Foo",
+                    "y"
+                  |) in
                 let γ0_1 :=
-                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "x" |) in
+                  M.SubPointer.get_struct_record_field (|
+                    γ,
+                    "match_destructuring_structs::Foo",
+                    "x"
+                  |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -169,7 +185,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
+                  M.SubPointer.get_struct_record_field (|
+                    γ,
+                    "match_destructuring_structs::Foo",
+                    "y"
+                  |) in
                 let y := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_structs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_structs.v
@@ -47,19 +47,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (|
-                    γ,
-                    "match_destructuring_structs::Foo",
-                    "x"
-                  |) in
+                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "x" |) in
                 let γ0_1 :=
-                  M.get_struct_record_field_or_break_match (|
-                    γ,
-                    "match_destructuring_structs::Foo",
-                    "y"
-                  |) in
-                let γ1_0 := M.get_tuple_field γ0_0 0 in
-                let γ1_1 := M.get_tuple_field γ0_0 1 in
+                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
+                let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ1_0 |),
@@ -122,17 +114,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (|
-                    γ,
-                    "match_destructuring_structs::Foo",
-                    "y"
-                  |) in
+                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
                 let γ0_1 :=
-                  M.get_struct_record_field_or_break_match (|
-                    γ,
-                    "match_destructuring_structs::Foo",
-                    "x"
-                  |) in
+                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "x" |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -185,11 +169,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (|
-                    γ,
-                    "match_destructuring_structs::Foo",
-                    "y"
-                  |) in
+                  M.get_struct_record_field (| γ, "match_destructuring_structs::Foo", "y" |) in
                 let y := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples.v
@@ -79,9 +79,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -143,9 +143,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -182,9 +182,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_2 |),
@@ -221,9 +221,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples.v
@@ -79,9 +79,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -143,9 +143,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -182,9 +182,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_2 |),
@@ -221,9 +221,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples_fixed.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples_fixed.v
@@ -79,9 +79,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -143,9 +143,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -182,9 +182,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_2 |),
@@ -221,9 +221,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples_fixed.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_destructuring_tuples_fixed.v
@@ -79,9 +79,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -143,9 +143,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),
@@ -182,9 +182,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_2 |),
@@ -221,9 +221,9 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
                 let _ :=
                   M.is_constant_or_break_match (|
                     M.read (| γ0_0 |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_guards.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_guards.v
@@ -51,11 +51,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_guards::Temperature::Celsius",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Celsius", 0 |) in
                 let t := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| t |)) (Value.Integer Integer.I32 30) |) in
@@ -106,11 +102,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_guards::Temperature::Celsius",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Celsius", 0 |) in
                 let t := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -158,11 +150,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_guards::Temperature::Fahrenheit",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Fahrenheit", 0 |) in
                 let t := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| t |)) (Value.Integer Integer.I32 86) |) in
@@ -213,11 +201,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "match_guards::Temperature::Fahrenheit",
-                    0
-                  |) in
+                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Fahrenheit", 0 |) in
                 let t := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_guards.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/match_guards.v
@@ -51,7 +51,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Celsius", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_guards::Temperature::Celsius",
+                    0
+                  |) in
                 let t := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| t |)) (Value.Integer Integer.I32 30) |) in
@@ -102,7 +106,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Celsius", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_guards::Temperature::Celsius",
+                    0
+                  |) in
                 let t := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|
@@ -150,7 +158,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Fahrenheit", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_guards::Temperature::Fahrenheit",
+                    0
+                  |) in
                 let t := M.copy (| γ0_0 |) in
                 let γ :=
                   M.alloc (| BinOp.Pure.gt (M.read (| t |)) (Value.Integer Integer.I32 86) |) in
@@ -201,7 +213,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (| γ, "match_guards::Temperature::Fahrenheit", 0 |) in
+                  M.SubPointer.get_struct_tuple_field (|
+                    γ,
+                    "match_guards::Temperature::Fahrenheit",
+                    0
+                  |) in
                 let t := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let.v
@@ -40,7 +40,12 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 fun γ =>
                   ltac:(M.monadic
                     (let γ := optional in
-                    let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                    let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (|
+                        γ,
+                        "core::option::Option::Some",
+                        0
+                      |) in
                     let i := M.copy (| γ0_0 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let.v
@@ -40,12 +40,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 fun γ =>
                   ltac:(M.monadic
                     (let γ := optional in
-                    let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::option::Option::Some",
-                        0
-                      |) in
+                    let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                     let i := M.copy (| γ0_0 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let_match_is_weird.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let_match_is_weird.v
@@ -45,7 +45,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                      M.SubPointer.get_struct_tuple_field (|
+                        γ,
+                        "core::option::Option::Some",
+                        0
+                      |) in
                     let i := M.copy (| γ0_0 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),

--- a/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let_match_is_weird.v
+++ b/CoqOfRust/examples/default/examples/rust_book/flow_of_control/while_let_match_is_weird.v
@@ -45,11 +45,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 fun γ =>
                   ltac:(M.monadic
                     (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::option::Option::Some",
-                        0
-                      |) in
+                      M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                     let i := M.copy (| γ0_0 |) in
                     M.match_operator (|
                       M.alloc (| Value.Tuple [] |),

--- a/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
@@ -73,10 +73,11 @@ Module Impl_associated_functions_and_methods_Rectangle.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "associated_functions_and_methods::Rectangle"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "associated_functions_and_methods::Rectangle",
             "p1"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -101,21 +102,22 @@ Module Impl_associated_functions_and_methods_Rectangle.
         (let self := M.alloc (| self |) in
         M.read (|
           M.match_operator (|
-            M.get_struct_record_field
-              (M.read (| self |))
-              "associated_functions_and_methods::Rectangle"
-              "p1",
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "associated_functions_and_methods::Rectangle",
+              "p1"
+            |),
             [
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_record_field_or_break_match (|
+                    M.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "x"
                     |) in
                   let γ0_1 :=
-                    M.get_struct_record_field_or_break_match (|
+                    M.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "y"
@@ -123,21 +125,22 @@ Module Impl_associated_functions_and_methods_Rectangle.
                   let x1 := M.copy (| γ0_0 |) in
                   let y1 := M.copy (| γ0_1 |) in
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "associated_functions_and_methods::Rectangle"
-                      "p2",
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "associated_functions_and_methods::Rectangle",
+                      "p2"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "y"
@@ -180,21 +183,22 @@ Module Impl_associated_functions_and_methods_Rectangle.
         (let self := M.alloc (| self |) in
         M.read (|
           M.match_operator (|
-            M.get_struct_record_field
-              (M.read (| self |))
-              "associated_functions_and_methods::Rectangle"
-              "p1",
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "associated_functions_and_methods::Rectangle",
+              "p1"
+            |),
             [
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_record_field_or_break_match (|
+                    M.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "x"
                     |) in
                   let γ0_1 :=
-                    M.get_struct_record_field_or_break_match (|
+                    M.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "y"
@@ -202,21 +206,22 @@ Module Impl_associated_functions_and_methods_Rectangle.
                   let x1 := M.copy (| γ0_0 |) in
                   let y1 := M.copy (| γ0_1 |) in
                   M.match_operator (|
-                    M.get_struct_record_field
-                      (M.read (| self |))
-                      "associated_functions_and_methods::Rectangle"
-                      "p2",
+                    M.get_struct_record_field (|
+                      M.read (| self |),
+                      "associated_functions_and_methods::Rectangle",
+                      "p2"
+                    |),
                     [
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "y"
@@ -267,43 +272,51 @@ Module Impl_associated_functions_and_methods_Rectangle.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "associated_functions_and_methods::Rectangle"
-                  "p1")
-                "associated_functions_and_methods::Point"
-                "x" in
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "associated_functions_and_methods::Rectangle",
+                  "p1"
+                |),
+                "associated_functions_and_methods::Point",
+                "x"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| x |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "associated_functions_and_methods::Rectangle"
-                  "p2")
-                "associated_functions_and_methods::Point"
-                "x" in
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "associated_functions_and_methods::Rectangle",
+                  "p2"
+                |),
+                "associated_functions_and_methods::Point",
+                "x"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| x |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "associated_functions_and_methods::Rectangle"
-                  "p1")
-                "associated_functions_and_methods::Point"
-                "y" in
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "associated_functions_and_methods::Rectangle",
+                  "p1"
+                |),
+                "associated_functions_and_methods::Point",
+                "y"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| y |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "associated_functions_and_methods::Rectangle"
-                  "p2")
-                "associated_functions_and_methods::Point"
-                "y" in
+              M.get_struct_record_field (|
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "associated_functions_and_methods::Rectangle",
+                  "p2"
+                |),
+                "associated_functions_and_methods::Point",
+                "y"
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| y |) |) |) in
           M.alloc (| Value.Tuple [] |)
         |)))
@@ -349,17 +362,9 @@ Module Impl_associated_functions_and_methods_Pair.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "associated_functions_and_methods::Pair",
-                      0
-                    |) in
+                    M.get_struct_tuple_field (| γ, "associated_functions_and_methods::Pair", 0 |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "associated_functions_and_methods::Pair",
-                      1
-                    |) in
+                    M.get_struct_tuple_field (| γ, "associated_functions_and_methods::Pair", 1 |) in
                   let first := M.copy (| γ0_0 |) in
                   let second := M.copy (| γ0_1 |) in
                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/associated_functions_and_methods.v
@@ -73,7 +73,7 @@ Module Impl_associated_functions_and_methods_Rectangle.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "associated_functions_and_methods::Rectangle",
             "p1"
@@ -102,7 +102,7 @@ Module Impl_associated_functions_and_methods_Rectangle.
         (let self := M.alloc (| self |) in
         M.read (|
           M.match_operator (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "associated_functions_and_methods::Rectangle",
               "p1"
@@ -111,13 +111,13 @@ Module Impl_associated_functions_and_methods_Rectangle.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "x"
                     |) in
                   let γ0_1 :=
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "y"
@@ -125,7 +125,7 @@ Module Impl_associated_functions_and_methods_Rectangle.
                   let x1 := M.copy (| γ0_0 |) in
                   let y1 := M.copy (| γ0_1 |) in
                   M.match_operator (|
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "associated_functions_and_methods::Rectangle",
                       "p2"
@@ -134,13 +134,13 @@ Module Impl_associated_functions_and_methods_Rectangle.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "y"
@@ -183,7 +183,7 @@ Module Impl_associated_functions_and_methods_Rectangle.
         (let self := M.alloc (| self |) in
         M.read (|
           M.match_operator (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "associated_functions_and_methods::Rectangle",
               "p1"
@@ -192,13 +192,13 @@ Module Impl_associated_functions_and_methods_Rectangle.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "x"
                     |) in
                   let γ0_1 :=
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       γ,
                       "associated_functions_and_methods::Point",
                       "y"
@@ -206,7 +206,7 @@ Module Impl_associated_functions_and_methods_Rectangle.
                   let x1 := M.copy (| γ0_0 |) in
                   let y1 := M.copy (| γ0_1 |) in
                   M.match_operator (|
-                    M.get_struct_record_field (|
+                    M.SubPointer.get_struct_record_field (|
                       M.read (| self |),
                       "associated_functions_and_methods::Rectangle",
                       "p2"
@@ -215,13 +215,13 @@ Module Impl_associated_functions_and_methods_Rectangle.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "associated_functions_and_methods::Point",
                               "y"
@@ -272,8 +272,8 @@ Module Impl_associated_functions_and_methods_Rectangle.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "associated_functions_and_methods::Rectangle",
                   "p1"
@@ -284,8 +284,8 @@ Module Impl_associated_functions_and_methods_Rectangle.
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| x |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "associated_functions_and_methods::Rectangle",
                   "p2"
@@ -296,8 +296,8 @@ Module Impl_associated_functions_and_methods_Rectangle.
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| x |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "associated_functions_and_methods::Rectangle",
                   "p1"
@@ -308,8 +308,8 @@ Module Impl_associated_functions_and_methods_Rectangle.
             M.write (| β, BinOp.Panic.add (| M.read (| β |), M.read (| y |) |) |) in
           let _ :=
             let β :=
-              M.get_struct_record_field (|
-                M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "associated_functions_and_methods::Rectangle",
                   "p2"
@@ -362,9 +362,17 @@ Module Impl_associated_functions_and_methods_Pair.
               fun γ =>
                 ltac:(M.monadic
                   (let γ0_0 :=
-                    M.get_struct_tuple_field (| γ, "associated_functions_and_methods::Pair", 0 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "associated_functions_and_methods::Pair",
+                      0
+                    |) in
                   let γ0_1 :=
-                    M.get_struct_tuple_field (| γ, "associated_functions_and_methods::Pair", 1 |) in
+                    M.SubPointer.get_struct_tuple_field (|
+                      γ,
+                      "associated_functions_and_methods::Pair",
+                      1
+                    |) in
                   let first := M.copy (| γ0_0 |) in
                   let second := M.copy (| γ0_1 |) in
                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/functions/diverging_functions_example_sum_odd_numbers.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/diverging_functions_example_sum_odd_numbers.v
@@ -159,7 +159,7 @@ Module main.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field (|
+                                      M.SubPointer.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0

--- a/CoqOfRust/examples/default/examples/rust_book/functions/diverging_functions_example_sum_odd_numbers.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/diverging_functions_example_sum_odd_numbers.v
@@ -159,7 +159,7 @@ Module main.
                                 fun γ =>
                                   ltac:(M.monadic
                                     (let γ0_0 :=
-                                      M.get_struct_tuple_field_or_break_match (|
+                                      M.get_struct_tuple_field (|
                                         γ,
                                         "core::option::Option::Some",
                                         0

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
@@ -319,7 +319,7 @@ Definition fizzbuzz_to (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions.v
@@ -319,7 +319,7 @@ Definition fizzbuzz_to (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
@@ -139,8 +139,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -263,8 +263,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/functions_closures_example_searching_through_iterators_Iterator_position.v
@@ -139,8 +139,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -263,8 +263,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/functions/higher_order_functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/higher_order_functions.v
@@ -131,7 +131,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/functions/higher_order_functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/functions/higher_order_functions.v
@@ -131,7 +131,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
@@ -37,10 +37,11 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
             |),
             [
               M.alloc (|
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_associated_types_problem::Container"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_associated_types_problem::Container",
                   0
+                |)
               |);
               number_1
             ]
@@ -56,10 +57,11 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
               |),
               [
                 M.alloc (|
-                  M.get_struct_tuple_field
-                    (M.read (| self |))
-                    "generics_associated_types_problem::Container"
+                  M.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "generics_associated_types_problem::Container",
                     1
+                  |)
                 |);
                 number_2
               ]
@@ -79,10 +81,11 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.read (| self |))
-            "generics_associated_types_problem::Container"
+          M.get_struct_tuple_field (|
+            M.read (| self |),
+            "generics_associated_types_problem::Container",
             0
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -98,10 +101,11 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.read (| self |))
-            "generics_associated_types_problem::Container"
+          M.get_struct_tuple_field (|
+            M.read (| self |),
+            "generics_associated_types_problem::Container",
             1
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_problem.v
@@ -37,7 +37,7 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
             |),
             [
               M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_associated_types_problem::Container",
                   0
@@ -57,7 +57,7 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
               |),
               [
                 M.alloc (|
-                  M.get_struct_tuple_field (|
+                  M.SubPointer.get_struct_tuple_field (|
                     M.read (| self |),
                     "generics_associated_types_problem::Container",
                     1
@@ -81,7 +81,7 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field (|
+          M.SubPointer.get_struct_tuple_field (|
             M.read (| self |),
             "generics_associated_types_problem::Container",
             0
@@ -101,7 +101,7 @@ Module Impl_generics_associated_types_problem_Contains_i32_i32_for_generics_asso
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field (|
+          M.SubPointer.get_struct_tuple_field (|
             M.read (| self |),
             "generics_associated_types_problem::Container",
             1

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
@@ -43,7 +43,7 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
             |),
             [
               M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_associated_types_solution::Container",
                   0
@@ -63,7 +63,7 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
               |),
               [
                 M.alloc (|
-                  M.get_struct_tuple_field (|
+                  M.SubPointer.get_struct_tuple_field (|
                     M.read (| self |),
                     "generics_associated_types_solution::Container",
                     1
@@ -87,7 +87,7 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field (|
+          M.SubPointer.get_struct_tuple_field (|
             M.read (| self |),
             "generics_associated_types_solution::Container",
             0
@@ -107,7 +107,7 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field (|
+          M.SubPointer.get_struct_tuple_field (|
             M.read (| self |),
             "generics_associated_types_solution::Container",
             1
@@ -127,7 +127,7 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field (|
+          M.SubPointer.get_struct_tuple_field (|
             M.read (| self |),
             "generics_associated_types_solution::Container",
             0

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_associated_types_solution.v
@@ -43,10 +43,11 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
             |),
             [
               M.alloc (|
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_associated_types_solution::Container"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_associated_types_solution::Container",
                   0
+                |)
               |);
               number_1
             ]
@@ -62,10 +63,11 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
               |),
               [
                 M.alloc (|
-                  M.get_struct_tuple_field
-                    (M.read (| self |))
-                    "generics_associated_types_solution::Container"
+                  M.get_struct_tuple_field (|
+                    M.read (| self |),
+                    "generics_associated_types_solution::Container",
                     1
+                  |)
                 |);
                 number_2
               ]
@@ -85,10 +87,11 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.read (| self |))
-            "generics_associated_types_solution::Container"
+          M.get_struct_tuple_field (|
+            M.read (| self |),
+            "generics_associated_types_solution::Container",
             0
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -104,10 +107,11 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.read (| self |))
-            "generics_associated_types_solution::Container"
+          M.get_struct_tuple_field (|
+            M.read (| self |),
+            "generics_associated_types_solution::Container",
             1
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -123,10 +127,11 @@ Module Impl_generics_associated_types_solution_Contains_for_generics_associated_
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_tuple_field
-            (M.read (| self |))
-            "generics_associated_types_solution::Container"
+          M.get_struct_tuple_field (|
+            M.read (| self |),
+            "generics_associated_types_solution::Container",
             0
+          |)
         |)))
     | _, _ => M.impossible
     end.

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
@@ -33,7 +33,7 @@ Module Impl_core_fmt_Debug_for_generics_bounds_Rectangle.
             M.read (| Value.String "length" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (|
+              (M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "generics_bounds::Rectangle",
                 "length"
@@ -42,7 +42,7 @@ Module Impl_core_fmt_Debug_for_generics_bounds_Rectangle.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "generics_bounds::Rectangle",
                   "height"
@@ -83,14 +83,14 @@ Module Impl_generics_bounds_HasArea_for_generics_bounds_Rectangle.
         (let self := M.alloc (| self |) in
         BinOp.Panic.mul (|
           M.read (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "generics_bounds::Rectangle",
               "length"
             |)
           |),
           M.read (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "generics_bounds::Rectangle",
               "height"

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_bounds.v
@@ -33,12 +33,20 @@ Module Impl_core_fmt_Debug_for_generics_bounds_Rectangle.
             M.read (| Value.String "length" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (M.read (| self |)) "generics_bounds::Rectangle" "length");
+              (M.get_struct_record_field (|
+                M.read (| self |),
+                "generics_bounds::Rectangle",
+                "length"
+              |));
             M.read (| Value.String "height" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (M.read (| self |)) "generics_bounds::Rectangle" "height"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "generics_bounds::Rectangle",
+                  "height"
+                |)
               |))
           ]
         |)))
@@ -75,10 +83,18 @@ Module Impl_generics_bounds_HasArea_for_generics_bounds_Rectangle.
         (let self := M.alloc (| self |) in
         BinOp.Panic.mul (|
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "generics_bounds::Rectangle" "length"
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "generics_bounds::Rectangle",
+              "length"
+            |)
           |),
           M.read (|
-            M.get_struct_record_field (M.read (| self |)) "generics_bounds::Rectangle" "height"
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "generics_bounds::Rectangle",
+              "height"
+            |)
           |)
         |)))
     | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_implementation.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_implementation.v
@@ -28,7 +28,11 @@ Module Impl_generics_implementation_Val.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.get_struct_record_field (| M.read (| self |), "generics_implementation::Val", "val" |)))
+        M.SubPointer.get_struct_record_field (|
+          M.read (| self |),
+          "generics_implementation::Val",
+          "val"
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -49,7 +53,7 @@ Module Impl_generics_implementation_GenVal_T.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.get_struct_record_field (|
+        M.SubPointer.get_struct_record_field (|
           M.read (| self |),
           "generics_implementation::GenVal",
           "gen_val"

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_implementation.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_implementation.v
@@ -28,7 +28,7 @@ Module Impl_generics_implementation_Val.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.get_struct_record_field (M.read (| self |)) "generics_implementation::Val" "val"))
+        M.get_struct_record_field (| M.read (| self |), "generics_implementation::Val", "val" |)))
     | _, _ => M.impossible
     end.
   
@@ -49,7 +49,11 @@ Module Impl_generics_implementation_GenVal_T.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.get_struct_record_field (M.read (| self |)) "generics_implementation::GenVal" "gen_val"))
+        M.get_struct_record_field (|
+          M.read (| self |),
+          "generics_implementation::GenVal",
+          "gen_val"
+        |)))
     | _, _ => M.impossible
     end.
   

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom.v
@@ -33,7 +33,7 @@ Module Impl_generics_new_type_idiom_Years.
           [
             BinOp.Panic.mul (|
               M.read (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_new_type_idiom::Years",
                   0
@@ -66,7 +66,11 @@ Module Impl_generics_new_type_idiom_Days.
           [
             BinOp.Panic.div (|
               M.read (|
-                M.get_struct_tuple_field (| M.read (| self |), "generics_new_type_idiom::Days", 0 |)
+                M.SubPointer.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_new_type_idiom::Days",
+                  0
+                |)
               |),
               Value.Integer Integer.I64 365
             |)
@@ -89,7 +93,11 @@ Definition old_enough (τ : list Ty.t) (α : list Value.t) : M :=
       (let age := M.alloc (| age |) in
       BinOp.Pure.ge
         (M.read (|
-          M.get_struct_tuple_field (| M.read (| age |), "generics_new_type_idiom::Years", 0 |)
+          M.SubPointer.get_struct_tuple_field (|
+            M.read (| age |),
+            "generics_new_type_idiom::Years",
+            0
+          |)
         |))
         (Value.Integer Integer.I64 18)))
   | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom.v
@@ -33,7 +33,11 @@ Module Impl_generics_new_type_idiom_Years.
           [
             BinOp.Panic.mul (|
               M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "generics_new_type_idiom::Years" 0
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_new_type_idiom::Years",
+                  0
+                |)
               |),
               Value.Integer Integer.I64 365
             |)
@@ -62,7 +66,7 @@ Module Impl_generics_new_type_idiom_Days.
           [
             BinOp.Panic.div (|
               M.read (|
-                M.get_struct_tuple_field (M.read (| self |)) "generics_new_type_idiom::Days" 0
+                M.get_struct_tuple_field (| M.read (| self |), "generics_new_type_idiom::Days", 0 |)
               |),
               Value.Integer Integer.I64 365
             |)
@@ -85,7 +89,7 @@ Definition old_enough (τ : list Ty.t) (α : list Value.t) : M :=
       (let age := M.alloc (| age |) in
       BinOp.Pure.ge
         (M.read (|
-          M.get_struct_tuple_field (M.read (| age |)) "generics_new_type_idiom::Years" 0
+          M.get_struct_tuple_field (| M.read (| age |), "generics_new_type_idiom::Years", 0 |)
         |))
         (Value.Integer Integer.I64 18)))
   | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom_as_base_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom_as_base_type.v
@@ -28,7 +28,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           |) in
         let years_as_primitive_1 :=
           M.copy (|
-            M.get_struct_tuple_field (| years, "generics_new_type_idiom_as_base_type::Years", 0 |)
+            M.SubPointer.get_struct_tuple_field (|
+              years,
+              "generics_new_type_idiom_as_base_type::Years",
+              0
+            |)
           |) in
         M.match_operator (|
           years,
@@ -36,7 +40,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field (|
+                  M.SubPointer.get_struct_tuple_field (|
                     γ,
                     "generics_new_type_idiom_as_base_type::Years",
                     0

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom_as_base_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_new_type_idiom_as_base_type.v
@@ -28,7 +28,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           |) in
         let years_as_primitive_1 :=
           M.copy (|
-            M.get_struct_tuple_field years "generics_new_type_idiom_as_base_type::Years" 0
+            M.get_struct_tuple_field (| years, "generics_new_type_idiom_as_base_type::Years", 0 |)
           |) in
         M.match_operator (|
           years,
@@ -36,7 +36,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
+                  M.get_struct_tuple_field (|
                     γ,
                     "generics_new_type_idiom_as_base_type::Years",
                     0

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
@@ -37,12 +37,12 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
             [
-              M.get_struct_tuple_field (|
+              M.SubPointer.get_struct_tuple_field (|
                 M.read (| self |),
                 "generics_phantom_type::PhantomTuple",
                 0
               |);
-              M.get_struct_tuple_field (|
+              M.SubPointer.get_struct_tuple_field (|
                 M.read (| other |),
                 "generics_phantom_type::PhantomTuple",
                 0
@@ -59,12 +59,12 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
                 []
               |),
               [
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_phantom_type::PhantomTuple",
                   1
                 |);
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| other |),
                   "generics_phantom_type::PhantomTuple",
                   1
@@ -120,12 +120,12 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
             [
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "generics_phantom_type::PhantomStruct",
                 "first"
               |);
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| other |),
                 "generics_phantom_type::PhantomStruct",
                 "first"
@@ -142,12 +142,12 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "generics_phantom_type::PhantomStruct",
                   "phantom"
                 |);
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| other |),
                   "generics_phantom_type::PhantomStruct",
                   "phantom"

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type.v
@@ -37,8 +37,16 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
             [
-              M.get_struct_tuple_field (M.read (| self |)) "generics_phantom_type::PhantomTuple" 0;
-              M.get_struct_tuple_field (M.read (| other |)) "generics_phantom_type::PhantomTuple" 0
+              M.get_struct_tuple_field (|
+                M.read (| self |),
+                "generics_phantom_type::PhantomTuple",
+                0
+              |);
+              M.get_struct_tuple_field (|
+                M.read (| other |),
+                "generics_phantom_type::PhantomTuple",
+                0
+              |)
             ]
           |),
           ltac:(M.monadic
@@ -51,14 +59,16 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_phantom_type::PhantomTuple"
-                  1;
-                M.get_struct_tuple_field
-                  (M.read (| other |))
-                  "generics_phantom_type::PhantomTuple"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_phantom_type::PhantomTuple",
                   1
+                |);
+                M.get_struct_tuple_field (|
+                  M.read (| other |),
+                  "generics_phantom_type::PhantomTuple",
+                  1
+                |)
               ]
             |)))
         |)))
@@ -110,14 +120,16 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
           M.call_closure (|
             M.get_trait_method (| "core::cmp::PartialEq", A, [ A ], "eq", [] |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "generics_phantom_type::PhantomStruct"
-                "first";
-              M.get_struct_record_field
-                (M.read (| other |))
-                "generics_phantom_type::PhantomStruct"
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "generics_phantom_type::PhantomStruct",
                 "first"
+              |);
+              M.get_struct_record_field (|
+                M.read (| other |),
+                "generics_phantom_type::PhantomStruct",
+                "first"
+              |)
             ]
           |),
           ltac:(M.monadic
@@ -130,14 +142,16 @@ Module Impl_core_cmp_PartialEq_where_core_cmp_PartialEq_A_where_core_cmp_Partial
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "generics_phantom_type::PhantomStruct"
-                  "phantom";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "generics_phantom_type::PhantomStruct"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "generics_phantom_type::PhantomStruct",
                   "phantom"
+                |);
+                M.get_struct_record_field (|
+                  M.read (| other |),
+                  "generics_phantom_type::PhantomStruct",
+                  "phantom"
+                |)
               ]
             |)))
         |)))

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -147,7 +147,7 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_t
             M.read (| Value.String "Length" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_tuple_field (|
+              (M.SubPointer.get_struct_tuple_field (|
                 M.read (| self |),
                 "generics_phantom_type_test_case_unit_clarification::Length",
                 0
@@ -155,7 +155,7 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_t
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_phantom_type_test_case_unit_clarification::Length",
                   1
@@ -192,7 +192,7 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_ty
             M.call_closure (|
               M.get_trait_method (| "core::clone::Clone", Ty.path "f64", [], "clone", [] |),
               [
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_phantom_type_test_case_unit_clarification::Length",
                   0
@@ -208,7 +208,7 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_ty
                 []
               |),
               [
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "generics_phantom_type_test_case_unit_clarification::Length",
                   1
@@ -267,14 +267,14 @@ Module Impl_core_ops_arith_Add_for_generics_phantom_type_test_case_unit_clarific
           [
             BinOp.Panic.add (|
               M.read (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   self,
                   "generics_phantom_type_test_case_unit_clarification::Length",
                   0
                 |)
               |),
               M.read (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   rhs,
                   "generics_phantom_type_test_case_unit_clarification::Length",
                   0
@@ -405,7 +405,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f64" ]
                                 |),
                                 [
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     two_feet,
                                     "generics_phantom_type_test_case_unit_clarification::Length",
                                     0
@@ -451,7 +451,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f64" ]
                                 |),
                                 [
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     two_meters,
                                     "generics_phantom_type_test_case_unit_clarification::Length",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
+++ b/CoqOfRust/examples/default/examples/rust_book/generics/generics_phantom_type_test_case_unit_clarification.v
@@ -147,17 +147,19 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_Unit_for_generics_phantom_type_t
             M.read (| Value.String "Length" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_tuple_field
-                (M.read (| self |))
-                "generics_phantom_type_test_case_unit_clarification::Length"
-                0);
+              (M.get_struct_tuple_field (|
+                M.read (| self |),
+                "generics_phantom_type_test_case_unit_clarification::Length",
+                0
+              |));
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_phantom_type_test_case_unit_clarification::Length"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_phantom_type_test_case_unit_clarification::Length",
                   1
+                |)
               |))
           ]
         |)))
@@ -190,10 +192,11 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_ty
             M.call_closure (|
               M.get_trait_method (| "core::clone::Clone", Ty.path "f64", [], "clone", [] |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_phantom_type_test_case_unit_clarification::Length"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_phantom_type_test_case_unit_clarification::Length",
                   0
+                |)
               ]
             |);
             M.call_closure (|
@@ -205,10 +208,11 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_Unit_for_generics_phantom_ty
                 []
               |),
               [
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "generics_phantom_type_test_case_unit_clarification::Length"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "generics_phantom_type_test_case_unit_clarification::Length",
                   1
+                |)
               ]
             |)
           ]))
@@ -263,16 +267,18 @@ Module Impl_core_ops_arith_Add_for_generics_phantom_type_test_case_unit_clarific
           [
             BinOp.Panic.add (|
               M.read (|
-                M.get_struct_tuple_field
-                  self
-                  "generics_phantom_type_test_case_unit_clarification::Length"
+                M.get_struct_tuple_field (|
+                  self,
+                  "generics_phantom_type_test_case_unit_clarification::Length",
                   0
+                |)
               |),
               M.read (|
-                M.get_struct_tuple_field
-                  rhs
-                  "generics_phantom_type_test_case_unit_clarification::Length"
+                M.get_struct_tuple_field (|
+                  rhs,
+                  "generics_phantom_type_test_case_unit_clarification::Length",
                   0
+                |)
               |)
             |);
             Value.StructTuple "core::marker::PhantomData" []
@@ -399,10 +405,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f64" ]
                                 |),
                                 [
-                                  M.get_struct_tuple_field
-                                    two_feet
-                                    "generics_phantom_type_test_case_unit_clarification::Length"
+                                  M.get_struct_tuple_field (|
+                                    two_feet,
+                                    "generics_phantom_type_test_case_unit_clarification::Length",
                                     0
+                                  |)
                                 ]
                               |)
                             ]
@@ -444,10 +451,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "f64" ]
                                 |),
                                 [
-                                  M.get_struct_tuple_field
-                                    two_meters
-                                    "generics_phantom_type_test_case_unit_clarification::Length"
+                                  M.get_struct_tuple_field (|
+                                    two_meters,
+                                    "generics_phantom_type_test_case_unit_clarification::Length",
                                     0
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/examples/default/examples/rust_book/guessing_game/guessing_game.v
+++ b/CoqOfRust/examples/default/examples/rust_book/guessing_game/guessing_game.v
@@ -174,21 +174,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let num := M.copy (| γ0_0 |) in
                         num));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         M.alloc (| M.never_to_any (| M.read (| M.continue (||) |) |) |)))
                   ]
                 |)

--- a/CoqOfRust/examples/default/examples/rust_book/guessing_game/guessing_game.v
+++ b/CoqOfRust/examples/default/examples/rust_book/guessing_game/guessing_game.v
@@ -174,13 +174,21 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let num := M.copy (| γ0_0 |) in
                         num));
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         M.alloc (| M.never_to_any (| M.read (| M.continue (||) |) |) |)))
                   ]
                 |)

--- a/CoqOfRust/examples/default/examples/rust_book/modules/struct_visibility.v
+++ b/CoqOfRust/examples/default/examples/rust_book/modules/struct_visibility.v
@@ -108,10 +108,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    open_box
-                                    "struct_visibility::my::OpenBox"
+                                  M.get_struct_record_field (|
+                                    open_box,
+                                    "struct_visibility::my::OpenBox",
                                     "contents"
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/examples/default/examples/rust_book/modules/struct_visibility.v
+++ b/CoqOfRust/examples/default/examples/rust_book/modules/struct_visibility.v
@@ -108,7 +108,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     open_box,
                                     "struct_visibility::my::OpenBox",
                                     "contents"

--- a/CoqOfRust/examples/default/examples/rust_book/primitives/arrays_and_slices.v
+++ b/CoqOfRust/examples/default/examples/rust_book/primitives/arrays_and_slices.v
@@ -458,8 +458,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -552,8 +552,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -679,7 +679,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -700,7 +700,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0

--- a/CoqOfRust/examples/default/examples/rust_book/primitives/arrays_and_slices.v
+++ b/CoqOfRust/examples/default/examples/rust_book/primitives/arrays_and_slices.v
@@ -44,7 +44,7 @@ Definition analyze_slice (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     M.read (| slice |),
                                     M.alloc (| Value.Integer Integer.Usize 0 |)
                                   |)
@@ -211,7 +211,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     xs,
                                     M.alloc (| Value.Integer Integer.Usize 0 |)
                                   |)
@@ -256,7 +256,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_array_field (|
+                                  M.SubPointer.get_array_field (|
                                     xs,
                                     M.alloc (| Value.Integer Integer.Usize 1 |)
                                   |)
@@ -458,8 +458,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -552,8 +552,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -679,7 +679,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
@@ -700,7 +700,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0

--- a/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
+++ b/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
@@ -20,8 +20,8 @@ Definition reverse (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 let int_param := M.copy (| γ0_0 |) in
                 let bool_param := M.copy (| γ0_1 |) in
                 M.alloc (| Value.Tuple [ M.read (| bool_param |); M.read (| int_param |) ] |)))
@@ -59,16 +59,18 @@ Module Impl_core_fmt_Debug_for_tuples_Matrix.
             M.read (| Value.String "Matrix" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 0 |));
+              (M.SubPointer.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 0 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 1 |));
+              (M.SubPointer.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 1 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 2 |));
+              (M.SubPointer.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 2 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 3 |) |))
+              (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 3 |)
+              |))
           ]
         |)))
     | _, _ => M.impossible
@@ -179,7 +181,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "u8" ]
                                 |),
-                                [ M.get_tuple_field (| long_tuple, 0 |) ]
+                                [ M.SubPointer.get_tuple_field (| long_tuple, 0 |) ]
                               |)
                             ]
                         |))
@@ -219,7 +221,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "u16" ]
                                 |),
-                                [ M.get_tuple_field (| long_tuple, 1 |) ]
+                                [ M.SubPointer.get_tuple_field (| long_tuple, 1 |) ]
                               |)
                             ]
                         |))
@@ -470,10 +472,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
-                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
-                let γ0_3 := M.get_tuple_field (| γ, 3 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.SubPointer.get_tuple_field (| γ, 2 |) in
+                let γ0_3 := M.SubPointer.get_tuple_field (| γ, 3 |) in
                 let a := M.copy (| γ0_0 |) in
                 let b := M.copy (| γ0_1 |) in
                 let c := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
+++ b/CoqOfRust/examples/default/examples/rust_book/primitives/tuples.v
@@ -20,8 +20,8 @@ Definition reverse (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 let int_param := M.copy (| γ0_0 |) in
                 let bool_param := M.copy (| γ0_1 |) in
                 M.alloc (| Value.Tuple [ M.read (| bool_param |); M.read (| int_param |) ] |)))
@@ -58,14 +58,17 @@ Module Impl_core_fmt_Debug_for_tuples_Matrix.
             M.read (| f |);
             M.read (| Value.String "Matrix" |);
             (* Unsize *)
-            M.pointer_coercion (M.get_struct_tuple_field (M.read (| self |)) "tuples::Matrix" 0);
-            (* Unsize *)
-            M.pointer_coercion (M.get_struct_tuple_field (M.read (| self |)) "tuples::Matrix" 1);
-            (* Unsize *)
-            M.pointer_coercion (M.get_struct_tuple_field (M.read (| self |)) "tuples::Matrix" 2);
+            M.pointer_coercion
+              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 0 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "tuples::Matrix" 3 |))
+              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 1 |));
+            (* Unsize *)
+            M.pointer_coercion
+              (M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 2 |));
+            (* Unsize *)
+            M.pointer_coercion
+              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "tuples::Matrix", 3 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -176,7 +179,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "u8" ]
                                 |),
-                                [ M.get_tuple_field long_tuple 0 ]
+                                [ M.get_tuple_field (| long_tuple, 0 |) ]
                               |)
                             ]
                         |))
@@ -216,7 +219,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   "new_display",
                                   [ Ty.path "u16" ]
                                 |),
-                                [ M.get_tuple_field long_tuple 1 ]
+                                [ M.get_tuple_field (| long_tuple, 1 |) ]
                               |)
                             ]
                         |))
@@ -467,10 +470,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
-                let γ0_2 := M.get_tuple_field γ 2 in
-                let γ0_3 := M.get_tuple_field γ 3 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                let γ0_2 := M.get_tuple_field (| γ, 2 |) in
+                let γ0_3 := M.get_tuple_field (| γ, 3 |) in
                 let a := M.copy (| γ0_0 |) in
                 let b := M.copy (| γ0_1 |) in
                 let c := M.copy (| γ0_2 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_aliasing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_aliasing.v
@@ -115,7 +115,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| borrowed_point |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "x"
@@ -129,7 +129,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| another_borrow |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "y"
@@ -143,7 +143,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     point,
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "z"
@@ -191,7 +191,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| borrowed_point |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "x"
@@ -205,7 +205,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| another_borrow |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "y"
@@ -219,7 +219,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     point,
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "z"
@@ -237,7 +237,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
         let mutable_borrow := M.alloc (| point |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| mutable_borrow |),
               "scoping_rules_borrowing_aliasing::Point",
               "x"
@@ -246,7 +246,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| mutable_borrow |),
               "scoping_rules_borrowing_aliasing::Point",
               "y"
@@ -255,7 +255,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| mutable_borrow |),
               "scoping_rules_borrowing_aliasing::Point",
               "z"
@@ -295,7 +295,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| mutable_borrow |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "x"
@@ -309,7 +309,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| mutable_borrow |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "y"
@@ -323,7 +323,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| mutable_borrow |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "z"
@@ -372,7 +372,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| new_borrowed_point |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "x"
@@ -386,7 +386,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| new_borrowed_point |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "y"
@@ -400,7 +400,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| new_borrowed_point |),
                                     "scoping_rules_borrowing_aliasing::Point",
                                     "z"

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_aliasing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_aliasing.v
@@ -115,10 +115,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| borrowed_point |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| borrowed_point |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "x"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -128,10 +129,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| another_borrow |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| another_borrow |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "y"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -141,10 +143,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    point
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    point,
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "z"
+                                  |)
                                 ]
                               |)
                             ]
@@ -188,10 +191,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| borrowed_point |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| borrowed_point |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "x"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -201,10 +205,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| another_borrow |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| another_borrow |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "y"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -214,10 +219,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    point
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    point,
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "z"
+                                  |)
                                 ]
                               |)
                             ]
@@ -231,26 +237,29 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
         let mutable_borrow := M.alloc (| point |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field
-              (M.read (| mutable_borrow |))
-              "scoping_rules_borrowing_aliasing::Point"
-              "x",
+            M.get_struct_record_field (|
+              M.read (| mutable_borrow |),
+              "scoping_rules_borrowing_aliasing::Point",
+              "x"
+            |),
             Value.Integer Integer.I32 5
           |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field
-              (M.read (| mutable_borrow |))
-              "scoping_rules_borrowing_aliasing::Point"
-              "y",
+            M.get_struct_record_field (|
+              M.read (| mutable_borrow |),
+              "scoping_rules_borrowing_aliasing::Point",
+              "y"
+            |),
             Value.Integer Integer.I32 2
           |) in
         let _ :=
           M.write (|
-            M.get_struct_record_field
-              (M.read (| mutable_borrow |))
-              "scoping_rules_borrowing_aliasing::Point"
-              "z",
+            M.get_struct_record_field (|
+              M.read (| mutable_borrow |),
+              "scoping_rules_borrowing_aliasing::Point",
+              "z"
+            |),
             Value.Integer Integer.I32 1
           |) in
         let _ :=
@@ -286,10 +295,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| mutable_borrow |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| mutable_borrow |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "x"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -299,10 +309,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| mutable_borrow |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| mutable_borrow |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "y"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -312,10 +323,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| mutable_borrow |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| mutable_borrow |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "z"
+                                  |)
                                 ]
                               |)
                             ]
@@ -360,10 +372,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| new_borrowed_point |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| new_borrowed_point |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "x"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -373,10 +386,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| new_borrowed_point |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| new_borrowed_point |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "y"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -386,10 +400,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "i32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| new_borrowed_point |))
-                                    "scoping_rules_borrowing_aliasing::Point"
+                                  M.get_struct_record_field (|
+                                    M.read (| new_borrowed_point |),
+                                    "scoping_rules_borrowing_aliasing::Point",
                                     "z"
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_mutablity.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_mutablity.v
@@ -106,7 +106,7 @@ Definition borrow_book (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| book |),
                                     "scoping_rules_borrowing_mutablity::Book",
                                     "title"
@@ -120,7 +120,7 @@ Definition borrow_book (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "u32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| book |),
                                     "scoping_rules_borrowing_mutablity::Book",
                                     "year"
@@ -154,7 +154,7 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
       M.read (|
         let _ :=
           M.write (|
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| book |),
               "scoping_rules_borrowing_mutablity::Book",
               "year"
@@ -193,7 +193,7 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| book |),
                                     "scoping_rules_borrowing_mutablity::Book",
                                     "title"
@@ -207,7 +207,7 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "u32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field (|
+                                  M.SubPointer.get_struct_record_field (|
                                     M.read (| book |),
                                     "scoping_rules_borrowing_mutablity::Book",
                                     "year"

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_mutablity.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_mutablity.v
@@ -106,10 +106,11 @@ Definition borrow_book (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| book |))
-                                    "scoping_rules_borrowing_mutablity::Book"
+                                  M.get_struct_record_field (|
+                                    M.read (| book |),
+                                    "scoping_rules_borrowing_mutablity::Book",
                                     "title"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -119,10 +120,11 @@ Definition borrow_book (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "u32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| book |))
-                                    "scoping_rules_borrowing_mutablity::Book"
+                                  M.get_struct_record_field (|
+                                    M.read (| book |),
+                                    "scoping_rules_borrowing_mutablity::Book",
                                     "year"
+                                  |)
                                 ]
                               |)
                             ]
@@ -152,10 +154,11 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
       M.read (|
         let _ :=
           M.write (|
-            M.get_struct_record_field
-              (M.read (| book |))
-              "scoping_rules_borrowing_mutablity::Book"
-              "year",
+            M.get_struct_record_field (|
+              M.read (| book |),
+              "scoping_rules_borrowing_mutablity::Book",
+              "year"
+            |),
             Value.Integer Integer.U32 2014
           |) in
         let _ :=
@@ -190,10 +193,11 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| book |))
-                                    "scoping_rules_borrowing_mutablity::Book"
+                                  M.get_struct_record_field (|
+                                    M.read (| book |),
+                                    "scoping_rules_borrowing_mutablity::Book",
                                     "title"
+                                  |)
                                 ]
                               |);
                               M.call_closure (|
@@ -203,10 +207,11 @@ Definition new_edition (τ : list Ty.t) (α : list Value.t) : M :=
                                   [ Ty.path "u32" ]
                                 |),
                                 [
-                                  M.get_struct_record_field
-                                    (M.read (| book |))
-                                    "scoping_rules_borrowing_mutablity::Book"
+                                  M.get_struct_record_field (|
+                                    M.read (| book |),
+                                    "scoping_rules_borrowing_mutablity::Book",
                                     "year"
+                                  |)
                                 ]
                               |)
                             ]

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
@@ -175,13 +175,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.get_struct_record_field (|
                                 γ,
                                 "scoping_rules_borrowing_the_ref_pattern::Point",
                                 "x"
                               |) in
                             let γ0_1 :=
-                              M.get_struct_record_field_or_break_match (|
+                              M.get_struct_record_field (|
                                 γ,
                                 "scoping_rules_borrowing_the_ref_pattern::Point",
                                 "y"
@@ -199,13 +199,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "scoping_rules_borrowing_the_ref_pattern::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field_or_break_match (|
+                            M.get_struct_record_field (|
                               γ,
                               "scoping_rules_borrowing_the_ref_pattern::Point",
                               "y"
@@ -252,10 +252,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            point
-                                            "scoping_rules_borrowing_the_ref_pattern::Point"
+                                          M.get_struct_record_field (|
+                                            point,
+                                            "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "x"
+                                          |)
                                         ]
                                       |);
                                       M.call_closure (|
@@ -265,10 +266,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            point
-                                            "scoping_rules_borrowing_the_ref_pattern::Point"
+                                          M.get_struct_record_field (|
+                                            point,
+                                            "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "y"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -315,10 +317,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            mutable_point
-                                            "scoping_rules_borrowing_the_ref_pattern::Point"
+                                          M.get_struct_record_field (|
+                                            mutable_point,
+                                            "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "x"
+                                          |)
                                         ]
                                       |);
                                       M.call_closure (|
@@ -328,10 +331,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            mutable_point
-                                            "scoping_rules_borrowing_the_ref_pattern::Point"
+                                          M.get_struct_record_field (|
+                                            mutable_point,
+                                            "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "y"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -365,8 +369,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field γ 0 in
-                          let γ0_1 := M.get_tuple_field γ 1 in
+                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                           let last := M.alloc (| γ0_1 |) in
                           let _ := M.write (| M.read (| last |), Value.Integer Integer.U32 2 |) in
                           M.alloc (| Value.Tuple [] |)))

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_borrowing_the_ref_pattern.v
@@ -175,13 +175,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "scoping_rules_borrowing_the_ref_pattern::Point",
                                 "x"
                               |) in
                             let γ0_1 :=
-                              M.get_struct_record_field (|
+                              M.SubPointer.get_struct_record_field (|
                                 γ,
                                 "scoping_rules_borrowing_the_ref_pattern::Point",
                                 "y"
@@ -199,13 +199,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "scoping_rules_borrowing_the_ref_pattern::Point",
                               "x"
                             |) in
                           let γ0_1 :=
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               γ,
                               "scoping_rules_borrowing_the_ref_pattern::Point",
                               "y"
@@ -252,7 +252,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             point,
                                             "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "x"
@@ -266,7 +266,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             point,
                                             "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "y"
@@ -317,7 +317,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             mutable_point,
                                             "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "x"
@@ -331,7 +331,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.path "i32" ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             mutable_point,
                                             "scoping_rules_borrowing_the_ref_pattern::Point",
                                             "y"
@@ -369,8 +369,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     [
                       fun γ =>
                         ltac:(M.monadic
-                          (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                          let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                          (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                          let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                           let last := M.alloc (| γ0_1 |) in
                           let _ := M.write (| M.read (| last |), Value.Integer Integer.U32 2 |) in
                           M.alloc (| Value.Tuple [] |)))

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -32,7 +32,11 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bo
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (M.read (| self |)) "scoping_rules_lifetimes_bounds::Ref" 0
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "scoping_rules_lifetimes_bounds::Ref",
+                  0
+                |)
               |))
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_bounds.v
@@ -32,7 +32,7 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_scoping_rules_lifetimes_bo
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "scoping_rules_lifetimes_bounds::Ref",
                   0

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_methods.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_methods.v
@@ -24,7 +24,7 @@ Module Impl_scoping_rules_lifetimes_methods_Owner.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_tuple_field (|
+              M.SubPointer.get_struct_tuple_field (|
                 M.read (| self |),
                 "scoping_rules_lifetimes_methods::Owner",
                 0
@@ -77,7 +77,7 @@ Module Impl_scoping_rules_lifetimes_methods_Owner.
                                     [ Ty.path "i32" ]
                                   |),
                                   [
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       M.read (| self |),
                                       "scoping_rules_lifetimes_methods::Owner",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_methods.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_methods.v
@@ -24,10 +24,11 @@ Module Impl_scoping_rules_lifetimes_methods_Owner.
         M.read (|
           let _ :=
             let β :=
-              M.get_struct_tuple_field
-                (M.read (| self |))
-                "scoping_rules_lifetimes_methods::Owner"
-                0 in
+              M.get_struct_tuple_field (|
+                M.read (| self |),
+                "scoping_rules_lifetimes_methods::Owner",
+                0
+              |) in
             M.write (| β, BinOp.Panic.add (| M.read (| β |), Value.Integer Integer.I32 1 |) |) in
           M.alloc (| Value.Tuple [] |)
         |)))
@@ -76,10 +77,11 @@ Module Impl_scoping_rules_lifetimes_methods_Owner.
                                     [ Ty.path "i32" ]
                                   |),
                                   [
-                                    M.get_struct_tuple_field
-                                      (M.read (| self |))
-                                      "scoping_rules_lifetimes_methods::Owner"
+                                    M.get_struct_tuple_field (|
+                                      M.read (| self |),
+                                      "scoping_rules_lifetimes_methods::Owner",
                                       0
+                                    |)
                                   ]
                                 |)
                               ]

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_structs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_structs.v
@@ -30,10 +30,11 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Borrowed.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field
-                  (M.read (| self |))
-                  "scoping_rules_lifetimes_structs::Borrowed"
+                M.get_struct_tuple_field (|
+                  M.read (| self |),
+                  "scoping_rules_lifetimes_structs::Borrowed",
                   0
+                |)
               |))
           ]
         |)))
@@ -81,18 +82,20 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_NamedBorrowed.
             M.read (| Value.String "x" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field
-                (M.read (| self |))
-                "scoping_rules_lifetimes_structs::NamedBorrowed"
-                "x");
+              (M.get_struct_record_field (|
+                M.read (| self |),
+                "scoping_rules_lifetimes_structs::NamedBorrowed",
+                "x"
+              |));
             M.read (| Value.String "y" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "scoping_rules_lifetimes_structs::NamedBorrowed"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "scoping_rules_lifetimes_structs::NamedBorrowed",
                   "y"
+                |)
               |))
           ]
         |)))
@@ -145,7 +148,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Either.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
+                    M.get_struct_tuple_field (|
                       γ,
                       "scoping_rules_lifetimes_structs::Either::Num",
                       0
@@ -169,7 +172,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Either.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
+                    M.get_struct_tuple_field (|
                       γ,
                       "scoping_rules_lifetimes_structs::Either::Ref",
                       0

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_structs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_structs.v
@@ -30,7 +30,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Borrowed.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_tuple_field (|
+                M.SubPointer.get_struct_tuple_field (|
                   M.read (| self |),
                   "scoping_rules_lifetimes_structs::Borrowed",
                   0
@@ -82,7 +82,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_NamedBorrowed.
             M.read (| Value.String "x" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (|
+              (M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "scoping_rules_lifetimes_structs::NamedBorrowed",
                 "x"
@@ -91,7 +91,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_NamedBorrowed.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "scoping_rules_lifetimes_structs::NamedBorrowed",
                   "y"
@@ -148,7 +148,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Either.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_tuple_field (|
                       γ,
                       "scoping_rules_lifetimes_structs::Either::Num",
                       0
@@ -172,7 +172,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_structs_Either.
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
                   let γ1_0 :=
-                    M.get_struct_tuple_field (|
+                    M.SubPointer.get_struct_tuple_field (|
                       γ,
                       "scoping_rules_lifetimes_structs::Either::Ref",
                       0

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_traits.v
@@ -31,7 +31,7 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_traits_Borrowed.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "scoping_rules_lifetimes_traits::Borrowed",
                   "x"

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_lifetimes_traits.v
@@ -31,10 +31,11 @@ Module Impl_core_fmt_Debug_for_scoping_rules_lifetimes_traits_Borrowed.
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "scoping_rules_lifetimes_traits::Borrowed"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "scoping_rules_lifetimes_traits::Borrowed",
                   "x"
+                |)
               |))
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
@@ -68,13 +68,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field_or_break_match (|
+                  M.get_struct_record_field (|
                     γ,
                     "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "name"
                   |) in
                 let γ0_1 :=
-                  M.get_struct_record_field_or_break_match (|
+                  M.get_struct_record_field (|
                     γ,
                     "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "age"
@@ -218,10 +218,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            person
-                                            "scoping_rules_ownership_and_rules_partial_moves::main::Person"
+                                          M.get_struct_record_field (|
+                                            person,
+                                            "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                                             "age"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -275,18 +276,20 @@ Module main.
               M.read (| Value.String "name" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field
-                  (M.read (| self |))
-                  "scoping_rules_ownership_and_rules_partial_moves::main::Person"
-                  "name");
+                (M.get_struct_record_field (|
+                  M.read (| self |),
+                  "scoping_rules_ownership_and_rules_partial_moves::main::Person",
+                  "name"
+                |));
               M.read (| Value.String "age" |);
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "scoping_rules_ownership_and_rules_partial_moves::main::Person"
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "age"
+                  |)
                 |))
             ]
           |)))

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_ownership_and_rules_partial_moves.v
@@ -68,13 +68,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             fun γ =>
               ltac:(M.monadic
                 (let γ0_0 :=
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     γ,
                     "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "name"
                   |) in
                 let γ0_1 :=
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     γ,
                     "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "age"
@@ -218,7 +218,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                           ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             person,
                                             "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                                             "age"
@@ -276,7 +276,7 @@ Module main.
               M.read (| Value.String "name" |);
               (* Unsize *)
               M.pointer_coercion
-                (M.get_struct_record_field (|
+                (M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                   "name"
@@ -285,7 +285,7 @@ Module main.
               (* Unsize *)
               M.pointer_coercion
                 (M.alloc (|
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "scoping_rules_ownership_and_rules_partial_moves::main::Person",
                     "age"

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_raii.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_raii.v
@@ -135,7 +135,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_raii.v
+++ b/CoqOfRust/examples/default/examples/rust_book/scoping_rules/scoping_rules_raii.v
@@ -135,7 +135,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/arc.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/arc.v
@@ -89,7 +89,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/arc.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/arc.v
@@ -89,7 +89,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/box_stack_heap.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/box_stack_heap.v
@@ -30,12 +30,12 @@ Module Impl_core_fmt_Debug_for_box_stack_heap_Point.
             M.read (| Value.String "x" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (M.read (| self |)) "box_stack_heap::Point" "x");
+              (M.get_struct_record_field (| M.read (| self |), "box_stack_heap::Point", "x" |));
             M.read (| Value.String "y" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (M.read (| self |)) "box_stack_heap::Point" "y"
+                M.get_struct_record_field (| M.read (| self |), "box_stack_heap::Point", "y" |)
               |))
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/box_stack_heap.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/box_stack_heap.v
@@ -30,12 +30,20 @@ Module Impl_core_fmt_Debug_for_box_stack_heap_Point.
             M.read (| Value.String "x" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (| M.read (| self |), "box_stack_heap::Point", "x" |));
+              (M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "box_stack_heap::Point",
+                "x"
+              |));
             M.read (| Value.String "y" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (| M.read (| self |), "box_stack_heap::Point", "y" |)
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "box_stack_heap::Point",
+                  "y"
+                |)
               |))
           ]
         |)))

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map.v
@@ -199,7 +199,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ0_0 := M.read (| γ0_0 |) in
                   let number := M.copy (| γ0_0 |) in
                   let _ :=
@@ -319,7 +320,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ0_0 := M.read (| γ0_0 |) in
                   let number := M.copy (| γ0_0 |) in
                   let _ :=
@@ -484,13 +486,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
-                                let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                 let contact := M.copy (| γ1_0 |) in
                                 let γ1_1 := M.read (| γ1_1 |) in
                                 let number := M.copy (| γ1_1 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map.v
@@ -199,12 +199,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ0_0 := M.read (| γ0_0 |) in
                   let number := M.copy (| γ0_0 |) in
                   let _ :=
@@ -324,12 +319,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::option::Option::Some",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                   let γ0_0 := M.read (| γ0_0 |) in
                   let number := M.copy (| γ0_0 |) in
                   let _ :=
@@ -494,13 +484,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0
                                   |) in
-                                let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                 let contact := M.copy (| γ1_0 |) in
                                 let γ1_1 := M.read (| γ1_1 |) in
                                 let number := M.copy (| γ1_1 |) in

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -43,12 +43,12 @@ Module Impl_core_cmp_PartialEq_for_hash_map_alternate_or_custom_key_types_Accoun
               []
             |),
             [
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| self |),
                 "hash_map_alternate_or_custom_key_types::Account",
                 "username"
               |);
-              M.get_struct_record_field (|
+              M.SubPointer.get_struct_record_field (|
                 M.read (| other |),
                 "hash_map_alternate_or_custom_key_types::Account",
                 "username"
@@ -65,12 +65,12 @@ Module Impl_core_cmp_PartialEq_for_hash_map_alternate_or_custom_key_types_Accoun
                 []
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "hash_map_alternate_or_custom_key_types::Account",
                   "password"
                 |);
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| other |),
                   "hash_map_alternate_or_custom_key_types::Account",
                   "password"
@@ -156,7 +156,7 @@ Module Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account.
                   [ __H ]
                 |),
                 [
-                  M.get_struct_record_field (|
+                  M.SubPointer.get_struct_record_field (|
                     M.read (| self |),
                     "hash_map_alternate_or_custom_key_types::Account",
                     "username"
@@ -175,7 +175,7 @@ Module Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field (|
+                M.SubPointer.get_struct_record_field (|
                   M.read (| self |),
                   "hash_map_alternate_or_custom_key_types::Account",
                   "password"
@@ -366,7 +366,8 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let account_info := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=
@@ -428,7 +429,7 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             M.read (| account_info |),
                                             "hash_map_alternate_or_custom_key_types::AccountInfo",
                                             "name"
@@ -478,7 +479,7 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                         |),
                                         [
-                                          M.get_struct_record_field (|
+                                          M.SubPointer.get_struct_record_field (|
                                             M.read (| account_info |),
                                             "hash_map_alternate_or_custom_key_types::AccountInfo",
                                             "email"

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/hash_map_alternate_or_custom_key_types.v
@@ -43,14 +43,16 @@ Module Impl_core_cmp_PartialEq_for_hash_map_alternate_or_custom_key_types_Accoun
               []
             |),
             [
-              M.get_struct_record_field
-                (M.read (| self |))
-                "hash_map_alternate_or_custom_key_types::Account"
-                "username";
-              M.get_struct_record_field
-                (M.read (| other |))
-                "hash_map_alternate_or_custom_key_types::Account"
+              M.get_struct_record_field (|
+                M.read (| self |),
+                "hash_map_alternate_or_custom_key_types::Account",
                 "username"
+              |);
+              M.get_struct_record_field (|
+                M.read (| other |),
+                "hash_map_alternate_or_custom_key_types::Account",
+                "username"
+              |)
             ]
           |),
           ltac:(M.monadic
@@ -63,14 +65,16 @@ Module Impl_core_cmp_PartialEq_for_hash_map_alternate_or_custom_key_types_Accoun
                 []
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "hash_map_alternate_or_custom_key_types::Account"
-                  "password";
-                M.get_struct_record_field
-                  (M.read (| other |))
-                  "hash_map_alternate_or_custom_key_types::Account"
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "hash_map_alternate_or_custom_key_types::Account",
                   "password"
+                |);
+                M.get_struct_record_field (|
+                  M.read (| other |),
+                  "hash_map_alternate_or_custom_key_types::Account",
+                  "password"
+                |)
               ]
             |)))
         |)))
@@ -152,10 +156,11 @@ Module Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account.
                   [ __H ]
                 |),
                 [
-                  M.get_struct_record_field
-                    (M.read (| self |))
-                    "hash_map_alternate_or_custom_key_types::Account"
-                    "username";
+                  M.get_struct_record_field (|
+                    M.read (| self |),
+                    "hash_map_alternate_or_custom_key_types::Account",
+                    "username"
+                  |);
                   M.read (| state |)
                 ]
               |)
@@ -170,10 +175,11 @@ Module Impl_core_hash_Hash_for_hash_map_alternate_or_custom_key_types_Account.
                 [ __H ]
               |),
               [
-                M.get_struct_record_field
-                  (M.read (| self |))
-                  "hash_map_alternate_or_custom_key_types::Account"
-                  "password";
+                M.get_struct_record_field (|
+                  M.read (| self |),
+                  "hash_map_alternate_or_custom_key_types::Account",
+                  "password"
+                |);
                 M.read (| state |)
               ]
             |)
@@ -360,12 +366,7 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let account_info := M.copy (| γ0_0 |) in
                 let _ :=
                   let _ :=
@@ -427,10 +428,11 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| account_info |))
-                                            "hash_map_alternate_or_custom_key_types::AccountInfo"
+                                          M.get_struct_record_field (|
+                                            M.read (| account_info |),
+                                            "hash_map_alternate_or_custom_key_types::AccountInfo",
                                             "name"
+                                          |)
                                         ]
                                       |)
                                     ]
@@ -476,10 +478,11 @@ Definition try_logon (τ : list Ty.t) (α : list Value.t) : M :=
                                           [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                         |),
                                         [
-                                          M.get_struct_record_field
-                                            (M.read (| account_info |))
-                                            "hash_map_alternate_or_custom_key_types::AccountInfo"
+                                          M.get_struct_record_field (|
+                                            M.read (| account_info |),
+                                            "hash_map_alternate_or_custom_key_types::AccountInfo",
                                             "email"
+                                          |)
                                         ]
                                       |)
                                     ]

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/option.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/option.v
@@ -126,7 +126,8 @@ Definition try_division (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let quotient := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/option.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/option.v
@@ -126,12 +126,7 @@ Definition try_division (τ : list Ty.t) (α : list Value.t) : M :=
                 M.alloc (| Value.Tuple [] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let quotient := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/result.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/result.v
@@ -258,8 +258,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -299,8 +298,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let ratio := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -313,11 +311,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Err",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                         let why := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -358,11 +352,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
-                            γ,
-                            "core::result::Result::Ok",
-                            0
-                          |) in
+                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                         let ln := M.copy (| γ0_0 |) in
                         M.match_operator (|
                           M.alloc (|
@@ -375,7 +365,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -422,11 +412,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
-                                    γ,
-                                    "core::result::Result::Ok",
-                                    0
-                                  |) in
+                                  M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                                 let sqrt := M.copy (| γ0_0 |) in
                                 sqrt))
                           ]

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/result.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/result.v
@@ -258,7 +258,8 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -298,7 +299,8 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let ratio := M.copy (| γ0_0 |) in
                 M.match_operator (|
                   M.alloc (|
@@ -311,7 +313,11 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Err",
+                            0
+                          |) in
                         let why := M.copy (| γ0_0 |) in
                         M.alloc (|
                           M.never_to_any (|
@@ -352,7 +358,11 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                          M.SubPointer.get_struct_tuple_field (|
+                            γ,
+                            "core::result::Result::Ok",
+                            0
+                          |) in
                         let ln := M.copy (| γ0_0 |) in
                         M.match_operator (|
                           M.alloc (|
@@ -365,7 +375,7 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0
@@ -412,7 +422,11 @@ Definition op (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                                  M.SubPointer.get_struct_tuple_field (|
+                                    γ,
+                                    "core::result::Result::Ok",
+                                    0
+                                  |) in
                                 let sqrt := M.copy (| γ0_0 |) in
                                 sqrt))
                           ]

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
@@ -286,7 +286,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -327,7 +327,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -369,7 +369,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -410,7 +410,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field (|
+                            M.SubPointer.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -463,7 +463,8 @@ Module checked.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.never_to_any (|
@@ -494,7 +495,8 @@ Module checked.
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let value := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/result_chaining_with_question_mark.v
@@ -286,7 +286,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -327,7 +327,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -369,7 +369,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Break",
                               0
@@ -410,7 +410,7 @@ Module checked.
                       fun γ =>
                         ltac:(M.monadic
                           (let γ0_0 :=
-                            M.get_struct_tuple_field_or_break_match (|
+                            M.get_struct_tuple_field (|
                               γ,
                               "core::ops::control_flow::ControlFlow::Continue",
                               0
@@ -463,12 +463,7 @@ Module checked.
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.never_to_any (|
@@ -499,12 +494,7 @@ Module checked.
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let value := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings.v
@@ -169,7 +169,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -342,7 +342,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings.v
@@ -169,7 +169,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -342,7 +342,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings_byte_strings_as_non_utf8.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings_byte_strings_as_non_utf8.v
@@ -187,7 +187,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         [ (* Unsize *) M.pointer_coercion (M.read (| raw_bytestring |)) ]
                       |)
                     |) in
-                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let my_str := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -250,7 +251,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let my_str := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -297,7 +299,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let e := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings_byte_strings_as_non_utf8.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/strings_byte_strings_as_non_utf8.v
@@ -187,12 +187,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         [ (* Unsize *) M.pointer_coercion (M.read (| raw_bytestring |)) ]
                       |)
                     |) in
-                  let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let my_str := M.copy (| γ0_0 |) in
                   let _ :=
                     let _ :=
@@ -255,12 +250,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let my_str := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -307,12 +297,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let e := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/vectors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/vectors.v
@@ -522,7 +522,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -663,13 +663,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
-                                  let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                  let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                  let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                  let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                   let i := M.copy (| γ1_0 |) in
                                   let x := M.copy (| γ1_1 |) in
                                   let _ :=
@@ -800,7 +800,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_library_types/vectors.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_library_types/vectors.v
@@ -522,7 +522,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -663,13 +663,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
-                                  let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                  let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                  let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                  let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                   let i := M.copy (| γ1_0 |) in
                                   let x := M.copy (| γ1_1 |) in
                                   let _ :=
@@ -800,7 +800,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/channels.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/channels.v
@@ -62,8 +62,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                 let tx := M.copy (| γ0_0 |) in
                 let rx := M.copy (| γ0_1 |) in
                 let children :=
@@ -138,7 +138,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -387,7 +387,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -488,7 +488,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/channels.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/channels.v
@@ -62,8 +62,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_tuple_field γ 0 in
-                let γ0_1 := M.get_tuple_field γ 1 in
+                (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                 let tx := M.copy (| γ0_0 |) in
                 let rx := M.copy (| γ0_1 |) in
                 let children :=
@@ -138,7 +138,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -387,7 +387,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0
@@ -488,7 +488,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes.v
@@ -137,7 +137,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                           "success",
                           []
                         |),
-                        [ M.get_struct_record_field output "std::process::Output" "status" ]
+                        [ M.get_struct_record_field (| output, "std::process::Output", "status" |) ]
                       |)
                     |)) in
                 let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -160,7 +160,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             "deref",
                             []
                           |),
-                          [ M.get_struct_record_field output "std::process::Output" "stdout" ]
+                          [ M.get_struct_record_field (| output, "std::process::Output", "stdout" |)
+                          ]
                         |)
                       ]
                     |)
@@ -232,7 +233,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             "deref",
                             []
                           |),
-                          [ M.get_struct_record_field output "std::process::Output" "stderr" ]
+                          [ M.get_struct_record_field (| output, "std::process::Output", "stderr" |)
+                          ]
                         |)
                       ]
                     |)

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes.v
@@ -137,7 +137,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                           "success",
                           []
                         |),
-                        [ M.get_struct_record_field (| output, "std::process::Output", "status" |) ]
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            output,
+                            "std::process::Output",
+                            "status"
+                          |)
+                        ]
                       |)
                     |)) in
                 let _ := M.is_constant_or_break_match (| M.read (| γ |), Value.Bool true |) in
@@ -160,7 +166,12 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             "deref",
                             []
                           |),
-                          [ M.get_struct_record_field (| output, "std::process::Output", "stdout" |)
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              output,
+                              "std::process::Output",
+                              "stdout"
+                            |)
                           ]
                         |)
                       ]
@@ -233,7 +244,12 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             "deref",
                             []
                           |),
-                          [ M.get_struct_record_field (| output, "std::process::Output", "stderr" |)
+                          [
+                            M.SubPointer.get_struct_record_field (|
+                              output,
+                              "std::process::Output",
+                              "stderr"
+                            |)
                           ]
                         |)
                       ]

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes_pipes.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes_pipes.v
@@ -103,7 +103,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -145,7 +146,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let process := M.copy (| γ0_0 |) in
                     process))
               ]
@@ -174,7 +176,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       |),
                       [
                         M.read (|
-                          M.get_struct_record_field (| process, "std::process::Child", "stdin" |)
+                          M.SubPointer.get_struct_record_field (|
+                            process,
+                            "std::process::Child",
+                            "stdin"
+                          |)
                         |)
                       ]
                     |)
@@ -193,7 +199,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.never_to_any (|
@@ -236,7 +243,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let _ :=
                     M.alloc (|
                       M.call_closure (|
@@ -292,7 +300,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |),
                     [
                       M.read (|
-                        M.get_struct_record_field (| process, "std::process::Child", "stdout" |)
+                        M.SubPointer.get_struct_record_field (|
+                          process,
+                          "std::process::Child",
+                          "stdout"
+                        |)
                       |)
                     ]
                   |)
@@ -304,7 +316,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -347,7 +360,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes_pipes.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/child_processes_pipes.v
@@ -103,12 +103,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -150,12 +145,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let process := M.copy (| γ0_0 |) in
                     process))
               ]
@@ -182,7 +172,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         "unwrap",
                         []
                       |),
-                      [ M.read (| M.get_struct_record_field process "std::process::Child" "stdin" |)
+                      [
+                        M.read (|
+                          M.get_struct_record_field (| process, "std::process::Child", "stdin" |)
+                        |)
                       ]
                     |)
                   |);
@@ -200,12 +193,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   M.alloc (|
                     M.never_to_any (|
@@ -248,12 +236,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let _ :=
                     M.alloc (|
                       M.call_closure (|
@@ -307,7 +290,10 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       "unwrap",
                       []
                     |),
-                    [ M.read (| M.get_struct_record_field process "std::process::Child" "stdout" |)
+                    [
+                      M.read (|
+                        M.get_struct_record_field (| process, "std::process::Child", "stdout" |)
+                      |)
                     ]
                   |)
                 |);
@@ -318,8 +304,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -362,8 +347,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_create.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_create.v
@@ -72,12 +72,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -131,12 +126,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let file := M.copy (| γ0_0 |) in
                     file))
               ]
@@ -164,8 +154,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -219,8 +208,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_create.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_create.v
@@ -72,7 +72,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -126,7 +127,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let file := M.copy (| γ0_0 |) in
                     file))
               ]
@@ -154,7 +156,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -208,7 +211,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_open.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_open.v
@@ -62,7 +62,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -116,7 +117,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let file := M.copy (| γ0_0 |) in
                     file))
               ]
@@ -145,7 +147,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -199,7 +202,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_open.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_open.v
@@ -62,12 +62,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let why := M.copy (| γ0_0 |) in
                     M.alloc (|
                       M.never_to_any (|
@@ -121,12 +116,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                     |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     let file := M.copy (| γ0_0 |) in
                     file))
               ]
@@ -155,8 +145,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let why := M.copy (| γ0_0 |) in
                 M.alloc (|
                   M.never_to_any (|
@@ -210,8 +199,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let _ :=
                   M.alloc (|
                     M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
@@ -157,7 +157,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines.v
@@ -157,7 +157,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
@@ -44,7 +44,7 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -89,7 +89,7 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -166,7 +166,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       [ M.read (| Value.String "./hosts" |) ]
                     |)
                   |) in
-                let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let lines := M.copy (| γ0_0 |) in
                 M.use
                   (M.match_operator (|
@@ -223,7 +224,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -236,7 +237,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                               ltac:(M.monadic
                                                 (let γ := line in
                                                 let γ0_0 :=
-                                                  M.get_struct_tuple_field (|
+                                                  M.SubPointer.get_struct_tuple_field (|
                                                     γ,
                                                     "core::result::Result::Ok",
                                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/file_io_read_lines_efficient_method.v
@@ -44,7 +44,7 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -89,7 +89,7 @@ Definition read_lines (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -166,8 +166,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                       [ M.read (| Value.String "./hosts" |) ]
                     |)
                   |) in
-                let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 let lines := M.copy (| γ0_0 |) in
                 M.use
                   (M.match_operator (|
@@ -224,7 +223,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
@@ -237,7 +236,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                               ltac:(M.monadic
                                                 (let γ := line in
                                                 let γ0_0 :=
-                                                  M.get_struct_tuple_field_or_break_match (|
+                                                  M.get_struct_tuple_field (|
                                                     γ,
                                                     "core::result::Result::Ok",
                                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
@@ -49,7 +49,7 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -88,7 +88,7 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -121,21 +121,11 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Ok",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| s |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 :=
-                      M.get_struct_tuple_field_or_break_match (|
-                        γ,
-                        "core::result::Result::Err",
-                        0
-                      |) in
+                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
@@ -191,7 +181,7 @@ Definition echo (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -227,7 +217,7 @@ Definition echo (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field_or_break_match (|
+                          M.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -312,13 +302,11 @@ Definition touch (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
           ]
@@ -429,12 +417,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -490,12 +473,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (| Value.Tuple [] |)))
             ]
           |) in
@@ -1041,12 +1019,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1102,12 +1075,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let s := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1185,12 +1153,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Err",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1246,12 +1209,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 :=
-                    M.get_struct_tuple_field_or_break_match (|
-                      γ,
-                      "core::result::Result::Ok",
-                      0
-                    |) in
+                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let paths := M.copy (| γ0_0 |) in
                   M.use
                     (M.match_operator (|
@@ -1296,7 +1254,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field_or_break_match (|
+                                            M.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/filesystem_operations.v
@@ -49,7 +49,7 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -88,7 +88,7 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -121,11 +121,13 @@ Definition cat (τ : list Ty.t) (α : list Value.t) : M :=
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Ok" [ M.read (| s |) ] |)));
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                    (let γ0_0 :=
+                      M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                     let e := M.copy (| γ0_0 |) in
                     M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
               ]
@@ -181,7 +183,7 @@ Definition echo (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Break",
                             0
@@ -217,7 +219,7 @@ Definition echo (τ : list Ty.t) (α : list Value.t) : M :=
                     fun γ =>
                       ltac:(M.monadic
                         (let γ0_0 :=
-                          M.get_struct_tuple_field (|
+                          M.SubPointer.get_struct_tuple_field (|
                             γ,
                             "core::ops::control_flow::ControlFlow::Continue",
                             0
@@ -302,11 +304,13 @@ Definition touch (τ : list Ty.t) (α : list Value.t) : M :=
           [
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Ok" [ Value.Tuple [] ] |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                 let e := M.copy (| γ0_0 |) in
                 M.alloc (| Value.StructTuple "core::result::Result::Err" [ M.read (| e |) ] |)))
           ]
@@ -417,7 +421,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -473,7 +478,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   M.alloc (| Value.Tuple [] |)))
             ]
           |) in
@@ -1019,7 +1025,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1075,7 +1082,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let s := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1153,7 +1161,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Err", 0 |) in
                   let why := M.copy (| γ0_0 |) in
                   let _ :=
                     M.alloc (|
@@ -1209,7 +1218,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                   M.alloc (| Value.Tuple [] |)));
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                  (let γ0_0 :=
+                    M.SubPointer.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                   let paths := M.copy (| γ0_0 |) in
                   M.use
                     (M.match_operator (|
@@ -1254,7 +1264,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                                       fun γ =>
                                         ltac:(M.monadic
                                           (let γ0_0 :=
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               γ,
                                               "core::option::Option::Some",
                                               0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/foreign_function_interface.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/foreign_function_interface.v
@@ -231,10 +231,11 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                       (M.alloc (|
                         BinOp.Pure.lt
                           (M.read (|
-                            M.get_struct_record_field
-                              (M.read (| self |))
-                              "foreign_function_interface::Complex"
+                            M.get_struct_record_field (|
+                              M.read (| self |),
+                              "foreign_function_interface::Complex",
                               "im"
+                            |)
                           |))
                           (M.read (| UnsupportedLiteral |))
                       |)) in
@@ -277,10 +278,11 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "foreign_function_interface::Complex"
+                                        M.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "foreign_function_interface::Complex",
                                           "re"
+                                        |)
                                       ]
                                     |);
                                     M.call_closure (|
@@ -293,10 +295,11 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         M.alloc (|
                                           UnOp.Panic.neg (|
                                             M.read (|
-                                              M.get_struct_record_field
-                                                (M.read (| self |))
-                                                "foreign_function_interface::Complex"
+                                              M.get_struct_record_field (|
+                                                M.read (| self |),
+                                                "foreign_function_interface::Complex",
                                                 "im"
+                                              |)
                                             |)
                                           |)
                                         |)
@@ -349,10 +352,11 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "foreign_function_interface::Complex"
+                                        M.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "foreign_function_interface::Complex",
                                           "re"
+                                        |)
                                       ]
                                     |);
                                     M.call_closure (|
@@ -362,10 +366,11 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field
-                                          (M.read (| self |))
-                                          "foreign_function_interface::Complex"
+                                        M.get_struct_record_field (|
+                                          M.read (| self |),
+                                          "foreign_function_interface::Complex",
                                           "im"
+                                        |)
                                       ]
                                     |)
                                   ]

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/foreign_function_interface.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/foreign_function_interface.v
@@ -231,7 +231,7 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                       (M.alloc (|
                         BinOp.Pure.lt
                           (M.read (|
-                            M.get_struct_record_field (|
+                            M.SubPointer.get_struct_record_field (|
                               M.read (| self |),
                               "foreign_function_interface::Complex",
                               "im"
@@ -278,7 +278,7 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
                                           M.read (| self |),
                                           "foreign_function_interface::Complex",
                                           "re"
@@ -295,7 +295,7 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         M.alloc (|
                                           UnOp.Panic.neg (|
                                             M.read (|
-                                              M.get_struct_record_field (|
+                                              M.SubPointer.get_struct_record_field (|
                                                 M.read (| self |),
                                                 "foreign_function_interface::Complex",
                                                 "im"
@@ -352,7 +352,7 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
                                           M.read (| self |),
                                           "foreign_function_interface::Complex",
                                           "re"
@@ -366,7 +366,7 @@ Module Impl_core_fmt_Debug_for_foreign_function_interface_Complex.
                                         [ Ty.path "f32" ]
                                       |),
                                       [
-                                        M.get_struct_record_field (|
+                                        M.SubPointer.get_struct_record_field (|
                                           M.read (| self |),
                                           "foreign_function_interface::Complex",
                                           "im"

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/path.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/path.v
@@ -147,12 +147,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 :=
-                  M.get_struct_tuple_field_or_break_match (|
-                    γ,
-                    "core::option::Option::Some",
-                    0
-                  |) in
+                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let s := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/path.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/path.v
@@ -147,7 +147,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                 |)));
             fun γ =>
               ltac:(M.monadic
-                (let γ0_0 := M.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
+                (let γ0_0 :=
+                  M.SubPointer.get_struct_tuple_field (| γ, "core::option::Option::Some", 0 |) in
                 let s := M.copy (| γ0_0 |) in
                 let _ :=
                   M.alloc (|

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
@@ -340,11 +340,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field_or_break_match (|
-                                γ,
-                                "core::result::Result::Ok",
-                                0
-                              |) in
+                              M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                             let _ :=
                               M.is_constant_or_break_match (|
                                 M.read (| γ0_0 |),
@@ -470,17 +466,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
-                                    γ,
-                                    "core::result::Result::Ok",
-                                    0
-                                  |) in
+                                  M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
                                 let n := M.copy (| γ0_0 |) in
                                 n));
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/program_arguments_parsing.v
@@ -340,7 +340,11 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                         fun γ =>
                           ltac:(M.monadic
                             (let γ0_0 :=
-                              M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                              M.SubPointer.get_struct_tuple_field (|
+                                γ,
+                                "core::result::Result::Ok",
+                                0
+                              |) in
                             let _ :=
                               M.is_constant_or_break_match (|
                                 M.read (| γ0_0 |),
@@ -466,13 +470,17 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (| γ, "core::result::Result::Ok", 0 |) in
+                                  M.SubPointer.get_struct_tuple_field (|
+                                    γ,
+                                    "core::result::Result::Ok",
+                                    0
+                                  |) in
                                 let n := M.copy (| γ0_0 |) in
                                 n));
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::result::Result::Err",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/threads.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/threads.v
@@ -92,7 +92,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -262,7 +262,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/threads.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/threads.v
@@ -92,7 +92,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -262,7 +262,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/threads_test_case_map_reduce.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/threads_test_case_map_reduce.v
@@ -185,13 +185,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
-                                  let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                  let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                  let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                  let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                   let i := M.copy (| γ1_0 |) in
                                   let data_segment := M.copy (| γ1_1 |) in
                                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/std_misc/threads_test_case_map_reduce.v
+++ b/CoqOfRust/examples/default/examples/rust_book/std_misc/threads_test_case_map_reduce.v
@@ -185,13 +185,13 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
                                     |) in
-                                  let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                  let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                  let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                  let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                   let i := M.copy (| γ1_0 |) in
                                   let data_segment := M.copy (| γ1_1 |) in
                                   let _ :=

--- a/CoqOfRust/examples/default/examples/rust_book/testing/unit_testing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/testing/unit_testing.v
@@ -59,8 +59,8 @@ Module tests.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -141,8 +141,8 @@ Module tests.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/testing/unit_testing.v
+++ b/CoqOfRust/examples/default/examples/rust_book/testing/unit_testing.v
@@ -59,8 +59,8 @@ Module tests.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -141,8 +141,8 @@ Module tests.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
@@ -94,7 +94,7 @@ Module Impl_core_clone_Clone_for_clone_Pair.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "clone::Pair" 0 ]
+              [ M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |) ]
             |);
             M.call_closure (|
               M.get_trait_method (|
@@ -106,7 +106,7 @@ Module Impl_core_clone_Clone_for_clone_Pair.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (M.read (| self |)) "clone::Pair" 1 ]
+              [ M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |) ]
             |)
           ]))
     | _, _ => M.impossible
@@ -140,10 +140,10 @@ Module Impl_core_fmt_Debug_for_clone_Pair.
             M.read (| f |);
             M.read (| Value.String "Pair" |);
             (* Unsize *)
-            M.pointer_coercion (M.get_struct_tuple_field (M.read (| self |)) "clone::Pair" 0);
+            M.pointer_coercion (M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "clone::Pair" 1 |))
+              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |) |))
           ]
         |)))
     | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/clone.v
@@ -94,7 +94,7 @@ Module Impl_core_clone_Clone_for_clone_Pair.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |) ]
+              [ M.SubPointer.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |) ]
             |);
             M.call_closure (|
               M.get_trait_method (|
@@ -106,7 +106,7 @@ Module Impl_core_clone_Clone_for_clone_Pair.
                 "clone",
                 []
               |),
-              [ M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |) ]
+              [ M.SubPointer.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |) ]
             |)
           ]))
     | _, _ => M.impossible
@@ -140,10 +140,13 @@ Module Impl_core_fmt_Debug_for_clone_Pair.
             M.read (| f |);
             M.read (| Value.String "Pair" |);
             (* Unsize *)
-            M.pointer_coercion (M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |));
+            M.pointer_coercion
+              (M.SubPointer.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 0 |));
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |) |))
+              (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (| M.read (| self |), "clone::Pair", 1 |)
+              |))
           ]
         |)))
     | _, _ => M.impossible

--- a/CoqOfRust/examples/default/examples/rust_book/traits/derive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/derive.v
@@ -30,9 +30,11 @@ Module Impl_core_cmp_PartialEq_for_derive_Centimeters.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |) |))
           (M.read (|
-            M.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |)
+          |))
+          (M.read (|
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
           |))))
     | _, _ => M.impossible
     end.
@@ -64,8 +66,8 @@ Module Impl_core_cmp_PartialOrd_for_derive_Centimeters.
             []
           |),
           [
-            M.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |);
-            M.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
+            M.SubPointer.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |);
+            M.SubPointer.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -107,7 +109,9 @@ Module Impl_core_fmt_Debug_for_derive_Inches.
             M.read (| Value.String "Inches" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "derive::Inches", 0 |) |))
+              (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (| M.read (| self |), "derive::Inches", 0 |)
+              |))
           ]
         |)))
     | _, _ => M.impossible
@@ -143,7 +147,7 @@ Module Impl_derive_Inches.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 := M.get_struct_tuple_field (| γ, "derive::Inches", 0 |) in
+                  let γ1_0 := M.SubPointer.get_struct_tuple_field (| γ, "derive::Inches", 0 |) in
                   let inches := M.copy (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple

--- a/CoqOfRust/examples/default/examples/rust_book/traits/derive.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/derive.v
@@ -30,8 +30,10 @@ Module Impl_core_cmp_PartialEq_for_derive_Centimeters.
         (let self := M.alloc (| self |) in
         let other := M.alloc (| other |) in
         BinOp.Pure.eq
-          (M.read (| M.get_struct_tuple_field (M.read (| self |)) "derive::Centimeters" 0 |))
-          (M.read (| M.get_struct_tuple_field (M.read (| other |)) "derive::Centimeters" 0 |))))
+          (M.read (| M.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |) |))
+          (M.read (|
+            M.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
+          |))))
     | _, _ => M.impossible
     end.
   
@@ -62,8 +64,8 @@ Module Impl_core_cmp_PartialOrd_for_derive_Centimeters.
             []
           |),
           [
-            M.get_struct_tuple_field (M.read (| self |)) "derive::Centimeters" 0;
-            M.get_struct_tuple_field (M.read (| other |)) "derive::Centimeters" 0
+            M.get_struct_tuple_field (| M.read (| self |), "derive::Centimeters", 0 |);
+            M.get_struct_tuple_field (| M.read (| other |), "derive::Centimeters", 0 |)
           ]
         |)))
     | _, _ => M.impossible
@@ -105,7 +107,7 @@ Module Impl_core_fmt_Debug_for_derive_Inches.
             M.read (| Value.String "Inches" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "derive::Inches" 0 |))
+              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "derive::Inches", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -141,8 +143,7 @@ Module Impl_derive_Inches.
               fun γ =>
                 ltac:(M.monadic
                   (let γ := M.read (| γ |) in
-                  let γ1_0 :=
-                    M.get_struct_tuple_field_or_break_match (| γ, "derive::Inches", 0 |) in
+                  let γ1_0 := M.get_struct_tuple_field (| γ, "derive::Inches", 0 |) in
                   let inches := M.copy (| γ1_0 |) in
                   M.alloc (|
                     Value.StructTuple

--- a/CoqOfRust/examples/default/examples/rust_book/traits/disambiguating_overlapping_traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/disambiguating_overlapping_traits.v
@@ -36,7 +36,7 @@ Module Impl_disambiguating_overlapping_traits_UsernameWidget_for_disambiguating_
             []
           |),
           [
-            M.get_struct_record_field (|
+            M.SubPointer.get_struct_record_field (|
               M.read (| self |),
               "disambiguating_overlapping_traits::Form",
               "username"
@@ -68,7 +68,7 @@ Module Impl_disambiguating_overlapping_traits_AgeWidget_for_disambiguating_overl
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (|
+          M.SubPointer.get_struct_record_field (|
             M.read (| self |),
             "disambiguating_overlapping_traits::Form",
             "age"
@@ -163,8 +163,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -240,8 +240,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/traits/disambiguating_overlapping_traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/disambiguating_overlapping_traits.v
@@ -36,10 +36,11 @@ Module Impl_disambiguating_overlapping_traits_UsernameWidget_for_disambiguating_
             []
           |),
           [
-            M.get_struct_record_field
-              (M.read (| self |))
-              "disambiguating_overlapping_traits::Form"
+            M.get_struct_record_field (|
+              M.read (| self |),
+              "disambiguating_overlapping_traits::Form",
               "username"
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -67,10 +68,11 @@ Module Impl_disambiguating_overlapping_traits_AgeWidget_for_disambiguating_overl
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field
-            (M.read (| self |))
-            "disambiguating_overlapping_traits::Form"
+          M.get_struct_record_field (|
+            M.read (| self |),
+            "disambiguating_overlapping_traits::Form",
             "age"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -161,8 +163,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -238,8 +240,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/traits/drop.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/drop.v
@@ -53,7 +53,7 @@ Module Impl_core_ops_drop_Drop_for_drop_Droppable.
                                     [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "drop::Droppable",
                                       "name"

--- a/CoqOfRust/examples/default/examples/rust_book/traits/drop.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/drop.v
@@ -53,10 +53,11 @@ Module Impl_core_ops_drop_Drop_for_drop_Droppable.
                                     [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "drop::Droppable"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "drop::Droppable",
                                       "name"
+                                    |)
                                   ]
                                 |)
                               ]

--- a/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
@@ -26,7 +26,7 @@ Module Impl_core_hash_Hash_for_hash_Person.
               M.call_closure (|
                 M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "hash::Person" "id";
+                  M.get_struct_record_field (| M.read (| self |), "hash::Person", "id" |);
                   M.read (| state |)
                 ]
               |)
@@ -42,7 +42,7 @@ Module Impl_core_hash_Hash_for_hash_Person.
                   [ __H ]
                 |),
                 [
-                  M.get_struct_record_field (M.read (| self |)) "hash::Person" "name";
+                  M.get_struct_record_field (| M.read (| self |), "hash::Person", "name" |);
                   M.read (| state |)
                 ]
               |)
@@ -51,7 +51,7 @@ Module Impl_core_hash_Hash_for_hash_Person.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u64", [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field (M.read (| self |)) "hash::Person" "phone";
+                M.get_struct_record_field (| M.read (| self |), "hash::Person", "phone" |);
                 M.read (| state |)
               ]
             |)

--- a/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/hash.v
@@ -26,7 +26,11 @@ Module Impl_core_hash_Hash_for_hash_Person.
               M.call_closure (|
                 M.get_trait_method (| "core::hash::Hash", Ty.path "u32", [], "hash", [ __H ] |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "hash::Person", "id" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "hash::Person",
+                    "id"
+                  |);
                   M.read (| state |)
                 ]
               |)
@@ -42,7 +46,11 @@ Module Impl_core_hash_Hash_for_hash_Person.
                   [ __H ]
                 |),
                 [
-                  M.get_struct_record_field (| M.read (| self |), "hash::Person", "name" |);
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "hash::Person",
+                    "name"
+                  |);
                   M.read (| state |)
                 ]
               |)
@@ -51,7 +59,11 @@ Module Impl_core_hash_Hash_for_hash_Person.
             M.call_closure (|
               M.get_trait_method (| "core::hash::Hash", Ty.path "u64", [], "hash", [ __H ] |),
               [
-                M.get_struct_record_field (| M.read (| self |), "hash::Person", "phone" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "hash::Person",
+                  "phone"
+                |);
                 M.read (| state |)
               ]
             |)

--- a/CoqOfRust/examples/default/examples/rust_book/traits/impl_trait_as_return_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/impl_trait_as_return_type.v
@@ -279,8 +279,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -363,8 +363,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -447,8 +447,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -531,8 +531,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -615,8 +615,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/traits/impl_trait_as_return_type.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/impl_trait_as_return_type.v
@@ -279,8 +279,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -363,8 +363,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -447,8 +447,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -531,8 +531,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|
@@ -615,8 +615,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/traits/iterators.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/iterators.v
@@ -34,22 +34,42 @@ Module Impl_core_iter_traits_iterator_Iterator_for_iterators_Fibonacci.
         M.read (|
           let current :=
             M.copy (|
-              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "curr" |)
-            |) in
-          let _ :=
-            M.write (|
-              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "curr" |),
-              M.read (|
-                M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |)
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "iterators::Fibonacci",
+                "curr"
               |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |),
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "iterators::Fibonacci",
+                "curr"
+              |),
+              M.read (|
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "iterators::Fibonacci",
+                  "next"
+                |)
+              |)
+            |) in
+          let _ :=
+            M.write (|
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "iterators::Fibonacci",
+                "next"
+              |),
               BinOp.Panic.add (|
                 M.read (| current |),
                 M.read (|
-                  M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |)
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "iterators::Fibonacci",
+                    "next"
+                  |)
                 |)
               |)
             |) in
@@ -432,7 +452,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -575,7 +595,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -743,7 +763,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field (|
+                                    M.SubPointer.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -904,7 +924,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field (|
+                                  M.SubPointer.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/traits/iterators.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/iterators.v
@@ -34,22 +34,22 @@ Module Impl_core_iter_traits_iterator_Iterator_for_iterators_Fibonacci.
         M.read (|
           let current :=
             M.copy (|
-              M.get_struct_record_field (M.read (| self |)) "iterators::Fibonacci" "curr"
+              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "curr" |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "iterators::Fibonacci" "curr",
+              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "curr" |),
               M.read (|
-                M.get_struct_record_field (M.read (| self |)) "iterators::Fibonacci" "next"
+                M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |)
               |)
             |) in
           let _ :=
             M.write (|
-              M.get_struct_record_field (M.read (| self |)) "iterators::Fibonacci" "next",
+              M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |),
               BinOp.Panic.add (|
                 M.read (| current |),
                 M.read (|
-                  M.get_struct_record_field (M.read (| self |)) "iterators::Fibonacci" "next"
+                  M.get_struct_record_field (| M.read (| self |), "iterators::Fibonacci", "next" |)
                 |)
               |)
             |) in
@@ -432,7 +432,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -575,7 +575,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -743,7 +743,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                               fun γ =>
                                 ltac:(M.monadic
                                   (let γ0_0 :=
-                                    M.get_struct_tuple_field_or_break_match (|
+                                    M.get_struct_tuple_field (|
                                       γ,
                                       "core::option::Option::Some",
                                       0
@@ -904,7 +904,7 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
                             fun γ =>
                               ltac:(M.monadic
                                 (let γ0_0 :=
-                                  M.get_struct_tuple_field_or_break_match (|
+                                  M.get_struct_tuple_field (|
                                     γ,
                                     "core::option::Option::Some",
                                     0

--- a/CoqOfRust/examples/default/examples/rust_book/traits/traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/traits.v
@@ -112,7 +112,9 @@ Module Impl_traits_Sheep.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "naked" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "traits::Sheep", "naked" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -244,7 +246,7 @@ Module Impl_traits_Sheep.
                                             [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                           |),
                                           [
-                                            M.get_struct_record_field (|
+                                            M.SubPointer.get_struct_record_field (|
                                               M.read (| self |),
                                               "traits::Sheep",
                                               "name"
@@ -261,7 +263,11 @@ Module Impl_traits_Sheep.
                     M.alloc (| Value.Tuple [] |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "naked" |),
+                      M.SubPointer.get_struct_record_field (|
+                        M.read (| self |),
+                        "traits::Sheep",
+                        "naked"
+                      |),
                       Value.Bool true
                     |) in
                   M.alloc (| Value.Tuple [] |)))
@@ -306,7 +312,9 @@ Module Impl_traits_Animal_for_traits_Sheep.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "name" |) |)))
+        M.read (|
+          M.SubPointer.get_struct_record_field (| M.read (| self |), "traits::Sheep", "name" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -391,7 +399,7 @@ Module Impl_traits_Animal_for_traits_Sheep.
                                     [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field (|
+                                    M.SubPointer.get_struct_record_field (|
                                       M.read (| self |),
                                       "traits::Sheep",
                                       "name"

--- a/CoqOfRust/examples/default/examples/rust_book/traits/traits.v
+++ b/CoqOfRust/examples/default/examples/rust_book/traits/traits.v
@@ -112,7 +112,7 @@ Module Impl_traits_Sheep.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "traits::Sheep" "naked" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "naked" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -244,10 +244,11 @@ Module Impl_traits_Sheep.
                                             [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                           |),
                                           [
-                                            M.get_struct_record_field
-                                              (M.read (| self |))
-                                              "traits::Sheep"
+                                            M.get_struct_record_field (|
+                                              M.read (| self |),
+                                              "traits::Sheep",
                                               "name"
+                                            |)
                                           ]
                                         |)
                                       ]
@@ -260,7 +261,7 @@ Module Impl_traits_Sheep.
                     M.alloc (| Value.Tuple [] |) in
                   let _ :=
                     M.write (|
-                      M.get_struct_record_field (M.read (| self |)) "traits::Sheep" "naked",
+                      M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "naked" |),
                       Value.Bool true
                     |) in
                   M.alloc (| Value.Tuple [] |)))
@@ -305,7 +306,7 @@ Module Impl_traits_Animal_for_traits_Sheep.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "traits::Sheep" "name" |)))
+        M.read (| M.get_struct_record_field (| M.read (| self |), "traits::Sheep", "name" |) |)))
     | _, _ => M.impossible
     end.
   
@@ -390,10 +391,11 @@ Module Impl_traits_Animal_for_traits_Sheep.
                                     [ Ty.apply (Ty.path "&") [ Ty.path "str" ] ]
                                   |),
                                   [
-                                    M.get_struct_record_field
-                                      (M.read (| self |))
-                                      "traits::Sheep"
+                                    M.get_struct_record_field (|
+                                      M.read (| self |),
+                                      "traits::Sheep",
                                       "name"
+                                    |)
                                   ]
                                 |);
                                 M.call_closure (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/calling_unsafe_functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/calling_unsafe_functions.v
@@ -115,8 +115,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/calling_unsafe_functions.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/calling_unsafe_functions.v
@@ -115,8 +115,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_implemented.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_implemented.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_implemented.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_implemented.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_non_used.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_non_used.v
@@ -37,8 +37,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_non_used.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inlateout_case_non_used.v
@@ -37,8 +37,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inout.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inout.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inout.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inout.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs.v
@@ -27,8 +27,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs.v
@@ -27,8 +27,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example.v
@@ -34,8 +34,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example.v
@@ -34,8 +34,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example_without_mov.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example_without_mov.v
@@ -27,8 +27,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example_without_mov.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_inputs_and_outputs_another_example_without_mov.v
@@ -27,8 +27,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_labels.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_labels.v
@@ -37,8 +37,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_labels.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_labels.v
@@ -37,8 +37,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_options.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_options.v
@@ -33,8 +33,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_options.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_options.v
@@ -33,8 +33,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_register_template_modifiers.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_register_template_modifiers.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_register_template_modifiers.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_register_template_modifiers.v
@@ -29,8 +29,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_scratch_register.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_scratch_register.v
@@ -43,8 +43,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                  (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_scratch_register.v
+++ b/CoqOfRust/examples/default/examples/rust_book/unsafe_operations/inline_assembly_scratch_register.v
@@ -43,8 +43,8 @@ Definition main (τ : list Ty.t) (α : list Value.t) : M :=
             [
               fun γ =>
                 ltac:(M.monadic
-                  (let γ0_0 := M.get_tuple_field γ 0 in
-                  let γ0_1 := M.get_tuple_field γ 1 in
+                  (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                  let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                   let left_val := M.copy (| γ0_0 |) in
                   let right_val := M.copy (| γ0_1 |) in
                   M.match_operator (|

--- a/CoqOfRust/examples/default/examples/subtle.v
+++ b/CoqOfRust/examples/default/examples/subtle.v
@@ -62,7 +62,9 @@ Module Impl_core_fmt_Debug_for_subtle_Choice.
             M.read (| Value.String "Choice" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |) |))
+              (M.alloc (|
+                M.SubPointer.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |)
+              |))
           ]
         |)))
     | _, _ => M.impossible
@@ -89,7 +91,9 @@ Module Impl_subtle_Choice.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |) |)))
+        M.read (|
+          M.SubPointer.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -132,7 +136,7 @@ Module Impl_core_convert_From_subtle_Choice_for_bool.
                                       (BinOp.Pure.bit_or
                                         (BinOp.Pure.eq
                                           (M.read (|
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               source,
                                               "subtle::Choice",
                                               0
@@ -141,7 +145,7 @@ Module Impl_core_convert_From_subtle_Choice_for_bool.
                                           (Value.Integer Integer.U8 0))
                                         (BinOp.Pure.eq
                                           (M.read (|
-                                            M.get_struct_tuple_field (|
+                                            M.SubPointer.get_struct_tuple_field (|
                                               source,
                                               "subtle::Choice",
                                               0
@@ -176,7 +180,7 @@ Module Impl_core_convert_From_subtle_Choice_for_bool.
             |) in
           M.alloc (|
             BinOp.Pure.ne
-              (M.read (| M.get_struct_tuple_field (| source, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| source, "subtle::Choice", 0 |) |))
               (Value.Integer Integer.U8 0)
           |)
         |)))
@@ -218,8 +222,8 @@ Module Impl_core_ops_bit_BitAnd_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_and
-              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
-              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -303,8 +307,8 @@ Module Impl_core_ops_bit_BitOr_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_or
-              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
-              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -388,8 +392,8 @@ Module Impl_core_ops_bit_BitXor_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_xor
-              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
-              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.SubPointer.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -474,7 +478,7 @@ Module Impl_core_ops_bit_Not_for_subtle_Choice.
             BinOp.Pure.bit_and
               (Value.Integer Integer.U8 1)
               (UnOp.Pure.not
-                (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |)))
+                (M.read (| M.SubPointer.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |)))
           ]
         |)))
     | _, _ => M.impossible
@@ -793,13 +797,13 @@ Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field (|
+                                          M.SubPointer.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
-                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
+                                        let γ1_0 := M.SubPointer.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.SubPointer.get_tuple_field (| γ0_0, 1 |) in
                                         let ai := M.copy (| γ1_0 |) in
                                         let bi := M.copy (| γ1_1 |) in
                                         let _ :=
@@ -2896,8 +2900,8 @@ Module Impl_subtle_ConditionallySelectable_for_subtle_Choice.
                 []
               |),
               [
-                M.get_struct_tuple_field (| M.read (| a |), "subtle::Choice", 0 |);
-                M.get_struct_tuple_field (| M.read (| b |), "subtle::Choice", 0 |);
+                M.SubPointer.get_struct_tuple_field (| M.read (| a |), "subtle::Choice", 0 |);
+                M.SubPointer.get_struct_tuple_field (| M.read (| b |), "subtle::Choice", 0 |);
                 M.read (| choice |)
               ]
             |)
@@ -2997,7 +3001,13 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
             ("value",
               M.call_closure (|
                 M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
-                [ M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "value" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "subtle::CtOption",
+                    "value"
+                  |)
+                ]
               |));
             ("is_some",
               M.call_closure (|
@@ -3008,7 +3018,13 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |) ]
+                [
+                  M.SubPointer.get_struct_record_field (|
+                    M.read (| self |),
+                    "subtle::CtOption",
+                    "is_some"
+                  |)
+                ]
               |))
           ]))
     | _, _ => M.impossible
@@ -3058,12 +3074,20 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
             M.read (| Value.String "value" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "value" |));
+              (M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "subtle::CtOption",
+                "value"
+              |));
             M.read (| Value.String "is_some" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| self |),
+                  "subtle::CtOption",
+                  "is_some"
+                |)
               |))
           ]
         |)))
@@ -3134,7 +3158,11 @@ Module Impl_core_convert_From_subtle_CtOption_T_for_core_option_Option_T.
                       "core::option::Option::Some"
                       [
                         M.read (|
-                          M.get_struct_record_field (| source, "subtle::CtOption", "value" |)
+                          M.SubPointer.get_struct_record_field (|
+                            source,
+                            "subtle::CtOption",
+                            "value"
+                          |)
                         |)
                       ]
                   |)));
@@ -3204,7 +3232,13 @@ Module Impl_subtle_CtOption_T.
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "subtle::Choice", "unwrap_u8", [] |),
-                        [ M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) ]
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "subtle::CtOption",
+                            "is_some"
+                          |)
+                        ]
                       |)
                     |);
                     M.alloc (| Value.Integer Integer.U8 1 |)
@@ -3213,8 +3247,8 @@ Module Impl_subtle_CtOption_T.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -3297,7 +3331,7 @@ Module Impl_subtle_CtOption_T.
                     |)))
               ]
             |) in
-          M.get_struct_record_field (| self, "subtle::CtOption", "value" |)
+          M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "value" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -3328,7 +3362,13 @@ Module Impl_subtle_CtOption_T.
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "subtle::Choice", "unwrap_u8", [] |),
-                        [ M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) ]
+                        [
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "subtle::CtOption",
+                            "is_some"
+                          |)
+                        ]
                       |)
                     |);
                     M.alloc (| Value.Integer Integer.U8 1 |)
@@ -3337,8 +3377,8 @@ Module Impl_subtle_CtOption_T.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
-                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
+                    (let γ0_0 := M.SubPointer.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.SubPointer.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -3385,7 +3425,7 @@ Module Impl_subtle_CtOption_T.
                     |)))
               ]
             |) in
-          M.get_struct_record_field (| self, "subtle::CtOption", "value" |)
+          M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "value" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -3419,8 +3459,10 @@ Module Impl_subtle_CtOption_T.
           |),
           [
             def;
-            M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
-            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
+            M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+            M.read (|
+              M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3467,8 +3509,10 @@ Module Impl_subtle_CtOption_T.
                 [ M.read (| f |); Value.Tuple [] ]
               |)
             |);
-            M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
-            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
+            M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+            M.read (|
+              M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3490,7 +3534,11 @@ Module Impl_subtle_CtOption_T.
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
         M.read (|
-          M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
+          M.SubPointer.get_struct_record_field (|
+            M.read (| self |),
+            "subtle::CtOption",
+            "is_some"
+          |)
         |)))
     | _, _ => M.impossible
     end.
@@ -3514,7 +3562,11 @@ Module Impl_subtle_CtOption_T.
           M.get_trait_method (| "core::ops::bit::Not", Ty.path "subtle::Choice", [], "not", [] |),
           [
             M.read (|
-              M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
+              M.SubPointer.get_struct_record_field (|
+                M.read (| self |),
+                "subtle::CtOption",
+                "is_some"
+              |)
             |)
           ]
         |)))
@@ -3578,16 +3630,26 @@ Module Impl_subtle_CtOption_T.
                             []
                           |)
                         |);
-                        M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+                        M.SubPointer.get_struct_record_field (|
+                          self,
+                          "subtle::CtOption",
+                          "value"
+                        |);
                         M.read (|
-                          M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "subtle::CtOption",
+                            "is_some"
+                          |)
                         |)
                       ]
                     |)
                   ]
               ]
             |);
-            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
+            M.read (|
+              M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3654,9 +3716,17 @@ Module Impl_subtle_CtOption_T.
                               []
                             |)
                           |);
-                          M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+                          M.SubPointer.get_struct_record_field (|
+                            self,
+                            "subtle::CtOption",
+                            "value"
+                          |);
                           M.read (|
-                            M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+                            M.SubPointer.get_struct_record_field (|
+                              self,
+                              "subtle::CtOption",
+                              "is_some"
+                            |)
                           |)
                         ]
                       |)
@@ -3675,8 +3745,10 @@ Module Impl_subtle_CtOption_T.
                   []
                 |),
                 [
-                  M.get_struct_record_field (| tmp, "subtle::CtOption", "is_some" |);
-                  M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
+                  M.SubPointer.get_struct_record_field (| tmp, "subtle::CtOption", "is_some" |);
+                  M.read (|
+                    M.SubPointer.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+                  |)
                 ]
               |)
             |) in
@@ -3785,8 +3857,16 @@ Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| a |), "subtle::CtOption", "value" |);
-                M.get_struct_record_field (| M.read (| b |), "subtle::CtOption", "value" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| a |),
+                  "subtle::CtOption",
+                  "value"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| b |),
+                  "subtle::CtOption",
+                  "value"
+                |);
                 M.read (| choice |)
               ]
             |);
@@ -3799,8 +3879,16 @@ Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_
                 []
               |),
               [
-                M.get_struct_record_field (| M.read (| a |), "subtle::CtOption", "is_some" |);
-                M.get_struct_record_field (| M.read (| b |), "subtle::CtOption", "is_some" |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| a |),
+                  "subtle::CtOption",
+                  "is_some"
+                |);
+                M.SubPointer.get_struct_record_field (|
+                  M.read (| b |),
+                  "subtle::CtOption",
+                  "is_some"
+                |);
                 M.read (| choice |)
               ]
             |)
@@ -3891,12 +3979,12 @@ Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOpt
                     M.call_closure (|
                       M.get_trait_method (| "subtle::ConstantTimeEq", T, [], "ct_eq", [] |),
                       [
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| self |),
                           "subtle::CtOption",
                           "value"
                         |);
-                        M.get_struct_record_field (|
+                        M.SubPointer.get_struct_record_field (|
                           M.read (| rhs |),
                           "subtle::CtOption",
                           "value"

--- a/CoqOfRust/examples/default/examples/subtle.v
+++ b/CoqOfRust/examples/default/examples/subtle.v
@@ -62,7 +62,7 @@ Module Impl_core_fmt_Debug_for_subtle_Choice.
             M.read (| Value.String "Choice" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.alloc (| M.get_struct_tuple_field (M.read (| self |)) "subtle::Choice" 0 |))
+              (M.alloc (| M.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -89,7 +89,7 @@ Module Impl_subtle_Choice.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_tuple_field (M.read (| self |)) "subtle::Choice" 0 |)))
+        M.read (| M.get_struct_tuple_field (| M.read (| self |), "subtle::Choice", 0 |) |)))
     | _, _ => M.impossible
     end.
   
@@ -132,12 +132,20 @@ Module Impl_core_convert_From_subtle_Choice_for_bool.
                                       (BinOp.Pure.bit_or
                                         (BinOp.Pure.eq
                                           (M.read (|
-                                            M.get_struct_tuple_field source "subtle::Choice" 0
+                                            M.get_struct_tuple_field (|
+                                              source,
+                                              "subtle::Choice",
+                                              0
+                                            |)
                                           |))
                                           (Value.Integer Integer.U8 0))
                                         (BinOp.Pure.eq
                                           (M.read (|
-                                            M.get_struct_tuple_field source "subtle::Choice" 0
+                                            M.get_struct_tuple_field (|
+                                              source,
+                                              "subtle::Choice",
+                                              0
+                                            |)
                                           |))
                                           (Value.Integer Integer.U8 1)))
                                   |)) in
@@ -168,7 +176,7 @@ Module Impl_core_convert_From_subtle_Choice_for_bool.
             |) in
           M.alloc (|
             BinOp.Pure.ne
-              (M.read (| M.get_struct_tuple_field source "subtle::Choice" 0 |))
+              (M.read (| M.get_struct_tuple_field (| source, "subtle::Choice", 0 |) |))
               (Value.Integer Integer.U8 0)
           |)
         |)))
@@ -210,8 +218,8 @@ Module Impl_core_ops_bit_BitAnd_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_and
-              (M.read (| M.get_struct_tuple_field self "subtle::Choice" 0 |))
-              (M.read (| M.get_struct_tuple_field rhs "subtle::Choice" 0 |))
+              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -295,8 +303,8 @@ Module Impl_core_ops_bit_BitOr_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_or
-              (M.read (| M.get_struct_tuple_field self "subtle::Choice" 0 |))
-              (M.read (| M.get_struct_tuple_field rhs "subtle::Choice" 0 |))
+              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -380,8 +388,8 @@ Module Impl_core_ops_bit_BitXor_for_subtle_Choice.
           |),
           [
             BinOp.Pure.bit_xor
-              (M.read (| M.get_struct_tuple_field self "subtle::Choice" 0 |))
-              (M.read (| M.get_struct_tuple_field rhs "subtle::Choice" 0 |))
+              (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |))
+              (M.read (| M.get_struct_tuple_field (| rhs, "subtle::Choice", 0 |) |))
           ]
         |)))
     | _, _ => M.impossible
@@ -465,7 +473,8 @@ Module Impl_core_ops_bit_Not_for_subtle_Choice.
           [
             BinOp.Pure.bit_and
               (Value.Integer Integer.U8 1)
-              (UnOp.Pure.not (M.read (| M.get_struct_tuple_field self "subtle::Choice" 0 |)))
+              (UnOp.Pure.not
+                (M.read (| M.get_struct_tuple_field (| self, "subtle::Choice", 0 |) |)))
           ]
         |)))
     | _, _ => M.impossible
@@ -784,13 +793,13 @@ Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_slice_T.
                                     fun γ =>
                                       ltac:(M.monadic
                                         (let γ0_0 :=
-                                          M.get_struct_tuple_field_or_break_match (|
+                                          M.get_struct_tuple_field (|
                                             γ,
                                             "core::option::Option::Some",
                                             0
                                           |) in
-                                        let γ1_0 := M.get_tuple_field γ0_0 0 in
-                                        let γ1_1 := M.get_tuple_field γ0_0 1 in
+                                        let γ1_0 := M.get_tuple_field (| γ0_0, 0 |) in
+                                        let γ1_1 := M.get_tuple_field (| γ0_0, 1 |) in
                                         let ai := M.copy (| γ1_0 |) in
                                         let bi := M.copy (| γ1_1 |) in
                                         let _ :=
@@ -2887,8 +2896,8 @@ Module Impl_subtle_ConditionallySelectable_for_subtle_Choice.
                 []
               |),
               [
-                M.get_struct_tuple_field (M.read (| a |)) "subtle::Choice" 0;
-                M.get_struct_tuple_field (M.read (| b |)) "subtle::Choice" 0;
+                M.get_struct_tuple_field (| M.read (| a |), "subtle::Choice", 0 |);
+                M.get_struct_tuple_field (| M.read (| b |), "subtle::Choice", 0 |);
                 M.read (| choice |)
               ]
             |)
@@ -2988,7 +2997,7 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
             ("value",
               M.call_closure (|
                 M.get_trait_method (| "core::clone::Clone", T, [], "clone", [] |),
-                [ M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "value" ]
+                [ M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "value" |) ]
               |));
             ("is_some",
               M.call_closure (|
@@ -2999,7 +3008,7 @@ Module Impl_core_clone_Clone_where_core_clone_Clone_T_for_subtle_CtOption_T.
                   "clone",
                   []
                 |),
-                [ M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "is_some" ]
+                [ M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |) ]
               |))
           ]))
     | _, _ => M.impossible
@@ -3049,12 +3058,12 @@ Module Impl_core_fmt_Debug_where_core_fmt_Debug_T_for_subtle_CtOption_T.
             M.read (| Value.String "value" |);
             (* Unsize *)
             M.pointer_coercion
-              (M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "value");
+              (M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "value" |));
             M.read (| Value.String "is_some" |);
             (* Unsize *)
             M.pointer_coercion
               (M.alloc (|
-                M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "is_some"
+                M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
               |))
           ]
         |)))
@@ -3123,7 +3132,11 @@ Module Impl_core_convert_From_subtle_CtOption_T_for_core_option_Option_T.
                   M.alloc (|
                     Value.StructTuple
                       "core::option::Option::Some"
-                      [ M.read (| M.get_struct_record_field source "subtle::CtOption" "value" |) ]
+                      [
+                        M.read (|
+                          M.get_struct_record_field (| source, "subtle::CtOption", "value" |)
+                        |)
+                      ]
                   |)));
               fun γ =>
                 ltac:(M.monadic (M.alloc (| Value.StructTuple "core::option::Option::None" [] |)))
@@ -3191,7 +3204,7 @@ Module Impl_subtle_CtOption_T.
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "subtle::Choice", "unwrap_u8", [] |),
-                        [ M.get_struct_record_field self "subtle::CtOption" "is_some" ]
+                        [ M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) ]
                       |)
                     |);
                     M.alloc (| Value.Integer Integer.U8 1 |)
@@ -3200,8 +3213,8 @@ Module Impl_subtle_CtOption_T.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -3284,7 +3297,7 @@ Module Impl_subtle_CtOption_T.
                     |)))
               ]
             |) in
-          M.get_struct_record_field self "subtle::CtOption" "value"
+          M.get_struct_record_field (| self, "subtle::CtOption", "value" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -3315,7 +3328,7 @@ Module Impl_subtle_CtOption_T.
                     M.alloc (|
                       M.call_closure (|
                         M.get_associated_function (| Ty.path "subtle::Choice", "unwrap_u8", [] |),
-                        [ M.get_struct_record_field self "subtle::CtOption" "is_some" ]
+                        [ M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) ]
                       |)
                     |);
                     M.alloc (| Value.Integer Integer.U8 1 |)
@@ -3324,8 +3337,8 @@ Module Impl_subtle_CtOption_T.
               [
                 fun γ =>
                   ltac:(M.monadic
-                    (let γ0_0 := M.get_tuple_field γ 0 in
-                    let γ0_1 := M.get_tuple_field γ 1 in
+                    (let γ0_0 := M.get_tuple_field (| γ, 0 |) in
+                    let γ0_1 := M.get_tuple_field (| γ, 1 |) in
                     let left_val := M.copy (| γ0_0 |) in
                     let right_val := M.copy (| γ0_1 |) in
                     M.match_operator (|
@@ -3372,7 +3385,7 @@ Module Impl_subtle_CtOption_T.
                     |)))
               ]
             |) in
-          M.get_struct_record_field self "subtle::CtOption" "value"
+          M.get_struct_record_field (| self, "subtle::CtOption", "value" |)
         |)))
     | _, _ => M.impossible
     end.
@@ -3406,8 +3419,8 @@ Module Impl_subtle_CtOption_T.
           |),
           [
             def;
-            M.get_struct_record_field self "subtle::CtOption" "value";
-            M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+            M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3454,8 +3467,8 @@ Module Impl_subtle_CtOption_T.
                 [ M.read (| f |); Value.Tuple [] ]
               |)
             |);
-            M.get_struct_record_field self "subtle::CtOption" "value";
-            M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+            M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3476,7 +3489,9 @@ Module Impl_subtle_CtOption_T.
     | [], [ self ] =>
       ltac:(M.monadic
         (let self := M.alloc (| self |) in
-        M.read (| M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "is_some" |)))
+        M.read (|
+          M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
+        |)))
     | _, _ => M.impossible
     end.
   
@@ -3497,7 +3512,10 @@ Module Impl_subtle_CtOption_T.
         (let self := M.alloc (| self |) in
         M.call_closure (|
           M.get_trait_method (| "core::ops::bit::Not", Ty.path "subtle::Choice", [], "not", [] |),
-          [ M.read (| M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "is_some" |)
+          [
+            M.read (|
+              M.get_struct_record_field (| M.read (| self |), "subtle::CtOption", "is_some" |)
+            |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3560,14 +3578,16 @@ Module Impl_subtle_CtOption_T.
                             []
                           |)
                         |);
-                        M.get_struct_record_field self "subtle::CtOption" "value";
-                        M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+                        M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+                        M.read (|
+                          M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+                        |)
                       ]
                     |)
                   ]
               ]
             |);
-            M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+            M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
           ]
         |)))
     | _, _ => M.impossible
@@ -3634,8 +3654,10 @@ Module Impl_subtle_CtOption_T.
                               []
                             |)
                           |);
-                          M.get_struct_record_field self "subtle::CtOption" "value";
-                          M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+                          M.get_struct_record_field (| self, "subtle::CtOption", "value" |);
+                          M.read (|
+                            M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |)
+                          |)
                         ]
                       |)
                     ]
@@ -3653,8 +3675,8 @@ Module Impl_subtle_CtOption_T.
                   []
                 |),
                 [
-                  M.get_struct_record_field tmp "subtle::CtOption" "is_some";
-                  M.read (| M.get_struct_record_field self "subtle::CtOption" "is_some" |)
+                  M.get_struct_record_field (| tmp, "subtle::CtOption", "is_some" |);
+                  M.read (| M.get_struct_record_field (| self, "subtle::CtOption", "is_some" |) |)
                 ]
               |)
             |) in
@@ -3763,8 +3785,8 @@ Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| a |)) "subtle::CtOption" "value";
-                M.get_struct_record_field (M.read (| b |)) "subtle::CtOption" "value";
+                M.get_struct_record_field (| M.read (| a |), "subtle::CtOption", "value" |);
+                M.get_struct_record_field (| M.read (| b |), "subtle::CtOption", "value" |);
                 M.read (| choice |)
               ]
             |);
@@ -3777,8 +3799,8 @@ Module Impl_subtle_ConditionallySelectable_where_subtle_ConditionallySelectable_
                 []
               |),
               [
-                M.get_struct_record_field (M.read (| a |)) "subtle::CtOption" "is_some";
-                M.get_struct_record_field (M.read (| b |)) "subtle::CtOption" "is_some";
+                M.get_struct_record_field (| M.read (| a |), "subtle::CtOption", "is_some" |);
+                M.get_struct_record_field (| M.read (| b |), "subtle::CtOption", "is_some" |);
                 M.read (| choice |)
               ]
             |)
@@ -3869,8 +3891,16 @@ Module Impl_subtle_ConstantTimeEq_where_subtle_ConstantTimeEq_T_for_subtle_CtOpt
                     M.call_closure (|
                       M.get_trait_method (| "subtle::ConstantTimeEq", T, [], "ct_eq", [] |),
                       [
-                        M.get_struct_record_field (M.read (| self |)) "subtle::CtOption" "value";
-                        M.get_struct_record_field (M.read (| rhs |)) "subtle::CtOption" "value"
+                        M.get_struct_record_field (|
+                          M.read (| self |),
+                          "subtle::CtOption",
+                          "value"
+                        |);
+                        M.get_struct_record_field (|
+                          M.read (| rhs |),
+                          "subtle::CtOption",
+                          "value"
+                        |)
                       ]
                     |)
                   ]

--- a/CoqOfRust/simulations/M.v
+++ b/CoqOfRust/simulations/M.v
@@ -97,6 +97,29 @@ Module TupleIsToValue.
   }.
 End TupleIsToValue.
 
+Module SubPointer.
+  Module Runner.
+    Record t {A Sub_A : Set} {H_A : ToValue A} {H_Sub_A : ToValue Sub_A} : Set := {
+      index : Pointer.Index.t;
+      projection : A -> option Sub_A;
+      injection : A -> Sub_A -> option A;
+    }.
+    Arguments t _ _ {_ _}.
+  End Runner.
+
+  Definition get_sub
+      {A Sub_A : Set} `{ToValue A} `{ToValue Sub_A}
+      (mutable : Pointer.Mutable.t (A := A) Value.t φ)
+      (runner : Runner.t A Sub_A) :
+      Pointer.Mutable.t (A := Sub_A) Value.t φ :=
+    Pointer.Mutable.get_sub
+      mutable
+      runner.(Runner.index)
+      runner.(Runner.projection)
+      runner.(Runner.injection)
+      φ.
+End SubPointer.
+
 (** ** Monads that are useful for the definition of simulations. *)
 
 Module Error.

--- a/lib/src/expression.rs
+++ b/lib/src/expression.rs
@@ -561,8 +561,10 @@ impl Expr {
                 ]),
             Expr::Loop { body } => coq::Expression::just_name("M.loop")
                 .monadic_apply(&Rc::new(coq::Expression::monadic(&body.to_coq()))),
-            Expr::Index { base, index } => coq::Expression::just_name("M.get_array_field")
-                .monadic_apply_many(&[base.to_coq(), index.to_coq()]),
+            Expr::Index { base, index } => {
+                coq::Expression::just_name("M.SubPointer.get_array_field")
+                    .monadic_apply_many(&[base.to_coq(), index.to_coq()])
+            }
             Expr::ControlFlow(lcf_expression) => lcf_expression.to_coq(),
             Expr::StructStruct { path, fields, base } => match base {
                 None => coq::Expression::just_name("Value.StructRecord").apply_many(&[

--- a/lib/src/thir_expression.rs
+++ b/lib/src/thir_expression.rs
@@ -95,7 +95,7 @@ fn build_inner_match(
                             is_monadic: false,
                             name: Some(format!("γ{depth}_{index}")),
                             init: Rc::new(Expr::Call {
-                                func: Expr::local_var("M.get_struct_record_field"),
+                                func: Expr::local_var("M.SubPointer.get_struct_record_field"),
                                 args: vec![
                                     Expr::local_var(&scrutinee),
                                     Rc::new(Expr::InternalString(path.to_string())),
@@ -123,7 +123,7 @@ fn build_inner_match(
                         is_monadic: false,
                         name: Some(format!("γ{depth}_{index}")),
                         init: Rc::new(Expr::Call {
-                            func: Expr::local_var("M.get_struct_tuple_field"),
+                            func: Expr::local_var("M.SubPointer.get_struct_tuple_field"),
                             args: vec![
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalString(path.to_string())),
@@ -208,7 +208,7 @@ fn build_inner_match(
                         is_monadic: false,
                         name: Some(format!("γ{depth}_{index}")),
                         init: Rc::new(Expr::Call {
-                            func: Expr::local_var("M.get_tuple_field"),
+                            func: Expr::local_var("M.SubPointer.get_tuple_field"),
                             args: vec![
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalInteger(index)),
@@ -273,7 +273,7 @@ fn build_inner_match(
                                 is_monadic: false,
                                 name: Some(format!("γ{depth}_rev{index}")),
                                 init: Rc::new(Expr::Call {
-                                    func: Expr::local_var("M.get_slice_rev_index"),
+                                    func: Expr::local_var("M.SubPointer.get_slice_rev_index"),
                                     args: vec![
                                         Expr::local_var(&scrutinee),
                                         Rc::new(Expr::InternalInteger(index)),
@@ -290,7 +290,7 @@ fn build_inner_match(
                         is_monadic: false,
                         name: Some(format!("γ{depth}_rest")),
                         init: Rc::new(Expr::Call {
-                            func: Expr::local_var("M.get_slice_rest"),
+                            func: Expr::local_var("M.SubPointer.get_slice_rest"),
                             args: vec![
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalInteger(prefix_patterns.len())),
@@ -310,7 +310,7 @@ fn build_inner_match(
                             is_monadic: false,
                             name: Some(format!("γ{depth}_{index}")),
                             init: Rc::new(Expr::Call {
-                                func: Expr::local_var("M.get_slice_index"),
+                                func: Expr::local_var("M.SubPointer.get_slice_index"),
                                 args: vec![
                                     Expr::local_var(&scrutinee),
                                     Rc::new(Expr::InternalInteger(index)),
@@ -678,9 +678,9 @@ pub(crate) fn compile_expr<'a>(
                     let name = variant.fields.get(*name).unwrap().name.to_string();
                     let is_name_a_number = name.chars().all(|c| c.is_ascii_digit());
                     let getter_name = if is_name_a_number {
-                        "M.get_struct_tuple_field"
+                        "M.SubPointer.get_struct_tuple_field"
                     } else {
-                        "M.get_struct_record_field"
+                        "M.SubPointer.get_struct_record_field"
                     };
                     let constructor_name = compile_def_id(env, adt_def.did()).to_string();
                     let constructor = Rc::new(Expr::InternalString(constructor_name));
@@ -699,7 +699,7 @@ pub(crate) fn compile_expr<'a>(
                 None => {
                     // We assume that we are in the case of a tuple.
                     Rc::new(Expr::Call {
-                        func: Expr::local_var("M.get_tuple_field"),
+                        func: Expr::local_var("M.SubPointer.get_tuple_field"),
                         args: vec![base, Rc::new(Expr::InternalInteger(name.as_usize()))],
                         kind: CallKind::Effectful,
                     })

--- a/lib/src/thir_expression.rs
+++ b/lib/src/thir_expression.rs
@@ -95,7 +95,7 @@ fn build_inner_match(
                             is_monadic: false,
                             name: Some(format!("γ{depth}_{index}")),
                             init: Rc::new(Expr::Call {
-                                func: Expr::local_var("M.get_struct_record_field_or_break_match"),
+                                func: Expr::local_var("M.get_struct_record_field"),
                                 args: vec![
                                     Expr::local_var(&scrutinee),
                                     Rc::new(Expr::InternalString(path.to_string())),
@@ -123,7 +123,7 @@ fn build_inner_match(
                         is_monadic: false,
                         name: Some(format!("γ{depth}_{index}")),
                         init: Rc::new(Expr::Call {
-                            func: Expr::local_var("M.get_struct_tuple_field_or_break_match"),
+                            func: Expr::local_var("M.get_struct_tuple_field"),
                             args: vec![
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalString(path.to_string())),
@@ -213,7 +213,7 @@ fn build_inner_match(
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalInteger(index)),
                             ],
-                            kind: CallKind::Pure,
+                            kind: CallKind::Effectful,
                         }),
                         body,
                     })
@@ -273,7 +273,7 @@ fn build_inner_match(
                                 is_monadic: false,
                                 name: Some(format!("γ{depth}_rev{index}")),
                                 init: Rc::new(Expr::Call {
-                                    func: Expr::local_var("M.get_slice_rev_index_or_break_match"),
+                                    func: Expr::local_var("M.get_slice_rev_index"),
                                     args: vec![
                                         Expr::local_var(&scrutinee),
                                         Rc::new(Expr::InternalInteger(index)),
@@ -290,7 +290,7 @@ fn build_inner_match(
                         is_monadic: false,
                         name: Some(format!("γ{depth}_rest")),
                         init: Rc::new(Expr::Call {
-                            func: Expr::local_var("M.get_slice_rest_or_break_match"),
+                            func: Expr::local_var("M.get_slice_rest"),
                             args: vec![
                                 Expr::local_var(&scrutinee),
                                 Rc::new(Expr::InternalInteger(prefix_patterns.len())),
@@ -310,7 +310,7 @@ fn build_inner_match(
                             is_monadic: false,
                             name: Some(format!("γ{depth}_{index}")),
                             init: Rc::new(Expr::Call {
-                                func: Expr::local_var("M.get_slice_index_or_break_match"),
+                                func: Expr::local_var("M.get_slice_index"),
                                 args: vec![
                                     Expr::local_var(&scrutinee),
                                     Rc::new(Expr::InternalInteger(index)),
@@ -693,7 +693,7 @@ pub(crate) fn compile_expr<'a>(
                     Rc::new(Expr::Call {
                         func: Expr::local_var(getter_name),
                         args: vec![base, constructor, index],
-                        kind: CallKind::Pure,
+                        kind: CallKind::Effectful,
                     })
                 }
                 None => {
@@ -701,7 +701,7 @@ pub(crate) fn compile_expr<'a>(
                     Rc::new(Expr::Call {
                         func: Expr::local_var("M.get_tuple_field"),
                         args: vec![base, Rc::new(Expr::InternalInteger(name.as_usize()))],
-                        kind: CallKind::Pure,
+                        kind: CallKind::Effectful,
                     })
                 }
             }


### PR DESCRIPTION
In this pull request we keep a simulation mechanism with a single step.  However we directly use a memory that contains the simulated values, so that there is no back and forth with the `Value.t` type when we read or write at a memory address.

To do so, we "track" the pointers. The generated Coq code can only create, read, write, or create a sub-pointer (to a field of the `struct` it is pointing at, for example).

It seems to simplify the proofs for the simulation as we never have `Value.t` in the state. We still have to do some back and forth between the `Value.t` and the simulation types for the program values. We can improve this situation later.